### PR TITLE
fix: use bash instead of sh for hook execution

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -115,7 +115,7 @@ pub fn shell_command_with_env(
     workdir: &Path,
     env_vars: &[(&str, &str)],
 ) -> Result<()> {
-    let mut cmd = Command::new("sh");
+    let mut cmd = Command::new("bash");
     cmd.arg("-c").arg(command).current_dir(workdir);
 
     for (key, value) in env_vars {

--- a/src/command/exec.rs
+++ b/src/command/exec.rs
@@ -54,7 +54,7 @@ fn try_run(run_dir: &Path) -> Result<()> {
         .context("Failed to open stderr file")?;
 
     // Spawn the command
-    let mut child = Command::new("sh")
+    let mut child = Command::new("bash")
         .arg("-c")
         .arg(&spec.command)
         .current_dir(&spec.worktree_path)


### PR DESCRIPTION
On Ubuntu, /bin/sh is dash which doesn't support 'set -o pipefail'. This caused pre-merge and pre-remove hooks to fail when using bash-isms.

The built-in default pre_remove hook for Node.js projects (src/scripts/cleanup_node_modules.sh) uses 'set -euo pipefail', so users with Node.js projects would see:
  'sh: 2: set: Illegal option -o pipefail'

Fix by using 'bash' explicitly instead of 'sh' in:
- src/cmd.rs: shell_command_with_env (for hooks)
- src/command/exec.rs: run command
