### PR TITLE
Preserve whitespace in tmux format strings when injecting status

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1459,18 +1459,26 @@ pub fn ensure_status_format(pane: &str) -> Result<()> {
 fn update_format_option(pane: &str, option: &str) -> Result<()> {
     // Read current format. Try window-level first, fall back to global.
     // Note: show-option -wv returns empty string (not error) when no window option exists.
+    //
+    // Uses run() instead of run_and_capture_stdout() because the latter calls .trim()
+    // which strips meaningful whitespace from format strings (e.g., padding spaces in
+    // tmux themes). We only strip trailing newlines from command output.
     let window_format = Cmd::new("tmux")
         .args(&["show-option", "-wv", "-t", pane, option])
-        .run_and_capture_stdout()
+        .run()
         .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|s| s.trim_end_matches('\n').to_string())
         .filter(|s| !s.is_empty());
 
     let current = match window_format {
         Some(fmt) => fmt,
         None => Cmd::new("tmux")
             .args(&["show-option", "-gv", option])
-            .run_and_capture_stdout()
+            .run()
             .ok()
+            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .map(|s| s.trim_end_matches('\n').to_string())
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| "#I:#W#{?window_flags,#{window_flags}, }".to_string()),
     };
@@ -1819,6 +1827,32 @@ mod tests {
         assert_eq!(
             result,
             "#I:#W#{?@workmux_status, #{@workmux_status},}#{window_flags}"
+        );
+    }
+
+    #[test]
+    fn test_inject_status_format_preserves_whitespace() {
+        // Leading and trailing spaces from tmux themes must be preserved
+        let input = " #I:#W#{window_flags} ";
+        let result = inject_status_format(input);
+        assert_eq!(
+            result,
+            " #I:#W#{?@workmux_status, #{@workmux_status},}#{window_flags} "
+        );
+    }
+
+    #[test]
+    fn test_trim_end_newlines_preserves_spaces() {
+        // Simulates processing tmux show-option output: trailing newlines are
+        // stripped but meaningful whitespace (padding spaces) is kept intact.
+        let raw_output = " #I:#W#{window_flags} \n";
+        let processed = raw_output.trim_end_matches('\n').to_string();
+        assert_eq!(processed, " #I:#W#{window_flags} ");
+
+        let result = inject_status_format(&processed);
+        assert_eq!(
+            result,
+            " #I:#W#{?@workmux_status, #{@workmux_status},}#{window_flags} "
         );
     }
 }


### PR DESCRIPTION
Thanks for workmux, it's fantastic. This PR fixes a tiny detail: I noticed that the whitespace at either end of my window titles was getting trimmed off when workmux updated the status. This adjusts the trimming to only remove newlines. I added a couple of tests to capture the behavior. All the pre-existing tests continued to pass with this change.

Let me know if you have any feedback or if this needs any adjustment!