### PR TITLE
fix #33: Add PostToolUse hooks to plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -30,6 +30,16 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status working"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION
A fix for https://github.com/raine/workmux/issues/33, for your consideration.
