### PR TITLE
Add dashboard add-agent workflow

### DIFF
--- a/src/command/dashboard/actions.rs
+++ b/src/command/dashboard/actions.rs
@@ -23,6 +23,12 @@ pub enum Action {
     ToggleStaleFilter,
     EnterInputMode,
     ExitInputMode,
+    EnterAddMode,
+    CancelAddMode,
+    ToggleAddFormField,
+    SubmitAddSession,
+    DeleteAddChar,
+    AppendAddChar(char),
     ScrollPreviewUp,
     ScrollPreviewDown,
     IncreasePreviewSize,
@@ -119,6 +125,30 @@ pub fn apply_action(app: &mut App, action: Action) -> bool {
         }
         Action::ExitInputMode => {
             app.input_mode = false;
+            false
+        }
+        Action::EnterAddMode => {
+            app.enter_add_mode();
+            false
+        }
+        Action::CancelAddMode => {
+            app.cancel_add_mode();
+            false
+        }
+        Action::ToggleAddFormField => {
+            app.toggle_add_form_field();
+            false
+        }
+        Action::SubmitAddSession => {
+            app.submit_add_session();
+            false
+        }
+        Action::DeleteAddChar => {
+            app.delete_add_form_char();
+            false
+        }
+        Action::AppendAddChar(c) => {
+            app.append_add_form_char(c);
             false
         }
         Action::ScrollPreviewUp => {

--- a/src/command/dashboard/app.rs
+++ b/src/command/dashboard/app.rs
@@ -13,7 +13,9 @@ use crate::config::Config;
 use crate::git::{self, GitStatus};
 use crate::github::PrSummary;
 use crate::multiplexer::{AgentPane, AgentStatus, Multiplexer};
+use crate::prompt::Prompt;
 use crate::state::StateStore;
+use crate::workflow;
 
 use super::ui::theme::ThemePalette;
 
@@ -39,6 +41,52 @@ pub enum ViewMode {
     Diff(Box<DiffView>),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AddSessionField {
+    #[default]
+    Branch,
+    Prompt,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct AddSessionForm {
+    pub branch: String,
+    pub prompt: String,
+    pub active_field: AddSessionField,
+    pub error: Option<String>,
+}
+
+impl AddSessionForm {
+    fn active_value_mut(&mut self) -> &mut String {
+        match self.active_field {
+            AddSessionField::Branch => &mut self.branch,
+            AddSessionField::Prompt => &mut self.prompt,
+        }
+    }
+
+    pub fn toggle_field(&mut self) {
+        self.active_field = match self.active_field {
+            AddSessionField::Branch => AddSessionField::Prompt,
+            AddSessionField::Prompt => AddSessionField::Branch,
+        };
+        self.error = None;
+    }
+
+    pub fn push_char(&mut self, c: char) {
+        self.active_value_mut().push(c);
+        self.error = None;
+    }
+
+    pub fn pop_char(&mut self) {
+        self.active_value_mut().pop();
+        self.error = None;
+    }
+
+    pub fn is_valid(&self) -> bool {
+        !self.branch.trim().is_empty()
+    }
+}
+
 /// App state for the TUI
 pub struct App {
     /// The multiplexer backend
@@ -62,6 +110,8 @@ pub struct App {
     preview_pane_id: Option<String>,
     /// Input mode: keystrokes are sent directly to the selected agent's pane
     pub input_mode: bool,
+    /// Add mode: popup form for creating a new workmux agent
+    pub add_form: Option<AddSessionForm>,
     /// Manual scroll offset for the preview (None = auto-scroll to bottom)
     pub preview_scroll: Option<u16>,
     /// Number of lines in the current preview content
@@ -144,6 +194,7 @@ impl App {
             preview: None,
             preview_pane_id: None,
             input_mode: false,
+            add_form: None,
             preview_scroll: None,
             preview_line_count: 0,
             preview_height: 0,
@@ -651,6 +702,98 @@ impl App {
         }
     }
 
+    /// Enter add mode to create a new agent from the dashboard.
+    pub fn enter_add_mode(&mut self) {
+        self.input_mode = false;
+        self.add_form = Some(AddSessionForm::default());
+    }
+
+    /// Exit add mode and discard the form.
+    pub fn cancel_add_mode(&mut self) {
+        self.add_form = None;
+    }
+
+    /// Toggle active field in the add-session form.
+    pub fn toggle_add_form_field(&mut self) {
+        if let Some(form) = self.add_form.as_mut() {
+            form.toggle_field();
+        }
+    }
+
+    /// Append a character to the active add-session form field.
+    pub fn append_add_form_char(&mut self, c: char) {
+        if let Some(form) = self.add_form.as_mut() {
+            form.push_char(c);
+        }
+    }
+
+    /// Delete the last character from the active add-session form field.
+    pub fn delete_add_form_char(&mut self) {
+        if let Some(form) = self.add_form.as_mut() {
+            form.pop_char();
+        }
+    }
+
+    /// Submit the add-session form and create a new worktree agent.
+    pub fn submit_add_session(&mut self) {
+        let Some(form) = self.add_form.as_ref() else {
+            return;
+        };
+
+        if !form.is_valid() {
+            if let Some(active) = self.add_form.as_mut() {
+                active.error = Some("Branch name is required".to_string());
+            }
+            return;
+        }
+
+        let branch = form.branch.trim().to_string();
+        let prompt_text = form.prompt.trim().to_string();
+
+        let prompt = if prompt_text.is_empty() {
+            None
+        } else {
+            Some(Prompt::Inline(prompt_text))
+        };
+
+        match self.create_agent_from_form(&branch, prompt.as_ref()) {
+            Ok(()) => {
+                self.add_form = None;
+                self.refresh();
+            }
+            Err(err) => {
+                if let Some(active) = self.add_form.as_mut() {
+                    active.error = Some(err.to_string());
+                }
+            }
+        }
+    }
+
+    fn create_agent_from_form(&self, branch: &str, prompt: Option<&Prompt>) -> Result<()> {
+        let (config, config_location) = Config::load_with_location(None)?;
+        let mut options = workflow::SetupOptions::new(true, true, true);
+        options.focus_window = false;
+        options.mode = config.mode();
+
+        let handle = crate::naming::derive_handle(branch, None, &config)?;
+        let context = workflow::WorkflowContext::new(config, self.mux.clone(), config_location)?;
+
+        workflow::create(
+            &context,
+            workflow::CreateArgs {
+                branch_name: branch,
+                handle: &handle,
+                base_branch: None,
+                remote_branch: None,
+                prompt,
+                options,
+                agent: None,
+            },
+        )?;
+
+        Ok(())
+    }
+
     /// Scroll preview up (toward older content). Returns the amount to scroll by.
     pub fn scroll_preview_up(&mut self, visible_height: u16, total_lines: u16) {
         let max_scroll = total_lines.saturating_sub(visible_height);
@@ -766,5 +909,48 @@ impl App {
     /// Get PR statuses for caching
     pub fn pr_statuses(&self) -> &HashMap<PathBuf, HashMap<String, PrSummary>> {
         &self.pr_statuses
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AddSessionField, AddSessionForm};
+
+    #[test]
+    fn add_form_switches_fields() {
+        let mut form = AddSessionForm::default();
+        assert_eq!(form.active_field, AddSessionField::Branch);
+
+        form.toggle_field();
+        assert_eq!(form.active_field, AddSessionField::Prompt);
+
+        form.toggle_field();
+        assert_eq!(form.active_field, AddSessionField::Branch);
+    }
+
+    #[test]
+    fn add_form_edits_active_field() {
+        let mut form = AddSessionForm::default();
+
+        form.push_char('f');
+        form.push_char('e');
+        form.push_char('a');
+        form.push_char('t');
+
+        form.toggle_field();
+        form.push_char('h');
+        form.push_char('i');
+
+        assert_eq!(form.branch, "feat");
+        assert_eq!(form.prompt, "hi");
+    }
+
+    #[test]
+    fn add_form_requires_non_empty_branch() {
+        let mut form = AddSessionForm::default();
+        assert!(!form.is_valid());
+
+        form.branch = "new-thing".to_string();
+        assert!(form.is_valid());
     }
 }

--- a/src/command/dashboard/keymap.rs
+++ b/src/command/dashboard/keymap.rs
@@ -9,6 +9,7 @@ use super::actions::Action;
 pub enum Context {
     DashboardNormal,
     DashboardInput,
+    DashboardAdd,
     DiffNormal,
     Patch,
     Comment,
@@ -19,6 +20,7 @@ pub fn action_for_key(ctx: Context, key: KeyEvent) -> Option<Action> {
     match ctx {
         Context::DashboardNormal => dashboard_normal_key(key),
         Context::DashboardInput => dashboard_input_key(key),
+        Context::DashboardAdd => dashboard_add_key(key),
         Context::DiffNormal => diff_normal_key(key),
         Context::Patch => patch_key(key),
         Context::Comment => comment_key(key),
@@ -42,6 +44,7 @@ fn dashboard_normal_key(key: KeyEvent) -> Option<Action> {
         KeyCode::Char('s') => Some(Action::CycleSortMode),
         KeyCode::Char('f') => Some(Action::ToggleStaleFilter),
         KeyCode::Char('i') => Some(Action::EnterInputMode),
+        KeyCode::Char('a') => Some(Action::EnterAddMode),
         KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
             Some(Action::ScrollPreviewUp)
         }
@@ -54,6 +57,18 @@ fn dashboard_normal_key(key: KeyEvent) -> Option<Action> {
         KeyCode::Char('c') => Some(Action::SendCommitDashboard),
         KeyCode::Char('m') => Some(Action::TriggerMergeDashboard),
         KeyCode::Char(c @ '1'..='9') => Some(Action::JumpToIndex((c as u8 - b'1') as usize)),
+        _ => None,
+    }
+}
+
+fn dashboard_add_key(key: KeyEvent) -> Option<Action> {
+    match key.code {
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Action::Quit),
+        KeyCode::Esc => Some(Action::CancelAddMode),
+        KeyCode::Enter => Some(Action::SubmitAddSession),
+        KeyCode::Tab | KeyCode::Up | KeyCode::Down => Some(Action::ToggleAddFormField),
+        KeyCode::Backspace => Some(Action::DeleteAddChar),
+        KeyCode::Char(c) => Some(Action::AppendAddChar(c)),
         _ => None,
     }
 }
@@ -143,6 +158,7 @@ pub fn help_rows(ctx: Context) -> Vec<(&'static str, &'static str)> {
             ("s", "Cycle sort mode"),
             ("f", "Toggle stale filter"),
             ("i", "Enter input mode"),
+            ("a", "Create agent"),
             ("Ctrl+u/d", "Scroll preview"),
             ("+/-", "Resize preview"),
             ("d", "View diff"),
@@ -151,6 +167,13 @@ pub fn help_rows(ctx: Context) -> Vec<(&'static str, &'static str)> {
             ("1-9", "Quick jump"),
         ],
         Context::DashboardInput => vec![("Esc", "Exit input mode"), ("<keys>", "Send to agent")],
+        Context::DashboardAdd => vec![
+            ("Tab", "Switch field"),
+            ("<type>", "Edit field"),
+            ("Enter", "Create agent"),
+            ("Esc", "Cancel"),
+            ("Ctrl+c", "Quit"),
+        ],
         Context::DiffNormal => vec![
             ("?", "Show help"),
             ("q/Esc", "Close diff"),
@@ -200,6 +223,7 @@ mod tests {
         for ctx in [
             Context::DashboardNormal,
             Context::DashboardInput,
+            Context::DashboardAdd,
             Context::DiffNormal,
             Context::Patch,
             Context::Comment,
@@ -257,6 +281,50 @@ mod tests {
         assert_eq!(
             action_for_key(Context::Patch, y),
             Some(Action::StageAndNext)
+        );
+    }
+
+    #[test]
+    fn test_dashboard_add_mode_keys() {
+        let esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+        let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        let tab = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);
+        let backspace = KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE);
+        let a = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
+        let ctrl_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+
+        assert_eq!(
+            action_for_key(Context::DashboardAdd, esc),
+            Some(Action::CancelAddMode)
+        );
+        assert_eq!(
+            action_for_key(Context::DashboardAdd, enter),
+            Some(Action::SubmitAddSession)
+        );
+        assert_eq!(
+            action_for_key(Context::DashboardAdd, tab),
+            Some(Action::ToggleAddFormField)
+        );
+        assert_eq!(
+            action_for_key(Context::DashboardAdd, backspace),
+            Some(Action::DeleteAddChar)
+        );
+        assert_eq!(
+            action_for_key(Context::DashboardAdd, a),
+            Some(Action::AppendAddChar('a'))
+        );
+        assert_eq!(
+            action_for_key(Context::DashboardAdd, ctrl_c),
+            Some(Action::Quit)
+        );
+    }
+
+    #[test]
+    fn test_dashboard_normal_add_key() {
+        let a = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
+        assert_eq!(
+            action_for_key(Context::DashboardNormal, a),
+            Some(Action::EnterAddMode)
         );
     }
 }

--- a/src/command/dashboard/mod.rs
+++ b/src/command/dashboard/mod.rs
@@ -60,7 +60,9 @@ use self::ui::ui;
 fn get_context(app: &App) -> Context {
     match &app.view_mode {
         ViewMode::Dashboard => {
-            if app.input_mode {
+            if app.add_form.is_some() {
+                Context::DashboardAdd
+            } else if app.input_mode {
                 Context::DashboardInput
             } else {
                 Context::DashboardNormal

--- a/src/command/dashboard/ui/dashboard.rs
+++ b/src/command/dashboard/ui/dashboard.rs
@@ -2,15 +2,15 @@
 
 use ansi_to_tui::IntoText;
 use ratatui::{
-    Frame,
     layout::{Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
-    widgets::{Block, Cell, Paragraph, Row, Table},
+    widgets::{Block, Cell, Clear, Paragraph, Row, Table},
+    Frame,
 };
 use std::collections::{BTreeMap, HashSet};
 
-use super::super::app::App;
+use super::super::app::{AddSessionField, App};
 use super::super::spinner::SPINNER_FRAMES;
 use super::format::{format_git_status, format_pr_status};
 
@@ -52,7 +52,23 @@ pub fn render_dashboard(f: &mut Frame, app: &mut App) {
     };
 
     // Footer - show different help based on mode
-    let footer_text = if app.input_mode {
+    let footer_text = if app.add_form.is_some() {
+        Paragraph::new(Line::from(vec![
+            Span::styled(
+                "  CREATE AGENT",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" - branch + prompt  "),
+            Span::styled("[Tab]", Style::default().fg(Color::Yellow)),
+            Span::raw(" switch  "),
+            Span::styled("[Enter]", Style::default().fg(Color::Green)),
+            Span::raw(" create  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Yellow)),
+            Span::raw(" cancel"),
+        ]))
+    } else if app.input_mode {
         Paragraph::new(Line::from(vec![
             Span::styled(
                 "  INPUT MODE",
@@ -68,6 +84,8 @@ pub fn render_dashboard(f: &mut Frame, app: &mut App) {
         let mut spans = vec![
             Span::styled("  [i]", Style::default().fg(Color::Green)),
             Span::raw(" input  "),
+            Span::styled("[a]", Style::default().fg(Color::Green)),
+            Span::raw(" add  "),
             Span::styled("[d]", Style::default().fg(Color::Yellow)),
             Span::raw(" diff  "),
             Span::styled("[1-9]", Style::default().fg(Color::Yellow)),
@@ -115,6 +133,121 @@ pub fn render_dashboard(f: &mut Frame, app: &mut App) {
         Paragraph::new(Line::from(spans))
     };
     f.render_widget(footer_text, chunks[footer_index]);
+
+    if app.add_form.is_some() {
+        render_add_form(f, app);
+    }
+}
+
+fn render_add_form(f: &mut Frame, app: &App) {
+    let Some(form) = app.add_form.as_ref() else {
+        return;
+    };
+
+    let area = f.area();
+    let width = area.width.min(90).saturating_sub(4).max(40);
+    let height = 11;
+    let popup = Rect {
+        x: area.width.saturating_sub(width) / 2,
+        y: area.height.saturating_sub(height) / 2,
+        width,
+        height: height.min(area.height),
+    };
+
+    let palette = &app.palette;
+
+    let branch_style = if form.active_field == AddSessionField::Branch {
+        Style::default().fg(Color::Black).bg(Color::Cyan)
+    } else {
+        Style::default().fg(palette.text)
+    };
+
+    let prompt_style = if form.active_field == AddSessionField::Prompt {
+        Style::default().fg(Color::Black).bg(Color::Cyan)
+    } else {
+        Style::default().fg(palette.text)
+    };
+
+    let branch_text = if form.branch.is_empty() {
+        Span::styled("feature/name", Style::default().fg(palette.dimmed))
+    } else {
+        Span::styled(form.branch.as_str(), branch_style)
+    };
+
+    let prompt_text = if form.prompt.is_empty() {
+        Span::styled(
+            "What should this agent do?",
+            Style::default().fg(palette.dimmed),
+        )
+    } else {
+        Span::styled(form.prompt.as_str(), prompt_style)
+    };
+
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled(
+                " Branch ",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            branch_text,
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                " Prompt ",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            prompt_text,
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Tip: ", Style::default().fg(Color::Cyan)),
+            Span::styled(
+                "Prompt is optional; leave blank to start without one.",
+                Style::default().fg(palette.dimmed),
+            ),
+        ]),
+    ];
+
+    if let Some(err) = &form.error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            err,
+            Style::default().fg(Color::Red),
+        )));
+    }
+
+    let block = Block::bordered()
+        .border_type(ratatui::widgets::BorderType::Rounded)
+        .border_style(Style::default().fg(palette.help_border))
+        .title(Line::from(vec![
+            Span::styled(" ", Style::default()),
+            Span::styled(
+                "Create Agent",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" ", Style::default()),
+        ]))
+        .title_bottom(Line::from(vec![
+            Span::styled(" ", Style::default()),
+            Span::styled("Tab", Style::default().fg(Color::Yellow)),
+            Span::styled(" switch field · ", Style::default().fg(palette.help_muted)),
+            Span::styled("Enter", Style::default().fg(Color::Green)),
+            Span::styled(" create · ", Style::default().fg(palette.help_muted)),
+            Span::styled("Esc", Style::default().fg(Color::Yellow)),
+            Span::styled(" cancel ", Style::default().fg(palette.help_muted)),
+        ]));
+
+    let panel = Paragraph::new(lines).block(block);
+
+    f.render_widget(Clear, popup);
+    f.render_widget(panel, popup);
 }
 
 fn render_table(f: &mut Frame, app: &mut App, area: Rect) {

--- a/src/command/dashboard/ui/help.rs
+++ b/src/command/dashboard/ui/help.rs
@@ -1,21 +1,23 @@
 //! Help overlay rendering.
 
 use ratatui::{
-    Frame,
     layout::{Constraint, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Cell, Clear, Row, Table},
+    Frame,
 };
 
 use super::super::app::{App, ViewMode};
-use super::super::keymap::{Context, help_rows};
+use super::super::keymap::{help_rows, Context};
 
 /// Determine the current keymap context for help display.
 fn get_help_context(app: &App) -> Context {
     match &app.view_mode {
         ViewMode::Dashboard => {
-            if app.input_mode {
+            if app.add_form.is_some() {
+                Context::DashboardAdd
+            } else if app.input_mode {
                 Context::DashboardInput
             } else {
                 Context::DashboardNormal
@@ -40,6 +42,7 @@ fn context_title(ctx: Context) -> &'static str {
     match ctx {
         Context::DashboardNormal => "Dashboard",
         Context::DashboardInput => "Input Mode",
+        Context::DashboardAdd => "Create Agent",
         Context::DiffNormal => "Diff View",
         Context::Patch => "Patch Mode",
         Context::Comment => "Comment",


### PR DESCRIPTION
## Summary
- add a dashboard add-agent mode (`a`) with a popup form for branch + optional prompt input
- wire new add-mode actions and keymap context so users can switch fields, submit, or cancel without leaving the TUI
- create agents directly from the dashboard via the existing workflow create path, with inline validation/errors and background creation

## Testing
- cargo test command::dashboard::keymap::tests
- cargo test command::dashboard::