### PR TITLE
fix: update OpenCode plugin to use v2 event names

### DIFF
--- a/.opencode/plugin/workmux-status.ts
+++ b/.opencode/plugin/workmux-status.ts
@@ -9,10 +9,12 @@ export const WorkmuxStatusPlugin: Plugin = async ({ $ }) => {
             await $`workmux set-window-status working`.quiet();
           }
           break;
-        case 'permission.updated':
+        case 'permission.asked':
+        case 'question.asked':
           await $`workmux set-window-status waiting`.quiet();
           break;
         case 'permission.replied':
+        case 'question.replied':
           await $`workmux set-window-status working`.quiet();
           break;
         case 'session.idle':


### PR DESCRIPTION
## Summary

The OpenCode plugin's waiting (💬) status never fires because:
- `permission.updated` was renamed to `permission.asked` in the OpenCode v2 SDK
- `question.asked` is a new event type for multiple-choice questions that also requires user input

This updates `.opencode/plugin/workmux-status.ts` to use the current event names.

## Evidence

- Workmux log shows zero calls to `set-window-status waiting`
- `@opencode-ai/sdk` v1 types have `permission.updated`, v2 types have `permission.asked`
- OpenCode runtime (tested on v1.2.17) emits v2 event names
- OpenCode docs at https://opencode.ai/docs/plugins/ list `permission.asked` and `permission.replied` under Permission Events

## Changes

- `.opencode/plugin/workmux-status.ts`: Replace `permission.updated` with `permission.asked` + `question.asked`, add `question.replied` alongside `permission.replied`

## Testing

Tested locally by adding diagnostic logging to the event handler. Confirmed:
- `question.asked` fires when OpenCode presents a multiple-choice question → status set to waiting
- `question.replied` fires when user answers → status set to working  
- `permission.asked` fires when OpenCode requests tool approval → status set to waiting
- `permission.replied` fires when user approves → status set to working