### PR TITLE
fix: prevent LLM preamble from becoming worktree branch names

### DIFF
--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -28,7 +28,11 @@ ensure you have the latest version before writing prompts.
 
 For each task:
 
-1. Generate a short, descriptive worktree name (2-4 words, kebab-case)
+1. Generate a short, descriptive worktree name (2-4 words, kebab-case).
+   The name must describe the TASK, not be a sentence. NEVER include
+   preamble like "here-s-a-" or meta-descriptions like "kebab-case-git-branch".
+   Good: "fix-login-redirect", "add-s3-column-detection"
+   Bad: "here-s-a-suggested-branch-name", "here-s-a-kebab-case-git-branch"
 2. Write a detailed implementation prompt to a temp file
 3. Run `workmux add <worktree-name> -b -P <temp-file>` to create the worktree
 


### PR DESCRIPTION
## Problem

The worktree skill instructs the model to "generate a short, descriptive worktree name (2-4 words, kebab-case)", but some models interpret this as a prompt to output conversational text. The preamble then gets slugified into the actual branch name, producing names like:

- `here-s-a-suggested-branch-name`
- `here-s-a-kebab-case-git-branch-name-for-your-task`
- `here-s-a-kebab-case-git-branch-name-for-this-feature`

## Fix

Add explicit negative examples and a clear constraint that the name must describe the task, not be a sentence:

```
Good: "fix-login-redirect", "add-s3-column-detection"
Bad: "here-s-a-suggested-branch-name", "here-s-a-kebab-case-git-branch"
```

## Test plan

- [ ] Create worktrees with the updated skill and verify branch names are task-descriptive


🤖 Generated with [Claude Code](https://claude.com/claude-code)