### PR TITLE
chore: add GitHub draft release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,21 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+prerelease: false
+include-pre-releases: false
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## What's Changed
+
+  $CHANGES

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,0 +1,20 @@
+name: Draft Release Notes
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,6 +19,9 @@ This will:
 3. Open editor to review changelog
 4. Commit, publish to crates.io, tag, and push
 
+Merged PRs on `main` also keep the GitHub draft release up to date via Release
+Drafter, so upcoming release notes are visible before a tag is cut.
+
 ## Backfilling changelog
 
 To generate changelog entries for all git tags missing from CHANGELOG.md:


### PR DESCRIPTION
## Summary

Add a Release Drafter workflow so `main` always has an up-to-date draft GitHub release with upcoming release notes.

## Changes

- add `.github/release-drafter.yml` with a minimal release notes template and label-based version resolver
- add `.github/workflows/release-draft.yml` to refresh the draft release on pushes to `main`
- document the new draft-release behavior in `RELEASE.md`

## Testing

- validated `.github/release-drafter.yml` parses as YAML
- validated `.github/workflows/release-draft.yml` parses as YAML