### PR TITLE
Exclude .md from Prettier, rely on markdownlint-cli2

### DIFF
--- a/docs/.prettierignore
+++ b/docs/.prettierignore
@@ -1,3 +1,6 @@
 node_modules
 .vitepress/cache
 .vitepress/dist
+
+# Markdown (formatted by markdownlint-cli2, not Prettier)
+*.md


### PR DESCRIPTION
## Summary

- Exclude `*.md` from Prettier since it normalizes ordered lists to `1.` with no config option to disable
- markdownlint-cli2 `--fix` already handles markdown formatting