### PR TITLE
feat: add polling-based status detection for Copilot CLI

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -471,6 +471,14 @@ enum Commands {
         run_dir: std::path::PathBuf,
     },
 
+    /// Run status poller for agents without hooks support (e.g., Copilot CLI)
+    #[command(hide = true)]
+    Poll {
+        /// Polling interval in seconds
+        #[arg(long, short = 'i', default_value = "3")]
+        interval: Option<u64>,
+    },
+
     /// Switch to the agent that most recently completed its task
     #[command(hide = true, name = "last-done")]
     LastDone,
@@ -652,6 +660,7 @@ pub fn run() -> Result<()> {
             timeout,
         } => command::run::run(&name, command, background, keep, timeout),
         Commands::Exec { run_dir } => command::exec::run(&run_dir),
+        Commands::Poll { interval } => command::poll::run(interval),
         Commands::Init => crate::config::Config::init(),
         Commands::Setup => command::setup::run(),
         Commands::Docs => command::docs::run(),

--- a/src/command/dashboard/mod.rs
+++ b/src/command/dashboard/mod.rs
@@ -43,11 +43,13 @@ use crossterm::{
 };
 use ratatui::backend::CrosstermBackend;
 use std::io;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::git;
 use crate::github;
 use crate::multiplexer::{create_backend, detect_backend};
+use crate::state::StatusPoller;
 
 use self::actions::apply_action;
 use self::app::{App, ViewMode};
@@ -115,6 +117,10 @@ pub fn run(cli_preview_size: Option<u8>, open_diff: bool) -> Result<()> {
         return Ok(());
     }
 
+    // Start status poller for agents without hooks (e.g., Copilot CLI)
+    // The poller runs in a background thread and updates status via pattern matching
+    let poller = StatusPoller::start(Arc::clone(&mux), Duration::from_secs(3));
+
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -123,7 +129,7 @@ pub fn run(cli_preview_size: Option<u8>, open_diff: bool) -> Result<()> {
     let mut terminal = ratatui::Terminal::new(backend)?;
 
     // Create app state
-    let mut app = App::new(mux)?;
+    let mut app = App::new(Arc::clone(&mux))?;
 
     // CLI preview size overrides config/tmux if provided
     if let Some(size) = cli_preview_size {
@@ -230,6 +236,9 @@ pub fn run(cli_preview_size: Option<u8>, open_diff: bool) -> Result<()> {
             break;
         }
     }
+
+    // Stop the status poller
+    poller.stop();
 
     // Save git status cache before exiting
     git::save_status_cache(&app.git_statuses);

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -14,6 +14,7 @@ pub mod list;
 pub mod merge;
 pub mod open;
 pub mod path;
+pub mod poll;
 pub mod remove;
 pub mod run;
 pub mod sandbox;

--- a/src/command/poll.rs
+++ b/src/command/poll.rs
@@ -1,0 +1,55 @@
+//! Polling-based status detection command for agents without hooks.
+//!
+//! This command runs a background poller that periodically captures terminal
+//! output from agent panes and detects their status via pattern matching.
+
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::multiplexer::{create_backend, detect_backend};
+use crate::state::StatusPoller;
+
+/// Default polling interval in seconds.
+const DEFAULT_INTERVAL_SECS: u64 = 3;
+
+/// Run the status poller in the foreground.
+///
+/// This is useful for:
+/// - Testing pattern detection
+/// - Running as a background daemon
+/// - Debugging status detection issues
+pub fn run(interval_secs: Option<u64>) -> Result<()> {
+    let mux = create_backend(detect_backend());
+
+    // Check if multiplexer is running
+    if !mux.is_running().unwrap_or(false) {
+        println!("No {} server running.", mux.name());
+        return Ok(());
+    }
+
+    let interval = Duration::from_secs(interval_secs.unwrap_or(DEFAULT_INTERVAL_SECS));
+
+    println!(
+        "Starting status poller (interval: {}s). Press Ctrl+C to stop.",
+        interval.as_secs()
+    );
+
+    let poller = StatusPoller::start(mux, interval);
+
+    // Wait for Ctrl+C
+    ctrlc::set_handler(move || {
+        println!("\nStopping poller...");
+        std::process::exit(0);
+    })?;
+
+    // Keep main thread alive
+    loop {
+        std::thread::sleep(Duration::from_secs(1));
+        if !poller.is_running() {
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/src/multiplexer/agent.rs
+++ b/src/multiplexer/agent.rs
@@ -6,6 +6,27 @@
 
 use std::path::Path;
 
+use crate::multiplexer::types::AgentStatus;
+
+/// Terminal output patterns for detecting agent status via polling.
+///
+/// Used by agents that don't support hooks (like Copilot CLI) to infer
+/// status by matching patterns in the terminal output.
+#[derive(Debug, Clone)]
+pub struct StatusPatterns {
+    /// Patterns indicating the agent is waiting for user input/permission.
+    /// Examples: "[Y/n]", "Allow?", permission prompts
+    pub waiting: Vec<&'static str>,
+
+    /// Patterns indicating the agent is actively working.
+    /// Examples: spinner characters, "Thinking...", "Running tool"
+    pub working: Vec<&'static str>,
+
+    /// Patterns indicating the agent has finished (shell prompt visible).
+    /// Examples: "$ ", "❯ ", "% " at end of output
+    pub done: Vec<&'static str>,
+}
+
 /// Describes agent-specific behaviors for command rewriting and status handling.
 pub trait AgentProfile: Send + Sync {
     /// Canonical name used for matching (e.g., "claude", "gemini").
@@ -42,6 +63,77 @@ pub trait AgentProfile: Send + Sync {
     /// Returns the CLI fragment to append (e.g., `-- "$(cat PROMPT.md)"`).
     fn prompt_argument(&self, prompt_path: &str) -> String {
         format!("-- \"$(cat {})\"", prompt_path)
+    }
+
+    /// Whether this agent requires polling-based status detection.
+    ///
+    /// Returns true for agents without hooks support (like Copilot CLI).
+    /// When true, the status poller will periodically capture terminal output
+    /// and match against `status_patterns()` to infer agent status.
+    fn needs_polling(&self) -> bool {
+        false
+    }
+
+    /// Terminal patterns for polling-based status detection.
+    ///
+    /// Returns `None` for agents with hooks support (they don't need polling).
+    /// Returns `Some(StatusPatterns)` for agents that need pattern matching.
+    fn status_patterns(&self) -> Option<StatusPatterns> {
+        None
+    }
+
+    /// Detect agent status from terminal output using pattern matching.
+    ///
+    /// Analyzes the captured terminal content and returns the detected status.
+    /// Returns `None` if no patterns match (status unknown).
+    ///
+    /// The detection priority is: waiting > done > working
+    /// Done is checked before working because spinner chars linger in scrollback
+    /// even after the agent finishes, while a shell prompt on the last line is
+    /// a reliable signal that the agent has exited.
+    ///
+    /// Waiting and working patterns are checked only against the last few lines
+    /// of output (near the cursor) to avoid false positives from old artifacts
+    /// lingering in scrollback — e.g. spinner chars or tool names from a
+    /// previous task that are still visible higher in the capture buffer.
+    fn detect_status(&self, terminal_content: &str) -> Option<AgentStatus> {
+        let patterns = self.status_patterns()?;
+        let lines: Vec<&str> = terminal_content.lines().collect();
+
+        // Build a string from only the last few lines for recency-scoped checks.
+        // Spinners and tool indicators appear at/near the bottom when active;
+        // 5 lines is enough to capture them without matching old scrollback.
+        let recent_start = lines.len().saturating_sub(5);
+        let recent_text: String = lines[recent_start..].join("\n");
+
+        // Check waiting patterns first (highest priority, recent lines only)
+        for pattern in &patterns.waiting {
+            if recent_text.contains(pattern) {
+                return Some(AgentStatus::Waiting);
+            }
+        }
+
+        // Check done patterns (shell prompt on last line) before working.
+        // A shell prompt as the last non-empty line reliably means the agent exited,
+        // even if spinner chars are still visible higher in the scrollback.
+        // We require the prompt to have no trailing content (just cursor/spaces)
+        // to avoid matching Copilot's own tool output like "❯ Edit src/file.rs".
+        if let Some(last_line) = lines.iter().rev().find(|l| !l.trim().is_empty()) {
+            for pattern in &patterns.done {
+                if last_line.starts_with(pattern) && last_line.trim_end() == pattern.trim_end() {
+                    return Some(AgentStatus::Done);
+                }
+            }
+        }
+
+        // Check working patterns (active processing, recent lines only)
+        for pattern in &patterns.working {
+            if recent_text.contains(pattern) {
+                return Some(AgentStatus::Working);
+            }
+        }
+
+        None
     }
 }
 
@@ -111,6 +203,65 @@ impl AgentProfile for CodexProfile {
     }
 }
 
+pub struct CopilotProfile;
+
+impl AgentProfile for CopilotProfile {
+    fn name(&self) -> &'static str {
+        "copilot"
+    }
+
+    fn needs_polling(&self) -> bool {
+        true
+    }
+
+    fn skip_permissions_flag(&self) -> Option<&'static str> {
+        Some("--allow-all-tools")
+    }
+
+    fn prompt_argument(&self, prompt_path: &str) -> String {
+        format!("-p \"$(cat {})\"", prompt_path)
+    }
+
+    fn status_patterns(&self) -> Option<StatusPatterns> {
+        Some(StatusPatterns {
+            // Permission/confirmation prompts
+            waiting: vec![
+                "[Y/n]",
+                "[y/N]",
+                "(y/n)",
+                "Allow?",
+                "Confirm?",
+                "Continue?",
+                "Proceed?",
+                "? (Y/n)",
+                "? (y/N)",
+                "Do you want",
+            ],
+            // Active processing indicators
+            working: vec![
+                // Braille spinner characters
+                "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏",
+                // Copilot CLI circular spinner (three states)
+                "◎", "◉", "∙",
+                // Copilot CLI tool names (format: "● Edit src/file.rs")
+                "● Edit ",
+                "● Read ",
+                "● Bash ",
+                "● Write ",
+                "● Search ",
+                "● Grep ",
+                "● Glob ",
+                "● Run ",
+                "● List ",
+            ],
+            // Shell prompt patterns (agent exited)
+            done: vec![
+                "❯ ", "➜ ", "$ ", "% ", // Basic prompt ("> " omitted: conflicts with Copilot tool output lines)
+            ],
+        })
+    }
+}
+
 pub struct DefaultProfile;
 
 impl AgentProfile for DefaultProfile {
@@ -126,6 +277,7 @@ static PROFILES: &[&dyn AgentProfile] = &[
     &GeminiProfile,
     &OpenCodeProfile,
     &CodexProfile,
+    &CopilotProfile,
 ];
 
 /// Check if a command matches a known agent profile.
@@ -314,5 +466,168 @@ mod tests {
         assert!(!is_known_agent("npm run dev"));
         assert!(!is_known_agent("clear"));
         assert!(!is_known_agent("unknown-agent"));
+    }
+
+    // === CopilotProfile tests ===
+
+    #[test]
+    fn test_copilot_profile() {
+        let profile = CopilotProfile;
+        assert_eq!(profile.name(), "copilot");
+        assert!(!profile.needs_bang_delay());
+        assert!(!profile.needs_auto_status());
+        assert!(profile.needs_polling());
+        assert_eq!(
+            profile.prompt_argument("PROMPT.md"),
+            "-p \"$(cat PROMPT.md)\""
+        );
+        assert_eq!(profile.skip_permissions_flag(), Some("--allow-all-tools"));
+        assert!(profile.status_patterns().is_some());
+    }
+
+    #[test]
+    fn test_resolve_profile_copilot() {
+        let profile = resolve_profile(Some("copilot"));
+        assert_eq!(profile.name(), "copilot");
+    }
+
+    #[test]
+    fn test_is_known_agent_copilot() {
+        assert!(is_known_agent("copilot"));
+        assert!(is_known_agent("copilot --allow-all-tools"));
+    }
+
+    // === Status detection tests ===
+
+    #[test]
+    fn test_detect_status_waiting() {
+        let profile = CopilotProfile;
+
+        // Permission prompts
+        assert_eq!(
+            profile.detect_status("Allow file write? [Y/n]"),
+            Some(AgentStatus::Waiting)
+        );
+        assert_eq!(
+            profile.detect_status("Continue? (y/n)"),
+            Some(AgentStatus::Waiting)
+        );
+        // Copilot CLI numbered choice menu
+        assert_eq!(
+            profile.detect_status("Do you want to proceed?\n> 1. Yes\n> 2. No"),
+            Some(AgentStatus::Waiting)
+        );
+    }
+
+    #[test]
+    fn test_detect_status_working() {
+        let profile = CopilotProfile;
+
+        // Braille spinner character
+        assert_eq!(
+            profile.detect_status("⠋ Processing request..."),
+            Some(AgentStatus::Working)
+        );
+        // Copilot CLI circular spinner states
+        assert_eq!(
+            profile.detect_status("◎ Working..."),
+            Some(AgentStatus::Working)
+        );
+        assert_eq!(
+            profile.detect_status("◉ Working..."),
+            Some(AgentStatus::Working)
+        );
+        assert_eq!(
+            profile.detect_status("∙ Working..."),
+            Some(AgentStatus::Working)
+        );
+        // Status message (generic keywords removed — too broad)
+        // Tool execution
+        assert_eq!(
+            profile.detect_status("● Run tests\n◎ running"),
+            Some(AgentStatus::Working)
+        );
+    }
+
+    #[test]
+    fn test_detect_status_done() {
+        let profile = CopilotProfile;
+
+        // Shell prompts as the last non-empty line (starts_with check)
+        assert_eq!(
+            profile.detect_status("Task completed.\n❯ "),
+            Some(AgentStatus::Done)
+        );
+        assert_eq!(
+            profile.detect_status("Done!\n$ "),
+            Some(AgentStatus::Done)
+        );
+        // Prompt with trailing command should NOT match done (it's tool output)
+        // and working should be detected from the tool name in the content
+        assert_eq!(
+            profile.detect_status("● Edit src/file.rs\n◎ continuing"),
+            Some(AgentStatus::Working)
+        );
+    }
+
+    #[test]
+    fn test_detect_status_waiting_priority_over_working() {
+        let profile = CopilotProfile;
+
+        // If both waiting and working patterns present, waiting wins
+        let content = "⠋ Processing...\nAllow? [Y/n]";
+        assert_eq!(profile.detect_status(content), Some(AgentStatus::Waiting));
+    }
+
+    #[test]
+    fn test_detect_status_no_match() {
+        let profile = CopilotProfile;
+
+        // No recognizable patterns
+        assert_eq!(profile.detect_status("Some random text"), None);
+        // "> " only matches done when it STARTS the last non-empty line
+        assert_eq!(
+            profile.detect_status("Here is the change:\nsome text > with > in it"),
+            None
+        );
+        // spinner in scrollback but shell prompt on last line → done wins
+        assert_eq!(
+            profile.detect_status("◎ Reading file\n❯ "),
+            Some(AgentStatus::Done)
+        );
+    }
+
+    #[test]
+    fn test_detect_status_ignores_working_artifacts_in_scrollback() {
+        let profile = CopilotProfile;
+
+        // Spinner and tool names from a previous task are still in scrollback
+        // (more than 5 lines above the bottom), but the agent is now idle.
+        // The last lines are plain result text — should NOT match Working.
+        let content = "● Edit src/main.rs\n\
+                        ◎ applying changes\n\
+                        ⠋ thinking\n\
+                        line4\n\
+                        line5\n\
+                        line6\n\
+                        Changes applied successfully.\n\
+                        All tests pass.\n\
+                        Summary of changes:";
+        assert_eq!(profile.detect_status(content), None);
+    }
+
+    #[test]
+    fn test_default_profile_no_polling() {
+        let profile = DefaultProfile;
+        assert!(!profile.needs_polling());
+        assert!(profile.status_patterns().is_none());
+        assert!(profile.detect_status("anything").is_none());
+    }
+
+    #[test]
+    fn test_claude_profile_no_polling() {
+        let profile = ClaudeProfile;
+        assert!(!profile.needs_polling());
+        assert!(profile.status_patterns().is_none());
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides persistent state storage that works across all
 //! terminal multiplexer backends (tmux, WezTerm, Zellij).
 
+pub mod poller;
 pub mod run;
 pub(crate) mod store;
 mod types;
@@ -13,6 +14,7 @@ use tracing::warn;
 
 use crate::multiplexer::{AgentStatus, Multiplexer};
 
+pub use poller::StatusPoller;
 pub use store::StateStore;
 pub use types::{AgentState, PaneKey};
 

--- a/src/state/poller.rs
+++ b/src/state/poller.rs
@@ -1,0 +1,321 @@
+//! Polling-based status detection for agents without hooks support.
+//!
+//! This module provides a `StatusPoller` that periodically captures terminal
+//! output from agent panes and detects their status via pattern matching.
+//! Used for agents like Copilot CLI that don't have hook/plugin systems.
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use tracing::{debug, trace, warn};
+
+use crate::config::Config;
+use crate::multiplexer::agent::resolve_profile;
+use crate::multiplexer::{AgentStatus, Multiplexer};
+
+/// Number of terminal lines to capture for pattern matching.
+const CAPTURE_LINES: u16 = 30;
+
+/// Number of consecutive polls with identical content before inferring Done.
+/// With a 3-second poll interval this means ~6 seconds of idle before Done.
+const STABLE_THRESHOLD: u32 = 2;
+
+/// Per-pane tracking state for the poller.
+#[derive(Debug)]
+struct PollState {
+    status: AgentStatus,
+    content_hash: u64,
+    /// How many consecutive polls returned the same content hash.
+    stable_count: u32,
+}
+
+type StatusCache = HashMap<String, PollState>;
+
+fn hash_content(s: &str) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    s.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Polls agent panes for status changes using terminal output pattern matching.
+///
+/// The poller runs in a background thread and periodically:
+/// 1. Queries all live panes from the multiplexer
+/// 2. For panes running agents that need polling, captures terminal output
+/// 3. Detects status using the agent profile's pattern matching
+/// 4. Updates the status if it has changed
+pub struct StatusPoller {
+    /// Signal to stop the polling loop
+    stop_signal: Arc<AtomicBool>,
+    /// Handle to the polling thread
+    thread_handle: Option<thread::JoinHandle<()>>,
+}
+
+impl StatusPoller {
+    /// Start a new status poller with the given interval.
+    ///
+    /// The poller runs in a background thread and polls at the specified interval.
+    /// Call `stop()` to gracefully shut down the poller.
+    pub fn start(mux: Arc<dyn Multiplexer>, interval: Duration) -> Self {
+        let stop_signal = Arc::new(AtomicBool::new(false));
+        let stop_clone = stop_signal.clone();
+
+        let handle = thread::spawn(move || {
+            poll_loop(mux, interval, stop_clone);
+        });
+
+        StatusPoller {
+            stop_signal,
+            thread_handle: Some(handle),
+        }
+    }
+
+    /// Stop the poller gracefully.
+    ///
+    /// Signals the polling loop to stop and waits for it to finish.
+    pub fn stop(mut self) {
+        self.stop_signal.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.thread_handle.take() {
+            let _ = handle.join();
+        }
+    }
+
+    /// Check if the poller is still running.
+    pub fn is_running(&self) -> bool {
+        !self.stop_signal.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for StatusPoller {
+    fn drop(&mut self) {
+        self.stop_signal.store(true, Ordering::SeqCst);
+        // Note: We don't join here to avoid blocking in drop
+    }
+}
+
+/// Main polling loop that runs in a background thread.
+fn poll_loop(mux: Arc<dyn Multiplexer>, interval: Duration, stop_signal: Arc<AtomicBool>) {
+    let mut status_cache: StatusCache = HashMap::new();
+    let config = Config::load(None).unwrap_or_default();
+
+    debug!(interval_ms = interval.as_millis(), "status poller started");
+
+    while !stop_signal.load(Ordering::SeqCst) {
+        if let Err(e) = poll_once(&*mux, &mut status_cache, &config) {
+            warn!(error = %e, "status poll cycle failed");
+        }
+
+        // Sleep in small increments to allow faster shutdown
+        let sleep_increment = Duration::from_millis(100);
+        let mut remaining = interval;
+        while remaining > Duration::ZERO && !stop_signal.load(Ordering::SeqCst) {
+            let sleep_time = remaining.min(sleep_increment);
+            thread::sleep(sleep_time);
+            remaining = remaining.saturating_sub(sleep_time);
+        }
+    }
+
+    debug!("status poller stopped");
+}
+
+/// Perform a single poll cycle across all live panes.
+///
+/// Uses a hybrid approach for status detection:
+/// - **Waiting**: Pattern matching on recent terminal lines (permission prompts
+///   are distinctive and should always be detected immediately).
+/// - **Working vs Done**: Content-change detection. If the terminal output
+///   changed since the last poll, the agent is actively producing output
+///   (Working). If the content has been stable for multiple consecutive polls,
+///   the agent is idle (Done). This avoids false positives from old spinner
+///   chars and tool-name artifacts that linger in the visible terminal buffer.
+fn poll_once(
+    mux: &dyn Multiplexer,
+    status_cache: &mut StatusCache,
+    config: &Config,
+) -> anyhow::Result<()> {
+
+    // Get ALL live panes from the multiplexer
+    let live_panes = mux.get_all_live_pane_info()?;
+
+    debug!(pane_count = live_panes.len(), "polling live panes");
+
+    for (pane_id, pane_info) in &live_panes {
+        // Get the agent profile based on the running command
+        let profile = resolve_profile(Some(&pane_info.current_command));
+
+        // Skip panes that don't need polling (not a polling-based agent)
+        if !profile.needs_polling() {
+            trace!(
+                pane_id,
+                command = %pane_info.current_command,
+                "skipping non-polling pane"
+            );
+            continue;
+        }
+
+        debug!(
+            pane_id,
+            command = %pane_info.current_command,
+            agent = profile.name(),
+            "found polling-based agent"
+        );
+
+        // Capture terminal content
+        let Some(raw_content) = mux.capture_pane(pane_id, CAPTURE_LINES) else {
+            debug!(pane_id, "failed to capture pane content");
+            continue;
+        };
+
+        // Strip ANSI escape codes so pattern matching works regardless of
+        // whether the multiplexer returns colored output (e.g. tmux -e flag).
+        let content = strip_ansi(&raw_content);
+        let content_hash = hash_content(&content);
+        let prev = status_cache.get(pane_id.as_str());
+
+        // --- Detect status ---
+
+        // 1. Waiting: pattern-match on recent lines (highest priority).
+        //    Permission prompts are distinctive and need immediate detection.
+        let detected_status = if let Some(patterns) = profile.status_patterns() {
+            let lines: Vec<&str> = content.lines().collect();
+            let recent_start = lines.len().saturating_sub(5);
+            let recent_text: String = lines[recent_start..].join("\n");
+
+            if patterns.waiting.iter().any(|p| recent_text.contains(p)) {
+                AgentStatus::Waiting
+            } else if let Some(prev) = prev {
+                // 2. Content-change detection for working/done.
+                if content_hash != prev.content_hash {
+                    AgentStatus::Working
+                } else if prev.stable_count + 1 >= STABLE_THRESHOLD {
+                    AgentStatus::Done
+                } else {
+                    // Below threshold — keep current status, bump counter below
+                    prev.status
+                }
+            } else {
+                // 3. First poll for this pane — use pattern matching as a
+                //    one-shot fallback until we have a second sample to compare.
+                profile.detect_status(&content).unwrap_or(AgentStatus::Done)
+            }
+        } else {
+            continue;
+        };
+
+        // Update stable counter
+        let stable_count = match prev {
+            Some(p) if content_hash == p.content_hash => p.stable_count + 1,
+            _ => 0,
+        };
+
+        // Check if status actually changed
+        let status_changed = prev.map(|p| p.status) != Some(detected_status);
+
+        // Always update the cache (hash + counter must stay current)
+        status_cache.insert(
+            pane_id.to_string(),
+            PollState {
+                status: detected_status,
+                content_hash,
+                stable_count,
+            },
+        );
+
+        if !status_changed {
+            trace!(pane_id, ?detected_status, "status unchanged");
+            continue;
+        }
+
+        // Status changed - update UI and persist
+        debug!(
+            pane_id,
+            agent = profile.name(),
+            ?detected_status,
+            "detected status change via polling"
+        );
+
+        let icon = match detected_status {
+            AgentStatus::Working => config.status_icons.working(),
+            AgentStatus::Waiting => config.status_icons.waiting(),
+            AgentStatus::Done => config.status_icons.done(),
+        };
+        let auto_clear = matches!(detected_status, AgentStatus::Waiting | AgentStatus::Done);
+
+        if let Err(e) = mux.set_status(pane_id, icon, auto_clear) {
+            warn!(pane_id, error = %e, "failed to set status icon");
+        }
+
+        crate::state::persist_agent_update(mux, pane_id, Some(detected_status), None);
+    }
+
+    // Clean up cache entries for panes that no longer exist
+    status_cache.retain(|pane_id, _| live_panes.contains_key(pane_id));
+
+    Ok(())
+}
+
+/// Strip ANSI escape sequences from a string for plain-text pattern matching.
+/// Also processes carriage returns (\r) so that overwritten spinner lines
+/// reflect what is actually visible on screen rather than all states concatenated.
+fn strip_ansi(s: &str) -> String {
+    // First strip ANSI escape sequences
+    let mut stripped = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            // CSI sequence: ESC [ ... final-byte (0x40–0x7E)
+            if chars.peek() == Some(&'[') {
+                chars.next();
+                for ch in chars.by_ref() {
+                    if ('\x40'..='\x7e').contains(&ch) {
+                        break;
+                    }
+                }
+            } else {
+                // Other escape sequence: skip next char
+                chars.next();
+            }
+        } else {
+            stripped.push(c);
+        }
+    }
+
+    // Process carriage returns: \r without \n overwrites the current line,
+    // so keep only the content after the last \r on each line.
+    stripped
+        .lines()
+        .map(|line| {
+            // Split on \r and take the last non-empty segment (the visible content)
+            line.split('\r')
+                .filter(|s| !s.is_empty())
+                .last()
+                .unwrap_or("")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_ansi_removes_csi_sequences() {
+        assert_eq!(strip_ansi("\x1b[32mgreen\x1b[0m"), "green");
+    }
+
+    #[test]
+    fn test_strip_ansi_handles_carriage_return() {
+        assert_eq!(strip_ansi("old text\rnew text"), "new text");
+    }
+
+    #[test]
+    fn test_hash_content_deterministic() {
+        assert_eq!(hash_content("hello"), hash_content("hello"));
+        assert_ne!(hash_content("hello"), hash_content("world"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for tracking agent status for tools that don't have hooks, like GitHub Copilot CLI. Uses a hybrid of content-change detection and pattern matching to detect working/waiting/done states.

## Changes

- Add `StatusPatterns` struct and polling methods to `AgentProfile` trait
- Add `CopilotProfile` with terminal patterns for status detection
- Add `StatusPoller` service that scans all live panes periodically
- Integrate poller with dashboard (starts automatically)
- Add hidden `workmux poll` command for standalone testing

## How it works

The poller runs in a background thread and periodically:

1. Queries all live panes from the multiplexer
2. For panes running agents that need polling (e.g., `copilot`), captures terminal output
3. Detects status using a hybrid approach:
   - **Waiting**: Pattern matching on last 5 terminal lines for permission prompts (`[Y/n]`, `Allow?`, `Do you want`, etc.) — checked every cycle for instant detection
   - **Working**: Terminal content hash changed since last poll — the agent is actively producing output
   - **Done**: Terminal content has been identical for 2+ consecutive polls (~6s) — the agent is idle
   - **First poll**: Falls back to pattern matching (`detect_status`) as a one-shot bootstrap until a second sample is available for comparison
4. Updates the status icon and persists state if changed

Content-change detection avoids false positives from old spinner chars and tool-name artifacts that linger in the visible terminal buffer of persistent TUI agents.

## Testing

```sh
# Run poller standalone (debug)
workmux poll -i 2

# Or just open dashboard - poller runs automatically
workmux dashboard
```

Logs go to `~/.local/state/workmux/workmux.log`

### Test plan

- Unit tests pass (610 tests)
- Manual testing with Copilot CLI — status detection works
- Dashboard integration verified
