### PR TITLE
Fix broken link to delegating-tasks in slash-commands docs

### DIFF
--- a/docs/guide/slash-commands.md
+++ b/docs/guide/slash-commands.md
@@ -159,4 +159,4 @@ If nothing is staged, stage all changes first.
 
 ## Task delegation
 
-For spawning parallel agents in worktrees, see [Delegating tasks](/guide/delegating-tasks) which covers the `/worktree` slash command.
+For spawning parallel agents in worktrees, see [Delegating tasks](./delegating-tasks.md) which covers the `/worktree` slash command.


### PR DESCRIPTION
## Summary
Fixed a broken link in the slash commands documentation that was pointing to the delegating tasks page.

## Changes
- Changed from absolute path `/guide/delegating-tasks` to relative path `./delegating-tasks.md`
- This improves compatibility across different markdown viewers (VitePress, GitHub, IDEs)

## Testing
- Verified the target file exists at `docs/guide/delegating-tasks.md`
- Checked that the relative path format is consistent with VitePress's link handling