### PR TITLE
Rename __exec to _exec to fix bash completion panic

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -447,7 +447,7 @@ enum Commands {
     },
 
     /// Execute a run spec (internal use)
-    #[command(hide = true, name = "__exec")]
+    #[command(hide = true, name = "_exec")]
     Exec {
         /// Absolute path to run directory
         #[arg(long)]

--- a/src/command/exec.rs
+++ b/src/command/exec.rs
@@ -1,4 +1,4 @@
-//! Hidden `__exec` subcommand for running commands in worktree panes.
+//! Hidden `_exec` subcommand for running commands in worktree panes.
 //!
 //! This is invoked by `workmux run` in a split pane to execute the command
 //! while capturing output to files.

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -56,14 +56,14 @@ pub fn run(
     };
     let run_dir = create_run(&run_id, &spec)?;
 
-    // Get path to current executable for __exec
+    // Get path to current executable for _exec
     let exe_path = std::env::current_exe()
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_else(|_| "workmux".to_string());
 
-    // Split pane with __exec command (pass absolute run_dir path)
+    // Split pane with _exec command (pass absolute run_dir path)
     let exec_cmd = format!(
-        "{} __exec --run-dir {}",
+        "{} _exec --run-dir {}",
         shell_escape(&exe_path),
         shell_escape(&run_dir.to_string_lossy())
     );


### PR DESCRIPTION
clap_complete's bash generator uses `__` as a delimiter to encode hierarchical subcommand paths (e.g., `workmux add` → `workmux__add`). When a subcommand name itself starts with `__` (like `__exec`), the space-to-`__` and `__`-to-space round-trip breaks:

1. `workmux __exec` → replace spaces with `__` → `workmux____exec`
2. Split on `__` → `["workmux", "", "exec"]`
3. `find_subcommand("")` → `None` → **unwrap() panics**

This is the same class of bug fixed in #14, where `__complete-branches` was renamed to `_complete-branches`. The `__exec` subcommand was missed at the time.

Discovered while packaging workmux for Nix: https://github.com/numtide/llm-agents.nix/pull/2443