### PR TITLE
fix(pi): use positional prompt argument instead of -p

### DIFF
--- a/src/multiplexer/agent.rs
+++ b/src/multiplexer/agent.rs
@@ -227,7 +227,7 @@ impl AgentProfile for PiProfile {
     }
 
     fn prompt_argument(&self, prompt_path: &str) -> String {
-        format!("-p \"$(cat {})\"", prompt_path)
+        format!("\"$(cat {})\"" , prompt_path)
     }
 
     fn auto_name_command(&self) -> Option<&'static str> {
@@ -510,7 +510,7 @@ mod tests {
         assert!(profile.needs_auto_status());
         assert_eq!(
             profile.prompt_argument("PROMPT.md"),
-            "-p \"$(cat PROMPT.md)\""
+            "\"$(cat PROMPT.md)\""
         );
         assert_eq!(profile.skip_permissions_flag(), None);
         assert_eq!(profile.auto_name_command(), Some("pi -p"));


### PR DESCRIPTION
## Problem

pi's `-p`/`--print` flag is non-interactive mode (process prompt and exit). Using it in `prompt_argument()` causes pi to exit immediately after processing the injected prompt, killing the pane. This also breaks `workmux send` since there's no running session to send to.

This differs from claude's `-p` which reads from stdin and stays responsive.

## Fix

Use a positional `"$(cat FILE)"` argument for prompt injection, matching the default profile pattern. Pi accepts messages as positional arguments and stays in interactive TUI mode.

`auto_name_command` keeps `pi -p` since branch name generation is intentionally one-shot.

Fixes #118