### PR TITLE
add sidebar project filter toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1749,7 +1749,7 @@ The sidebar displays:
 | `Enter` | Jump to agent         |
 | `g`/`G` | Jump to first/last    |
 | `v`     | Toggle layout mode    |
-| `s`     | Toggle session filter |
+| `f`     | Toggle session filter |
 | `q`     | Quit sidebar          |
 
 With tmux mouse mode enabled (`set -g mouse on`), click an agent row or top-bar

--- a/README.md
+++ b/README.md
@@ -1726,10 +1726,10 @@ Then press `prefix + Ctrl-s` to open the dashboard as a tmux popup.
 ### `workmux sidebar`
 
 Toggles a live agent status sidebar on the left or top edge of all tmux
-windows. By default, each sidebar pane shows active agents in its current tmux
-session with live status updates, providing an always-visible overview without
-taking over the full screen like the dashboard. Use `workmux sidebar filter none`
-to show agents across all sessions.
+windows. By default, each sidebar pane shows active agents across all tmux
+sessions with live status updates, providing an always-visible overview without
+taking over the full screen like the dashboard. Use `workmux sidebar filter session`
+to show only agents in the current tmux session.
 
 ```bash
 workmux sidebar                 # Toggle sidebar on/off (all sessions)

--- a/README.md
+++ b/README.md
@@ -1726,9 +1726,10 @@ Then press `prefix + Ctrl-s` to open the dashboard as a tmux popup.
 ### `workmux sidebar`
 
 Toggles a live agent status sidebar on the left or top edge of all tmux
-windows. Shows all active agents across all sessions and projects with live
-status updates, providing an always-visible overview without taking over the
-full screen like the dashboard.
+windows. By default, each sidebar pane shows active agents in its current tmux
+session with live status updates, providing an always-visible overview without
+taking over the full screen like the dashboard. Use `workmux sidebar filter none`
+to show agents across all sessions.
 
 ```bash
 workmux sidebar                 # Toggle sidebar on/off (all sessions)
@@ -1742,13 +1743,14 @@ The sidebar displays:
 - Project and worktree name (e.g. `myproject/fix-bug`)
 - Elapsed time since last status change
 
-| Key     | Action             |
-| ------- | ------------------ |
-| `j`/`k` | Navigate up/down   |
-| `Enter` | Jump to agent      |
-| `g`/`G` | Jump to first/last |
-| `v`     | Toggle layout mode |
-| `q`     | Quit sidebar       |
+| Key     | Action                |
+| ------- | --------------------- |
+| `j`/`k` | Navigate up/down      |
+| `Enter` | Jump to agent         |
+| `g`/`G` | Jump to first/last    |
+| `v`     | Toggle layout mode    |
+| `s`     | Toggle session filter |
+| `q`     | Quit sidebar          |
 
 With tmux mouse mode enabled (`set -g mouse on`), click an agent row or top-bar
 chip to jump to its pane, or scroll to navigate the list.

--- a/docs/guide/sidebar/index.md
+++ b/docs/guide/sidebar/index.md
@@ -126,25 +126,25 @@ the list. Requires `set -g mouse on` in your `~/.tmux.conf`.
 | `Enter` | Jump to agent pane       |
 | `g`/`G` | Jump to first/last       |
 | `v`     | Toggle layout mode       |
-| `p`     | Toggle project filter    |
+| `s`     | Toggle session filter    |
 | `z`     | Toggle sleeping on agent |
 | `q`     | Quit sidebar             |
 
-### Project filter
+### Session filter
 
-Press `p` to filter the sidebar to only show agents belonging to the same
-project as the current window. This is useful when you have many agents across
-different projects and want to focus on the current one. Press `p` again to
+Press `s` to filter the sidebar to only show agents in the same tmux session as
+the current window. This is useful when each session maps to a project or
+workspace and you want to focus on the current one. Press `s` again to
 show all agents.
 
 The filter also applies to agent navigation hotkeys (`next`/`prev`/`jump`), so
-`Alt+j`/`Alt+k` will only cycle through agents in the current project.
+`Alt+j`/`Alt+k` will only cycle through agents in the current session.
 
 You can also toggle the filter from the command line:
 
 ```bash
-workmux sidebar filter          # Toggle between none and project
-workmux sidebar filter project  # Filter to current project
+workmux sidebar filter          # Toggle between none and session
+workmux sidebar filter session  # Filter to current session
 workmux sidebar filter none     # Show all agents (no filter)
 ```
 

--- a/docs/guide/sidebar/index.md
+++ b/docs/guide/sidebar/index.md
@@ -132,13 +132,13 @@ the list. Requires `set -g mouse on` in your `~/.tmux.conf`.
 
 ### Session filter
 
-By default, the sidebar only shows agents in the same tmux session as the
-current window. This is useful when each session maps to a project or workspace
-and you want to focus on the current one. Press `s` to show agents from all
-tmux sessions; press `s` again to return to the current session.
+By default, the sidebar shows agents across all tmux sessions. Press `s` to
+show only agents in the same tmux session as the current window; press `s` again
+to return to all sessions.
 
 The filter also applies to agent navigation hotkeys (`next`/`prev`/`jump`), so
-`Alt+j`/`Alt+k` will only cycle through agents in the current session.
+`Alt+j`/`Alt+k` cycle through the current session when the session filter is
+active.
 
 You can also toggle the filter from the command line:
 

--- a/docs/guide/sidebar/index.md
+++ b/docs/guide/sidebar/index.md
@@ -126,14 +126,14 @@ the list. Requires `set -g mouse on` in your `~/.tmux.conf`.
 | `Enter` | Jump to agent pane       |
 | `g`/`G` | Jump to first/last       |
 | `v`     | Toggle layout mode       |
-| `s`     | Toggle session filter    |
+| `f`     | Toggle session filter    |
 | `z`     | Toggle sleeping on agent |
 | `q`     | Quit sidebar             |
 
 ### Session filter
 
-By default, the sidebar shows agents across all tmux sessions. Press `s` to
-show only agents in the same tmux session as the current window; press `s` again
+By default, the sidebar shows agents across all tmux sessions. Press `f` to
+show only agents in the same tmux session as the current window; press `f` again
 to return to all sessions.
 
 The filter also applies to agent navigation hotkeys (`next`/`prev`/`jump`), so

--- a/docs/guide/sidebar/index.md
+++ b/docs/guide/sidebar/index.md
@@ -132,6 +132,7 @@ the list. Requires `set -g mouse on` in your `~/.tmux.conf`.
 
 ### Session filter
 
+By default, the sidebar shows agents from all tmux sessions.
 Press `s` to filter the sidebar to only show agents in the same tmux session as
 the current window. This is useful when each session maps to a project or
 workspace and you want to focus on the current one. Press `s` again to

--- a/docs/guide/sidebar/index.md
+++ b/docs/guide/sidebar/index.md
@@ -126,8 +126,27 @@ the list. Requires `set -g mouse on` in your `~/.tmux.conf`.
 | `Enter` | Jump to agent pane       |
 | `g`/`G` | Jump to first/last       |
 | `v`     | Toggle layout mode       |
+| `p`     | Toggle project filter    |
 | `z`     | Toggle sleeping on agent |
 | `q`     | Quit sidebar             |
+
+### Project filter
+
+Press `p` to filter the sidebar to only show agents belonging to the same
+project as the current window. This is useful when you have many agents across
+different projects and want to focus on the current one. Press `p` again to
+show all agents.
+
+The filter also applies to agent navigation hotkeys (`next`/`prev`/`jump`), so
+`Alt+j`/`Alt+k` will only cycle through agents in the current project.
+
+You can also toggle the filter from the command line:
+
+```bash
+workmux sidebar filter          # Toggle between none and project
+workmux sidebar filter project  # Filter to current project
+workmux sidebar filter none     # Show all agents (no filter)
+```
 
 ### Sleeping agents
 

--- a/docs/guide/sidebar/index.md
+++ b/docs/guide/sidebar/index.md
@@ -132,11 +132,10 @@ the list. Requires `set -g mouse on` in your `~/.tmux.conf`.
 
 ### Session filter
 
-By default, the sidebar shows agents from all tmux sessions.
-Press `s` to filter the sidebar to only show agents in the same tmux session as
-the current window. This is useful when each session maps to a project or
-workspace and you want to focus on the current one. Press `s` again to
-show all agents.
+By default, the sidebar only shows agents in the same tmux session as the
+current window. This is useful when each session maps to a project or workspace
+and you want to focus on the current one. Press `s` to show agents from all
+tmux sessions; press `s` again to return to the current session.
 
 The filter also applies to agent navigation hotkeys (`next`/`prev`/`jump`), so
 `Alt+j`/`Alt+k` will only cycle through agents in the current session.

--- a/docs/reference/commands/sidebar.md
+++ b/docs/reference/commands/sidebar.md
@@ -5,8 +5,9 @@ description: Toggle a live agent status sidebar in tmux
 # sidebar
 
 Toggles a live agent status sidebar on the left or top edge of all tmux
-windows. Shows all active agents across all sessions and projects with live
-status updates.
+windows. By default, each sidebar pane shows active agents in its current tmux
+session with live status updates. Use `workmux sidebar filter none` to show
+agents across all sessions.
 
 ```bash
 workmux sidebar                 # Toggle sidebar on/off (all sessions)
@@ -43,7 +44,8 @@ chip to jump to its pane, or scroll to navigate the list.
 ## Navigation commands
 
 Switch between agents from any tmux pane, in the same order shown in the
-sidebar:
+sidebar. Navigation uses the same filter mode as the sidebar view, so it cycles
+within the current tmux session by default:
 
 | Command                    | Action                               |
 | -------------------------- | ------------------------------------ |

--- a/docs/reference/commands/sidebar.md
+++ b/docs/reference/commands/sidebar.md
@@ -32,7 +32,7 @@ Each agent row displays:
 | `Enter` | Jump to agent pane       |
 | `g`/`G` | Jump to first/last       |
 | `v`     | Toggle layout mode       |
-| `s`     | Toggle session filter    |
+| `f`     | Toggle session filter    |
 | `z`     | Toggle sleeping on agent |
 | `q`     | Quit sidebar             |
 
@@ -47,13 +47,13 @@ Switch between agents from any tmux pane, in the same order shown in the
 sidebar. Navigation uses the same filter mode as the sidebar view, so it cycles
 through all sessions by default:
 
-| Command                         | Action                               |
-| ------------------------------- | ------------------------------------ |
-| `workmux sidebar next`          | Switch to the next agent (wraps)     |
-| `workmux sidebar prev`          | Switch to the previous agent (wraps) |
-| `workmux sidebar jump <N>`      | Jump to the Nth agent (1-indexed)    |
-| `workmux sidebar filter`        | Toggle session filter (none/session) |
-| `workmux sidebar filter <MODE>` | Set filter mode: `none` or `session` |
+| Command                         | Action                                               |
+| ------------------------------- | ---------------------------------------------------- |
+| `workmux sidebar next`          | Switch to the next agent (wraps)                     |
+| `workmux sidebar prev`          | Switch to the previous agent (wraps)                 |
+| `workmux sidebar jump <N>`      | Jump to the Nth agent (1-indexed)                    |
+| `workmux sidebar filter`        | Toggle session filter (none/session)                 |
+| `workmux sidebar filter <MODE>` | Set filter mode: `none`/`all` or `session`/`project` |
 
 ### Example tmux keybindings
 

--- a/docs/reference/commands/sidebar.md
+++ b/docs/reference/commands/sidebar.md
@@ -31,7 +31,7 @@ Each agent row displays:
 | `Enter` | Jump to agent pane       |
 | `g`/`G` | Jump to first/last       |
 | `v`     | Toggle layout mode       |
-| `p`     | Toggle project filter    |
+| `s`     | Toggle session filter    |
 | `z`     | Toggle sleeping on agent |
 | `q`     | Quit sidebar             |
 
@@ -50,8 +50,8 @@ sidebar:
 | `workmux sidebar next`            | Switch to the next agent (wraps)              |
 | `workmux sidebar prev`            | Switch to the previous agent (wraps)          |
 | `workmux sidebar jump <N>`        | Jump to the Nth agent (1-indexed)             |
-| `workmux sidebar filter`          | Toggle project filter (none/project)          |
-| `workmux sidebar filter <MODE>`   | Set filter mode: `none` or `project`          |
+| `workmux sidebar filter`          | Toggle session filter (none/session)          |
+| `workmux sidebar filter <MODE>`   | Set filter mode: `none` or `session`          |
 
 ### Example tmux keybindings
 

--- a/docs/reference/commands/sidebar.md
+++ b/docs/reference/commands/sidebar.md
@@ -47,13 +47,13 @@ Switch between agents from any tmux pane, in the same order shown in the
 sidebar. Navigation uses the same filter mode as the sidebar view, so it cycles
 within the current tmux session by default:
 
-| Command                    | Action                               |
-| -------------------------- | ------------------------------------ |
-| `workmux sidebar next`            | Switch to the next agent (wraps)              |
-| `workmux sidebar prev`            | Switch to the previous agent (wraps)          |
-| `workmux sidebar jump <N>`        | Jump to the Nth agent (1-indexed)             |
-| `workmux sidebar filter`          | Toggle session filter (none/session)          |
-| `workmux sidebar filter <MODE>`   | Set filter mode: `none` or `session`          |
+| Command                         | Action                               |
+| ------------------------------- | ------------------------------------ |
+| `workmux sidebar next`          | Switch to the next agent (wraps)     |
+| `workmux sidebar prev`          | Switch to the previous agent (wraps) |
+| `workmux sidebar jump <N>`      | Jump to the Nth agent (1-indexed)    |
+| `workmux sidebar filter`        | Toggle session filter (none/session) |
+| `workmux sidebar filter <MODE>` | Set filter mode: `none` or `session` |
 
 ### Example tmux keybindings
 

--- a/docs/reference/commands/sidebar.md
+++ b/docs/reference/commands/sidebar.md
@@ -31,6 +31,7 @@ Each agent row displays:
 | `Enter` | Jump to agent pane       |
 | `g`/`G` | Jump to first/last       |
 | `v`     | Toggle layout mode       |
+| `p`     | Toggle project filter    |
 | `z`     | Toggle sleeping on agent |
 | `q`     | Quit sidebar             |
 
@@ -46,9 +47,11 @@ sidebar:
 
 | Command                    | Action                               |
 | -------------------------- | ------------------------------------ |
-| `workmux sidebar next`     | Switch to the next agent (wraps)     |
-| `workmux sidebar prev`     | Switch to the previous agent (wraps) |
-| `workmux sidebar jump <N>` | Jump to the Nth agent (1-indexed)    |
+| `workmux sidebar next`            | Switch to the next agent (wraps)              |
+| `workmux sidebar prev`            | Switch to the previous agent (wraps)          |
+| `workmux sidebar jump <N>`        | Jump to the Nth agent (1-indexed)             |
+| `workmux sidebar filter`          | Toggle project filter (none/project)          |
+| `workmux sidebar filter <MODE>`   | Set filter mode: `none` or `project`          |
 
 ### Example tmux keybindings
 

--- a/docs/reference/commands/sidebar.md
+++ b/docs/reference/commands/sidebar.md
@@ -5,9 +5,9 @@ description: Toggle a live agent status sidebar in tmux
 # sidebar
 
 Toggles a live agent status sidebar on the left or top edge of all tmux
-windows. By default, each sidebar pane shows active agents in its current tmux
-session with live status updates. Use `workmux sidebar filter none` to show
-agents across all sessions.
+windows. By default, each sidebar pane shows active agents across all tmux
+sessions with live status updates. Use `workmux sidebar filter session` to show
+only agents in the current tmux session.
 
 ```bash
 workmux sidebar                 # Toggle sidebar on/off (all sessions)
@@ -45,7 +45,7 @@ chip to jump to its pane, or scroll to navigate the list.
 
 Switch between agents from any tmux pane, in the same order shown in the
 sidebar. Navigation uses the same filter mode as the sidebar view, so it cycles
-within the current tmux session by default:
+through all sessions by default:
 
 | Command                         | Action                               |
 | ------------------------------- | ------------------------------------ |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -794,6 +794,12 @@ pub enum SidebarAction {
         #[arg(value_name = "N", value_parser = clap::value_parser!(u64).range(1..))]
         index: u64,
     },
+    /// Set sidebar filter mode (all or project). Toggles if no mode given.
+    Filter {
+        /// Filter mode: "none" or "project"
+        #[arg(value_name = "MODE")]
+        mode: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1055,6 +1061,9 @@ pub fn run() -> Result<()> {
             }
             Some(SidebarAction::Jump { index }) => {
                 command::sidebar::navigate(command::sidebar::NavAction::Jump(index as usize))
+            }
+            Some(SidebarAction::Filter { mode }) => {
+                command::sidebar::set_filter_mode(mode.as_deref())
             }
             None => {
                 if session {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -794,9 +794,9 @@ pub enum SidebarAction {
         #[arg(value_name = "N", value_parser = clap::value_parser!(u64).range(1..))]
         index: u64,
     },
-    /// Set sidebar filter mode (none or session). Toggles if no mode given.
+    /// Set sidebar filter mode. Toggles if no mode given.
     Filter {
-        /// Filter mode: "none" or "session"
+        /// Filter mode: "none"/"all" or "session"/"project"
         #[arg(value_name = "MODE")]
         mode: Option<String>,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -794,9 +794,9 @@ pub enum SidebarAction {
         #[arg(value_name = "N", value_parser = clap::value_parser!(u64).range(1..))]
         index: u64,
     },
-    /// Set sidebar filter mode (all or project). Toggles if no mode given.
+    /// Set sidebar filter mode (none or session). Toggles if no mode given.
     Filter {
-        /// Filter mode: "none" or "project"
+        /// Filter mode: "none" or "session"
         #[arg(value_name = "MODE")]
         mode: Option<String>,
     },

--- a/src/command/dashboard/app/agents.rs
+++ b/src/command/dashboard/app/agents.rs
@@ -18,6 +18,7 @@ use super::super::settings::{load_last_pane_id, save_hide_stale, save_last_pane_
 use super::super::sort::SortMode;
 use super::super::spinner::SPINNER_FRAMES;
 use super::App;
+use crate::command::pane_history::pane_to_remember;
 
 /// Selected agent pane target for multiplexer operations.
 pub(crate) struct PaneTarget {
@@ -267,14 +268,8 @@ impl App {
             self.should_jump = true;
         }
 
-        // Only update last_pane_id if:
-        // 1. We actually moved to a different pane
-        // 2. The previous pane was an agent pane (not just any tmux pane)
-        if let Some(ref current) = current_pane
-            && current != target_pane_id
-            && self.agents.iter().any(|a| a.pane_id == *current)
-        {
-            self.last_pane_id = Some(current.clone());
+        if let Some(current) = pane_to_remember(current_pane.as_deref(), target_pane_id) {
+            self.last_pane_id = Some(current.to_string());
             save_last_pane_id(current);
         }
     }

--- a/src/command/last_agent.rs
+++ b/src/command/last_agent.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Result;
 
+use crate::command::pane_history::pane_to_remember;
 use crate::multiplexer::{create_backend, detect_backend};
 use crate::state::StateStore;
 
@@ -50,12 +51,11 @@ pub fn run() -> Result<()> {
         return Ok(());
     }
 
-    // Only persist after successful switch, and only if current pane is an agent
-    if let Some(ref current) = current_pane
-        && agents.iter().any(|a| a.pane_id == *current)
-    {
+    // Persist the pane we came from so hotkeys can toggle back even when
+    // invoked from a normal shell/editor pane.
+    if let Some(current) = pane_to_remember(current_pane.as_deref(), &target_pane_id) {
         let mut settings = store.load_settings()?;
-        settings.last_pane_id = Some(current.clone());
+        settings.last_pane_id = Some(current.to_string());
         store.save_settings(&settings)?;
     }
 

--- a/src/command/last_agent.rs
+++ b/src/command/last_agent.rs
@@ -9,13 +9,13 @@ use crate::state::StateStore;
 /// Switch to the last visited agent.
 ///
 /// Reads `last_pane_id` from GlobalSettings and switches to that pane.
-/// Updates last_pane_id to the current pane after successful switch,
-/// but only if the current pane is also an agent pane.
+/// Updates last_pane_id to the current pane after a successful switch when it
+/// differs from the target pane.
 pub fn run() -> Result<()> {
     let mux = create_backend(detect_backend());
     let store = StateStore::new()?;
 
-    // Load agents to verify panes are actually agent panes
+    // Load agents for window hints when the target is an agent pane.
     let agents = store
         .load_reconciled_agents(mux.as_ref())
         .unwrap_or_default();
@@ -26,9 +26,8 @@ pub fn run() -> Result<()> {
         return Ok(());
     };
 
-    // Verify target is still an agent pane
-    if !agents.iter().any(|a| a.pane_id == target_pane_id) {
-        println!("Last agent pane no longer exists");
+    if mux.get_live_pane_info(&target_pane_id)?.is_none() {
+        println!("Last pane no longer exists");
         return Ok(());
     }
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -14,6 +14,7 @@ pub mod last_done;
 pub mod list;
 pub mod merge;
 pub mod open;
+pub mod pane_history;
 pub mod path;
 pub mod reap_agents;
 pub mod rebase;

--- a/src/command/pane_history.rs
+++ b/src/command/pane_history.rs
@@ -1,0 +1,30 @@
+/// Return the pane to remember as the previous location after a successful switch.
+///
+/// We track any distinct source pane, not just agent panes, so pane-level hotkeys
+/// can round-trip cleanly between ordinary tmux panes and agent panes.
+pub fn pane_to_remember<'a>(
+    current_pane: Option<&'a str>,
+    target_pane_id: &str,
+) -> Option<&'a str> {
+    current_pane.filter(|pane_id| *pane_id != target_pane_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pane_to_remember;
+
+    #[test]
+    fn remembers_non_agent_source_pane() {
+        assert_eq!(pane_to_remember(Some("%42"), "%7"), Some("%42"));
+    }
+
+    #[test]
+    fn ignores_same_pane_switch() {
+        assert_eq!(pane_to_remember(Some("%7"), "%7"), None);
+    }
+
+    #[test]
+    fn ignores_missing_current_pane() {
+        assert_eq!(pane_to_remember(None, "%7"), None);
+    }
+}

--- a/src/command/sidebar/app.rs
+++ b/src/command/sidebar/app.rs
@@ -77,6 +77,26 @@ impl SidebarFilterMode {
     }
 }
 
+fn host_agent_index(
+    agents: &[AgentPane],
+    host_window_id: Option<&str>,
+    active_pane_ids: &std::collections::HashSet<String>,
+) -> Option<usize> {
+    host_window_id.and_then(|wid| {
+        let mut first_match = None;
+        for (i, agent) in agents.iter().enumerate() {
+            if agent.window_id != wid {
+                continue;
+            }
+            if active_pane_ids.contains(&agent.pane_id) {
+                return Some(i);
+            }
+            first_match.get_or_insert(i);
+        }
+        first_match
+    })
+}
+
 /// Whether the sidebar auto-follows its host window or the user is navigating manually.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SelectionMode {
@@ -401,19 +421,11 @@ impl SidebarApp {
         // Compute host agent index from the new snapshot first so that a
         // config_version bump anchors the reload to the *current* host path,
         // not whatever was selected from the previous snapshot.
-        self.host_agent_idx = self.host_window_id.as_ref().and_then(|wid| {
-            let mut first_match = None;
-            for (i, agent) in snapshot.agents.iter().enumerate() {
-                if agent.window_id != *wid {
-                    continue;
-                }
-                if snapshot.active_pane_ids.contains(&agent.pane_id) {
-                    return Some(i);
-                }
-                first_match.get_or_insert(i);
-            }
-            first_match
-        });
+        self.host_agent_idx = host_agent_index(
+            &snapshot.agents,
+            self.host_window_id.as_deref(),
+            &snapshot.active_pane_ids,
+        );
 
         if snapshot.config_version != self.last_config_version {
             self.last_config_version = snapshot.config_version;
@@ -459,10 +471,11 @@ impl SidebarApp {
         {
             self.agents.retain(|a| a.session == host_session);
             // Recompute host_agent_idx after filtering
-            self.host_agent_idx = self
-                .host_window_id
-                .as_ref()
-                .and_then(|wid| self.agents.iter().position(|a| a.window_id == *wid));
+            self.host_agent_idx = host_agent_index(
+                &self.agents,
+                self.host_window_id.as_deref(),
+                &snapshot.active_pane_ids,
+            );
         }
 
         // Restore selection
@@ -760,20 +773,25 @@ impl SidebarApp {
     pub fn toggle_filter_mode(&mut self) {
         self.filter_mode = self.filter_mode.toggle();
         // Persist to tmux so all sidebar instances pick it up immediately
-        let _ = Cmd::new("tmux")
+        if let Err(error) = Cmd::new("tmux")
             .args(&[
                 "set-option",
                 "-g",
                 "@workmux_sidebar_filter",
                 self.filter_mode.as_str(),
             ])
-            .run();
-        // Persist to settings.json so it survives tmux restarts
-        if let Ok(store) = crate::state::StateStore::new()
-            && let Ok(mut settings) = store.load_settings()
+            .run()
         {
+            warn!(%error, "failed to persist sidebar filter mode to tmux");
+        }
+        // Persist to settings.json so it survives tmux restarts
+        match crate::state::StateStore::new().and_then(|store| {
+            let mut settings = store.load_settings()?;
             settings.sidebar_filter = Some(self.filter_mode.as_str().to_string());
-            let _ = store.save_settings(&settings);
+            store.save_settings(&settings)
+        }) {
+            Ok(()) => {}
+            Err(error) => warn!(%error, "failed to persist sidebar filter mode to settings"),
         }
         // Signal daemon for immediate refresh
         super::daemon_ctrl::signal_daemon();
@@ -1406,6 +1424,46 @@ fn detect_host_window() -> (Option<String>, Option<String>) {
 #[cfg(test)]
 mod filter_tests {
     use super::*;
+
+    #[test]
+    fn host_agent_index_prefers_active_pane() {
+        let agents = vec![
+            AgentPane {
+                session: "s".to_string(),
+                window_name: "w".to_string(),
+                pane_id: "%1".to_string(),
+                window_id: "@1".to_string(),
+                path: PathBuf::from("/tmp/a"),
+                pane_title: None,
+                status: None,
+                status_ts: None,
+                updated_ts: None,
+                window_cmd: None,
+                agent_command: None,
+                agent_kind: None,
+            },
+            AgentPane {
+                session: "s".to_string(),
+                window_name: "w".to_string(),
+                pane_id: "%2".to_string(),
+                window_id: "@1".to_string(),
+                path: PathBuf::from("/tmp/b"),
+                pane_title: None,
+                status: None,
+                status_ts: None,
+                updated_ts: None,
+                window_cmd: None,
+                agent_command: None,
+                agent_kind: None,
+            },
+        ];
+        let active_panes = std::collections::HashSet::from(["%2".to_string()]);
+
+        assert_eq!(
+            host_agent_index(&agents, Some("@1"), &active_panes),
+            Some(1)
+        );
+    }
 
     #[test]
     fn filter_mode_toggle() {

--- a/src/command/sidebar/app.rs
+++ b/src/command/sidebar/app.rs
@@ -1404,7 +1404,7 @@ fn detect_host_window() -> (Option<String>, Option<String>) {
 }
 
 #[cfg(test)]
-mod tests {
+mod filter_tests {
     use super::*;
 
     #[test]

--- a/src/command/sidebar/app.rs
+++ b/src/command/sidebar/app.rs
@@ -70,6 +70,7 @@ impl SidebarFilterMode {
 
     pub fn from_str(s: &str) -> Self {
         match s.trim().to_lowercase().as_str() {
+            "none" | "all" => Self::None,
             "session" | "project" => Self::Session,
             _ => Self::None,
         }

--- a/src/command/sidebar/app.rs
+++ b/src/command/sidebar/app.rs
@@ -44,33 +44,33 @@ impl SidebarLayoutMode {
     }
 }
 
-/// Sidebar filter mode: show all agents or only those matching the host's project.
+/// Sidebar filter mode: show all agents or only those in the host tmux session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SidebarFilterMode {
     #[default]
     None,
-    Project,
+    Session,
 }
 
 impl SidebarFilterMode {
     pub fn toggle(self) -> Self {
         match self {
-            Self::None => Self::Project,
-            Self::Project => Self::None,
+            Self::None => Self::Session,
+            Self::Session => Self::None,
         }
     }
 
     pub fn as_str(self) -> &'static str {
         match self {
             Self::None => "none",
-            Self::Project => "project",
+            Self::Session => "session",
         }
     }
 
     pub fn from_str(s: &str) -> Self {
         match s.trim().to_lowercase().as_str() {
-            "project" => Self::Project,
+            "session" | "project" => Self::Session,
             _ => Self::None,
         }
     }
@@ -255,10 +255,8 @@ pub struct SidebarApp {
     /// Deadline after which pending resize should be processed.
     pub(super) resize_deadline: Option<Instant>,
     suppress_resize_once: bool,
-    /// Filter mode: show all agents or only those matching the host's project.
+    /// Filter mode: show all agents or only those in the host tmux session.
     pub filter_mode: SidebarFilterMode,
-    /// Working directory of the host pane for project detection.
-    host_pane_cwd: Option<PathBuf>,
 }
 
 impl SidebarApp {
@@ -315,7 +313,6 @@ impl SidebarApp {
             resize_deadline: None,
             suppress_resize_once: false,
             filter_mode: SidebarFilterMode::default(),
-            host_pane_cwd: None,
         }
     }
 
@@ -335,7 +332,6 @@ impl SidebarApp {
         let status_icons = config.status_icons.clone();
 
         let (host_session, host_window_id) = detect_host_window();
-        let host_pane_cwd = detect_host_pane_cwd();
 
         let (templates, template_error) = parse_templates(&config);
         let (current_compact_str, current_tile_strs, current_horizontal_strs) =
@@ -394,7 +390,6 @@ impl SidebarApp {
             resize_deadline: None,
             suppress_resize_once: false,
             filter_mode: SidebarFilterMode::default(),
-            host_pane_cwd,
         })
     }
 
@@ -457,12 +452,11 @@ impl SidebarApp {
 
         self.agents = snapshot.agents;
 
-        // Apply project filter: retain only agents matching the host's project
-        if self.filter_mode == SidebarFilterMode::Project
-            && let Some(host_project) = self.host_project_name()
+        // Apply session filter: retain only agents in the sidebar's host session.
+        if self.filter_mode == SidebarFilterMode::Session
+            && let Some(host_session) = self.host_session.as_deref()
         {
-            self.agents
-                .retain(|a| extract_project_name(&a.path) == host_project);
+            self.agents.retain(|a| a.session == host_session);
             // Recompute host_agent_idx after filtering
             self.host_agent_idx = self
                 .host_window_id
@@ -546,6 +540,10 @@ impl SidebarApp {
 
     pub fn host_window_id(&self) -> Option<&str> {
         self.host_window_id.as_deref()
+    }
+
+    pub fn host_session(&self) -> Option<&str> {
+        self.host_session.as_deref()
     }
 
     pub fn host_window_active(&self) -> bool {
@@ -778,15 +776,6 @@ impl SidebarApp {
         }
         // Signal daemon for immediate refresh
         super::daemon_ctrl::signal_daemon();
-    }
-
-    /// The project name derived from the host window. Prefers the host agent's path,
-    /// falls back to the host pane's working directory for non-agent windows.
-    pub fn host_project_name(&self) -> Option<String> {
-        self.host_agent_idx
-            .and_then(|idx| self.agents.get(idx))
-            .map(|a| extract_project_name(&a.path))
-            .or_else(|| self.host_pane_cwd.as_ref().map(|p| extract_project_name(p)))
     }
 
     pub fn window_prefix(&self) -> &str {
@@ -1413,41 +1402,19 @@ fn detect_host_window() -> (Option<String>, Option<String>) {
     (session, window_id)
 }
 
-/// Detect the working directory of the sidebar's host pane (one-time at startup).
-/// Used as a fallback for project detection when the host window has no agent.
-fn detect_host_pane_cwd() -> Option<PathBuf> {
-    let pane_id = std::env::var("TMUX_PANE").ok()?;
-    let output = Cmd::new("tmux")
-        .args(&[
-            "display-message",
-            "-t",
-            &pane_id,
-            "-p",
-            "#{pane_current_path}",
-        ])
-        .run_and_capture_stdout()
-        .ok()?;
-    let path = output.trim();
-    if path.is_empty() {
-        None
-    } else {
-        Some(PathBuf::from(path))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn filter_mode_toggle() {
-        assert_eq!(SidebarFilterMode::None.toggle(), SidebarFilterMode::Project);
-        assert_eq!(SidebarFilterMode::Project.toggle(), SidebarFilterMode::None);
+        assert_eq!(SidebarFilterMode::None.toggle(), SidebarFilterMode::Session);
+        assert_eq!(SidebarFilterMode::Session.toggle(), SidebarFilterMode::None);
     }
 
     #[test]
     fn filter_mode_roundtrip_strings() {
-        for mode in [SidebarFilterMode::None, SidebarFilterMode::Project] {
+        for mode in [SidebarFilterMode::None, SidebarFilterMode::Session] {
             assert_eq!(SidebarFilterMode::from_str(mode.as_str()), mode);
         }
     }
@@ -1464,12 +1431,16 @@ mod tests {
     #[test]
     fn filter_mode_from_str_case_insensitive() {
         assert_eq!(
-            SidebarFilterMode::from_str("Project"),
-            SidebarFilterMode::Project
+            SidebarFilterMode::from_str("Session"),
+            SidebarFilterMode::Session
         );
         assert_eq!(
-            SidebarFilterMode::from_str("PROJECT"),
-            SidebarFilterMode::Project
+            SidebarFilterMode::from_str("SESSION"),
+            SidebarFilterMode::Session
+        );
+        assert_eq!(
+            SidebarFilterMode::from_str("project"),
+            SidebarFilterMode::Session
         );
     }
 

--- a/src/command/sidebar/app.rs
+++ b/src/command/sidebar/app.rs
@@ -44,6 +44,38 @@ impl SidebarLayoutMode {
     }
 }
 
+/// Sidebar filter mode: show all agents or only those matching the host's project.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SidebarFilterMode {
+    #[default]
+    None,
+    Project,
+}
+
+impl SidebarFilterMode {
+    pub fn toggle(self) -> Self {
+        match self {
+            Self::None => Self::Project,
+            Self::Project => Self::None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Project => "project",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Self {
+        match s.trim().to_lowercase().as_str() {
+            "project" => Self::Project,
+            _ => Self::None,
+        }
+    }
+}
+
 /// Whether the sidebar auto-follows its host window or the user is navigating manually.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SelectionMode {
@@ -223,6 +255,10 @@ pub struct SidebarApp {
     /// Deadline after which pending resize should be processed.
     pub(super) resize_deadline: Option<Instant>,
     suppress_resize_once: bool,
+    /// Filter mode: show all agents or only those matching the host's project.
+    pub filter_mode: SidebarFilterMode,
+    /// Working directory of the host pane for project detection.
+    host_pane_cwd: Option<PathBuf>,
 }
 
 impl SidebarApp {
@@ -278,6 +314,8 @@ impl SidebarApp {
             pending_resize_rows: None,
             resize_deadline: None,
             suppress_resize_once: false,
+            filter_mode: SidebarFilterMode::default(),
+            host_pane_cwd: None,
         }
     }
 
@@ -297,6 +335,7 @@ impl SidebarApp {
         let status_icons = config.status_icons.clone();
 
         let (host_session, host_window_id) = detect_host_window();
+        let host_pane_cwd = detect_host_pane_cwd();
 
         let (templates, template_error) = parse_templates(&config);
         let (current_compact_str, current_tile_strs, current_horizontal_strs) =
@@ -354,6 +393,8 @@ impl SidebarApp {
             pending_resize_rows: None,
             resize_deadline: None,
             suppress_resize_once: false,
+            filter_mode: SidebarFilterMode::default(),
+            host_pane_cwd,
         })
     }
 
@@ -385,6 +426,7 @@ impl SidebarApp {
 
         self.position = snapshot.position;
         self.layout_mode = snapshot.layout_mode;
+        self.filter_mode = snapshot.filter_mode;
         self.git_statuses = snapshot.git_statuses;
         self.pr_statuses = snapshot.pr_statuses;
         self.interrupted_pane_ids = snapshot.interrupted_pane_ids;
@@ -414,6 +456,19 @@ impl SidebarApp {
             .map(|a| a.pane_id.clone());
 
         self.agents = snapshot.agents;
+
+        // Apply project filter: retain only agents matching the host's project
+        if self.filter_mode == SidebarFilterMode::Project
+            && let Some(host_project) = self.host_project_name()
+        {
+            self.agents
+                .retain(|a| extract_project_name(&a.path) == host_project);
+            // Recompute host_agent_idx after filtering
+            self.host_agent_idx = self
+                .host_window_id
+                .as_ref()
+                .and_then(|wid| self.agents.iter().position(|a| a.window_id == *wid));
+        }
 
         // Restore selection
         if let Some(ref pane_id) = selected_pane {
@@ -701,6 +756,37 @@ impl SidebarApp {
 
         // Signal daemon for immediate refresh (re-sort + broadcast)
         super::daemon_ctrl::signal_daemon();
+    }
+
+    pub fn toggle_filter_mode(&mut self) {
+        self.filter_mode = self.filter_mode.toggle();
+        // Persist to tmux so all sidebar instances pick it up immediately
+        let _ = Cmd::new("tmux")
+            .args(&[
+                "set-option",
+                "-g",
+                "@workmux_sidebar_filter",
+                self.filter_mode.as_str(),
+            ])
+            .run();
+        // Persist to settings.json so it survives tmux restarts
+        if let Ok(store) = crate::state::StateStore::new()
+            && let Ok(mut settings) = store.load_settings()
+        {
+            settings.sidebar_filter = Some(self.filter_mode.as_str().to_string());
+            let _ = store.save_settings(&settings);
+        }
+        // Signal daemon for immediate refresh
+        super::daemon_ctrl::signal_daemon();
+    }
+
+    /// The project name derived from the host window. Prefers the host agent's path,
+    /// falls back to the host pane's working directory for non-agent windows.
+    pub fn host_project_name(&self) -> Option<String> {
+        self.host_agent_idx
+            .and_then(|idx| self.agents.get(idx))
+            .map(|a| extract_project_name(&a.path))
+            .or_else(|| self.host_pane_cwd.as_ref().map(|p| extract_project_name(p)))
     }
 
     pub fn window_prefix(&self) -> &str {
@@ -1325,4 +1411,70 @@ fn detect_host_window() -> (Option<String>, Option<String>) {
     let session = parts.next().flatten();
     let window_id = parts.next().flatten();
     (session, window_id)
+}
+
+/// Detect the working directory of the sidebar's host pane (one-time at startup).
+/// Used as a fallback for project detection when the host window has no agent.
+fn detect_host_pane_cwd() -> Option<PathBuf> {
+    let pane_id = std::env::var("TMUX_PANE").ok()?;
+    let output = Cmd::new("tmux")
+        .args(&[
+            "display-message",
+            "-t",
+            &pane_id,
+            "-p",
+            "#{pane_current_path}",
+        ])
+        .run_and_capture_stdout()
+        .ok()?;
+    let path = output.trim();
+    if path.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_mode_toggle() {
+        assert_eq!(SidebarFilterMode::None.toggle(), SidebarFilterMode::Project);
+        assert_eq!(SidebarFilterMode::Project.toggle(), SidebarFilterMode::None);
+    }
+
+    #[test]
+    fn filter_mode_roundtrip_strings() {
+        for mode in [SidebarFilterMode::None, SidebarFilterMode::Project] {
+            assert_eq!(SidebarFilterMode::from_str(mode.as_str()), mode);
+        }
+    }
+
+    #[test]
+    fn filter_mode_from_str_defaults_to_all() {
+        assert_eq!(SidebarFilterMode::from_str(""), SidebarFilterMode::None);
+        assert_eq!(
+            SidebarFilterMode::from_str("unknown"),
+            SidebarFilterMode::None
+        );
+    }
+
+    #[test]
+    fn filter_mode_from_str_case_insensitive() {
+        assert_eq!(
+            SidebarFilterMode::from_str("Project"),
+            SidebarFilterMode::Project
+        );
+        assert_eq!(
+            SidebarFilterMode::from_str("PROJECT"),
+            SidebarFilterMode::Project
+        );
+    }
+
+    #[test]
+    fn filter_mode_default_is_all() {
+        assert_eq!(SidebarFilterMode::default(), SidebarFilterMode::None);
+    }
 }

--- a/src/command/sidebar/app.rs
+++ b/src/command/sidebar/app.rs
@@ -48,8 +48,8 @@ impl SidebarLayoutMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SidebarFilterMode {
-    None,
     #[default]
+    None,
     Session,
 }
 
@@ -1446,7 +1446,7 @@ mod filter_tests {
     }
 
     #[test]
-    fn filter_mode_default_is_session() {
-        assert_eq!(SidebarFilterMode::default(), SidebarFilterMode::Session);
+    fn filter_mode_default_shows_all_sessions() {
+        assert_eq!(SidebarFilterMode::default(), SidebarFilterMode::None);
     }
 }

--- a/src/command/sidebar/app.rs
+++ b/src/command/sidebar/app.rs
@@ -48,8 +48,8 @@ impl SidebarLayoutMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SidebarFilterMode {
-    #[default]
     None,
+    #[default]
     Session,
 }
 
@@ -1421,7 +1421,7 @@ mod tests {
     }
 
     #[test]
-    fn filter_mode_from_str_defaults_to_all() {
+    fn invalid_filter_mode_maps_to_all() {
         assert_eq!(SidebarFilterMode::from_str(""), SidebarFilterMode::None);
         assert_eq!(
             SidebarFilterMode::from_str("unknown"),
@@ -1446,7 +1446,7 @@ mod tests {
     }
 
     #[test]
-    fn filter_mode_default_is_all() {
-        assert_eq!(SidebarFilterMode::default(), SidebarFilterMode::None);
+    fn filter_mode_default_is_session() {
+        assert_eq!(SidebarFilterMode::default(), SidebarFilterMode::Session);
     }
 }

--- a/src/command/sidebar/daemon.rs
+++ b/src/command/sidebar/daemon.rs
@@ -1581,7 +1581,6 @@ pub fn run() -> Result<()> {
                 .map(|a| a.pane_id.as_str())
                 .collect::<Vec<_>>()
                 .join(" ");
-
             if agent_list != last_agent_list {
                 if !agent_list.is_empty() {
                     let _ = Cmd::new("tmux")

--- a/src/command/sidebar/daemon.rs
+++ b/src/command/sidebar/daemon.rs
@@ -21,7 +21,7 @@ use crate::github::PrSummary;
 use crate::multiplexer::{Multiplexer, create_backend, detect_backend};
 use crate::state::StateStore;
 
-use super::app::SidebarLayoutMode;
+use super::app::{SidebarFilterMode, SidebarLayoutMode};
 use super::snapshot::{PrPathEntry, build_snapshot};
 
 /// Compute socket path from instance_id.
@@ -229,6 +229,29 @@ fn read_sidebar_layout_mode(config: &Config) -> Option<SidebarLayoutMode> {
     }
 
     None
+}
+
+/// Read the sidebar filter mode from tmux global, falling back to settings.json.
+fn read_sidebar_filter_mode() -> SidebarFilterMode {
+    if let Ok(output) = Cmd::new("tmux")
+        .args(&["show-option", "-gqv", "@workmux_sidebar_filter"])
+        .run_and_capture_stdout()
+    {
+        let trimmed = output.trim();
+        if !trimmed.is_empty() {
+            return SidebarFilterMode::from_str(trimmed);
+        }
+    }
+
+    // Fall back to persisted setting
+    if let Ok(store) = StateStore::new()
+        && let Ok(settings) = store.load_settings()
+        && let Some(ref mode) = settings.sidebar_filter
+    {
+        return SidebarFilterMode::from_str(mode);
+    }
+
+    SidebarFilterMode::default()
 }
 
 /// Read pane IDs manually marked as sleeping from the tmux global option.
@@ -1441,6 +1464,7 @@ pub fn run() -> Result<()> {
                     read_sidebar_layout_mode(&cfg).unwrap_or_default(),
                 )
             };
+            let filter_mode = read_sidebar_filter_mode();
             let sleeping_pane_ids = read_sleeping_panes();
             let git_statuses = git_cache.lock().ok().map(|c| c.clone()).unwrap_or_default();
             let pr_statuses = pr_cache.lock().ok().map(|c| c.clone()).unwrap_or_default();
@@ -1462,6 +1486,7 @@ pub fn run() -> Result<()> {
                     now_ts,
                     position,
                     layout_mode,
+                    filter_mode,
                     git_statuses,
                     pr_statuses,
                     sleeping_pane_ids,
@@ -1634,6 +1659,7 @@ struct TickInput {
     now_ts: u64,
     position: SidebarPosition,
     layout_mode: SidebarLayoutMode,
+    filter_mode: SidebarFilterMode,
     git_statuses: HashMap<PathBuf, GitStatus>,
     pr_statuses: HashMap<PathBuf, PrPathEntry>,
     sleeping_pane_ids: HashSet<String>,
@@ -1677,6 +1703,7 @@ fn compute_tick(
         now_ts,
         position,
         layout_mode,
+        filter_mode,
         git_statuses,
         pr_statuses,
         sleeping_pane_ids,
@@ -1710,6 +1737,7 @@ fn compute_tick(
         tmux_state.window_pane_counts,
         position,
         layout_mode,
+        filter_mode,
         status_icons,
         git_statuses,
         pr_statuses,
@@ -2207,6 +2235,7 @@ mod tests {
                     now_ts,
                     position: SidebarPosition::Left,
                     layout_mode: SidebarLayoutMode::default(),
+                    filter_mode: SidebarFilterMode::default(),
                     git_statuses: HashMap::new(),
                     pr_statuses: HashMap::new(),
                     sleeping_pane_ids: HashSet::new(),

--- a/src/command/sidebar/mod.rs
+++ b/src/command/sidebar/mod.rs
@@ -807,6 +807,27 @@ fn pane_session_ids() -> std::collections::HashMap<String, String> {
         .unwrap_or_default()
 }
 
+fn read_sidebar_filter_mode() -> app::SidebarFilterMode {
+    if let Ok(output) = Cmd::new("tmux")
+        .args(&["show-option", "-gqv", "@workmux_sidebar_filter"])
+        .run_and_capture_stdout()
+    {
+        let trimmed = output.trim();
+        if !trimmed.is_empty() {
+            return app::SidebarFilterMode::from_str(trimmed);
+        }
+    }
+
+    if let Ok(store) = crate::state::StateStore::new()
+        && let Ok(settings) = store.load_settings()
+        && let Some(ref mode) = settings.sidebar_filter
+    {
+        return app::SidebarFilterMode::from_str(mode);
+    }
+
+    app::SidebarFilterMode::default()
+}
+
 fn current_listed_window_pane<'a>(
     panes: &'a [&str],
     current_pane_id: &'a str,
@@ -873,12 +894,8 @@ pub fn navigate(action: NavAction) -> Result<()> {
     let pane_window_ids = pane_window_ids();
     let pane_session_ids = pane_session_ids();
 
-    // Apply session filter if active
-    let filter_mode = Cmd::new("tmux")
-        .args(&["show-option", "-gqv", "@workmux_sidebar_filter"])
-        .run_and_capture_stdout()
-        .unwrap_or_default();
-    if app::SidebarFilterMode::from_str(filter_mode.trim()) == app::SidebarFilterMode::Session {
+    // Apply session filter if active.
+    if read_sidebar_filter_mode() == app::SidebarFilterMode::Session {
         let current_session = Cmd::new("tmux")
             .args(&["display-message", "-p", "#{session_name}"])
             .run_and_capture_stdout()
@@ -928,14 +945,7 @@ pub fn set_filter_mode(mode: Option<&str>) -> Result<()> {
 
     let new_mode = match mode {
         Some(m) => SidebarFilterMode::from_str(m),
-        None => {
-            // Read current mode from tmux and toggle
-            let current = Cmd::new("tmux")
-                .args(&["show-option", "-gqv", "@workmux_sidebar_filter"])
-                .run_and_capture_stdout()
-                .unwrap_or_default();
-            SidebarFilterMode::from_str(current.trim()).toggle()
-        }
+        None => read_sidebar_filter_mode().toggle(),
     };
 
     // Write to tmux global

--- a/src/command/sidebar/mod.rs
+++ b/src/command/sidebar/mod.rs
@@ -31,7 +31,6 @@ mod template;
 mod ui;
 
 use anyhow::{Result, anyhow};
-
 use crate::cmd::Cmd;
 use crate::config::SidebarPosition;
 
@@ -777,22 +776,21 @@ fn compute_nav_target(action: &NavAction, current_idx: Option<usize>, len: usize
 fn current_navigation_project(
     current_pane_id: &str,
     current_window_id: &str,
-    agents: &[crate::state::AgentState],
+    pane_paths: &std::collections::HashMap<String, std::path::PathBuf>,
     pane_window_ids: &std::collections::HashMap<String, String>,
 ) -> Option<String> {
-    agents
-        .iter()
-        .find(|a| a.pane_key.pane_id == current_pane_id)
-        .map(|a| crate::agent_display::extract_project_name(&a.workdir))
+    pane_paths
+        .get(current_pane_id)
+        .map(|p| crate::agent_display::extract_project_name(p))
         .or_else(|| {
-            agents
+            pane_paths
                 .iter()
-                .find(|a| {
+                .find(|(pane_id, _)| {
                     pane_window_ids
-                        .get(&a.pane_key.pane_id)
+                        .get(*pane_id)
                         .is_some_and(|window_id| window_id == current_window_id)
                 })
-                .map(|a| crate::agent_display::extract_project_name(&a.workdir))
+                .map(|(_, path)| crate::agent_display::extract_project_name(path))
         })
         .or_else(|| {
             Cmd::new("tmux")
@@ -829,6 +827,23 @@ fn pane_window_ids() -> std::collections::HashMap<String, String> {
         .unwrap_or_default()
 }
 
+fn pane_paths() -> std::collections::HashMap<String, std::path::PathBuf> {
+    Cmd::new("tmux")
+        .args(&["list-panes", "-a", "-F", "#{pane_id}\t#{pane_current_path}"])
+        .run_and_capture_stdout()
+        .ok()
+        .map(|output| {
+            output
+                .lines()
+                .filter_map(|line| {
+                    let (pane_id, path) = line.split_once('\t')?;
+                    Some((pane_id.to_string(), std::path::PathBuf::from(path)))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn current_listed_window_pane<'a>(
     panes: &'a [&str],
     current_pane_id: &'a str,
@@ -844,6 +859,16 @@ fn current_listed_window_pane<'a>(
             .get(*pane_id)
             .is_some_and(|window_id| window_id == current_window_id)
     })
+}
+
+fn navigation_anchor_pane<'a>(
+    panes: &'a [&str],
+    current_pane_id: &'a str,
+    current_window_id: &str,
+    pane_window_ids: &std::collections::HashMap<String, String>,
+) -> Option<&'a str> {
+    current_listed_window_pane(panes, current_pane_id, current_window_id, pane_window_ids)
+        .or(Some(current_pane_id).filter(|pane_id| panes.contains(pane_id)))
 }
 
 /// Navigate to an agent by reading the daemon's ordered agent list from tmux.
@@ -883,30 +908,25 @@ pub fn navigate(action: NavAction) -> Result<()> {
         .unwrap_or_default();
     let current_window_id = current_window_id.trim();
     let pane_window_ids = pane_window_ids();
+    let pane_paths = pane_paths();
 
     // Apply project filter if active
     let filter_mode = Cmd::new("tmux")
         .args(&["show-option", "-gqv", "@workmux_sidebar_filter"])
         .run_and_capture_stdout()
         .unwrap_or_default();
-    if filter_mode.trim() == "project"
-        && let Ok(store) = crate::state::StateStore::new()
-        && let Ok(agents) = store.list_all_agents()
-    {
+    if filter_mode.trim() == "project" {
         if let Some(project) = current_navigation_project(
             current_pane_id,
             current_window_id,
-            &agents,
+            &pane_paths,
             &pane_window_ids,
         ) {
-            // Build set of pane IDs that belong to this project
-            let project_panes: std::collections::HashSet<&str> = agents
-                .iter()
-                .filter(|a| crate::agent_display::extract_project_name(&a.workdir) == project)
-                .map(|a| a.pane_key.pane_id.as_str())
-                .collect();
-
-            panes.retain(|p| project_panes.contains(p));
+            panes.retain(|pane_id| {
+                pane_paths
+                    .get(*pane_id)
+                    .is_some_and(|path| crate::agent_display::extract_project_name(path) == project)
+            });
         }
     }
 
@@ -914,19 +934,10 @@ pub fn navigate(action: NavAction) -> Result<()> {
         anyhow::bail!("no matching agents found");
     }
 
-    if let Some(current_window_pane) =
-        current_listed_window_pane(&panes, current_pane_id, current_window_id, &pane_window_ids)
-        && current_window_pane != current_pane_id
-        && !matches!(action, NavAction::Jump(_))
-    {
-        Cmd::new("tmux")
-            .args(&["switch-client", "-t", current_window_pane])
-            .run()?;
-        signal_daemon();
-        return Ok(());
-    }
-
-    let current_idx = panes.iter().position(|&pid| pid == current_pane_id);
+    let current_anchor =
+        navigation_anchor_pane(&panes, current_pane_id, current_window_id, &pane_window_ids);
+    let current_idx =
+        current_anchor.and_then(|pane_id| panes.iter().position(|&pid| pid == pane_id));
 
     let len = panes.len();
     let target_idx = match &action {
@@ -937,8 +948,13 @@ pub fn navigate(action: NavAction) -> Result<()> {
     };
 
     let target_pane = panes[target_idx];
+    if let Some(target_window_id) = pane_window_ids.get(target_pane) {
+        Cmd::new("tmux")
+            .args(&["select-window", "-t", target_window_id])
+            .run()?;
+    }
     Cmd::new("tmux")
-        .args(&["switch-client", "-t", target_pane])
+        .args(&["select-pane", "-t", target_pane])
         .run()?;
 
     signal_daemon();
@@ -986,28 +1002,7 @@ pub fn set_filter_mode(mode: Option<&str>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{AgentState, PaneKey};
     use std::path::PathBuf;
-
-    fn test_agent_state(pane_id: &str, workdir: &str) -> AgentState {
-        AgentState {
-            pane_key: PaneKey {
-                backend: "tmux".to_string(),
-                instance: "default".to_string(),
-                pane_id: pane_id.to_string(),
-            },
-            workdir: PathBuf::from(workdir),
-            status: None,
-            status_ts: None,
-            pane_title: None,
-            pane_pid: 1,
-            command: "zsh".to_string(),
-            updated_ts: 0,
-            window_name: None,
-            session_name: None,
-            boot_id: None,
-        }
-    }
 
     #[test]
     fn parses_session_id_set() {
@@ -1170,12 +1165,13 @@ mod tests {
         let worktree = repo.join(".worktrees").join("feature");
         std::fs::create_dir_all(&worktree).unwrap();
 
-        let agents = vec![test_agent_state("%1", worktree.to_str().unwrap())];
+        let pane_paths =
+            std::collections::HashMap::from([("%1".to_string(), worktree.to_path_buf())]);
         assert_eq!(
             current_navigation_project(
                 "%1",
                 "@10",
-                &agents,
+                &pane_paths,
                 &std::collections::HashMap::from([("%1".to_string(), "@10".to_string())]),
             )
             .as_deref(),
@@ -1212,6 +1208,72 @@ mod tests {
     }
 
     #[test]
+    fn navigation_anchor_uses_agent_in_current_window() {
+        let panes = vec!["%1", "%2"];
+        let pane_window_ids = std::collections::HashMap::from([
+            ("%sidebar".to_string(), "@10".to_string()),
+            ("%1".to_string(), "@10".to_string()),
+            ("%2".to_string(), "@20".to_string()),
+        ]);
+
+        assert_eq!(
+            navigation_anchor_pane(&panes, "%sidebar", "@10", &pane_window_ids),
+            Some("%1")
+        );
+    }
+
+    #[test]
+    fn navigation_anchor_prefers_current_agent_pane() {
+        let panes = vec!["%1", "%2"];
+        let pane_window_ids = std::collections::HashMap::from([
+            ("%1".to_string(), "@10".to_string()),
+            ("%2".to_string(), "@10".to_string()),
+        ]);
+
+        assert_eq!(
+            navigation_anchor_pane(&panes, "%2", "@10", &pane_window_ids),
+            Some("%2")
+        );
+    }
+
+    #[test]
+    fn next_from_sidebar_in_filtered_two_window_project_advances_to_other_window() {
+        let panes = vec!["%0", "%317"];
+        let pane_window_ids = std::collections::HashMap::from([
+            ("%sidebar".to_string(), "@0".to_string()),
+            ("%0".to_string(), "@0".to_string()),
+            ("%317".to_string(), "@33".to_string()),
+        ]);
+
+        let current_idx = navigation_anchor_pane(&panes, "%sidebar", "@0", &pane_window_ids)
+            .and_then(|pane_id| panes.iter().position(|&pid| pid == pane_id));
+
+        assert_eq!(current_idx, Some(0));
+        assert_eq!(
+            compute_nav_target(&NavAction::Next, current_idx, panes.len()),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn next_from_agent_in_filtered_two_window_project_advances_to_other_window() {
+        let panes = vec!["%0", "%317"];
+        let pane_window_ids = std::collections::HashMap::from([
+            ("%0".to_string(), "@0".to_string()),
+            ("%317".to_string(), "@33".to_string()),
+        ]);
+
+        let current_idx = navigation_anchor_pane(&panes, "%0", "@0", &pane_window_ids)
+            .and_then(|pane_id| panes.iter().position(|&pid| pid == pane_id));
+
+        assert_eq!(current_idx, Some(0));
+        assert_eq!(
+            compute_nav_target(&NavAction::Next, current_idx, panes.len()),
+            Some(1)
+        );
+    }
+
+    #[test]
     fn navigation_project_falls_back_to_agent_in_current_window() {
         let temp = tempfile::TempDir::new().unwrap();
         let repo = temp.path().join("alpha");
@@ -1219,14 +1281,15 @@ mod tests {
         let worktree = repo.join(".worktrees").join("feature");
         std::fs::create_dir_all(&worktree).unwrap();
 
-        let agents = vec![test_agent_state("%1", worktree.to_str().unwrap())];
+        let pane_paths =
+            std::collections::HashMap::from([("%1".to_string(), worktree.to_path_buf())]);
         let pane_window_ids = std::collections::HashMap::from([
             ("%sidebar".to_string(), "@10".to_string()),
             ("%1".to_string(), "@10".to_string()),
         ]);
 
         assert_eq!(
-            current_navigation_project("%sidebar", "@10", &agents, &pane_window_ids).as_deref(),
+            current_navigation_project("%sidebar", "@10", &pane_paths, &pane_window_ids).as_deref(),
             Some("alpha")
         );
     }

--- a/src/command/sidebar/mod.rs
+++ b/src/command/sidebar/mod.rs
@@ -774,6 +774,32 @@ fn compute_nav_target(action: &NavAction, current_idx: Option<usize>, len: usize
     })
 }
 
+fn current_navigation_project(
+    current_pane_id: &str,
+    agents: &[crate::state::AgentState],
+) -> Option<String> {
+    agents
+        .iter()
+        .find(|a| a.pane_key.pane_id == current_pane_id)
+        .map(|a| crate::agent_display::extract_project_name(&a.workdir))
+        .or_else(|| {
+            Cmd::new("tmux")
+                .args(&[
+                    "display-message",
+                    "-p",
+                    "-t",
+                    current_pane_id,
+                    "#{pane_current_path}",
+                ])
+                .run_and_capture_stdout()
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .map(std::path::PathBuf::from)
+                .map(|p| crate::agent_display::extract_project_name(&p))
+        })
+}
+
 /// Navigate to an agent by reading the daemon's ordered agent list from tmux.
 /// Respects the sidebar filter mode: when set to "project", only navigates
 /// among agents belonging to the same project as the current pane.
@@ -815,13 +841,7 @@ pub fn navigate(action: NavAction) -> Result<()> {
         && let Ok(store) = crate::state::StateStore::new()
         && let Ok(agents) = store.list_all_agents()
     {
-        // Get the current pane's project name
-        let current_project = agents.iter().find_map(|a| {
-            (a.pane_key.pane_id == current_pane_id)
-                .then(|| crate::agent_display::extract_project_name(&a.workdir))
-        });
-
-        if let Some(project) = current_project {
+        if let Some(project) = current_navigation_project(current_pane_id, &agents) {
             // Build set of pane IDs that belong to this project
             let project_panes: std::collections::HashSet<&str> = agents
                 .iter()
@@ -897,6 +917,28 @@ pub fn set_filter_mode(mode: Option<&str>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::{AgentState, PaneKey};
+    use std::path::PathBuf;
+
+    fn test_agent_state(pane_id: &str, workdir: &str) -> AgentState {
+        AgentState {
+            pane_key: PaneKey {
+                backend: "tmux".to_string(),
+                instance: "default".to_string(),
+                pane_id: pane_id.to_string(),
+            },
+            workdir: PathBuf::from(workdir),
+            status: None,
+            status_ts: None,
+            pane_title: None,
+            pane_pid: 1,
+            command: "zsh".to_string(),
+            updated_ts: 0,
+            window_name: None,
+            session_name: None,
+            boot_id: None,
+        }
+    }
 
     #[test]
     fn parses_session_id_set() {
@@ -986,33 +1028,28 @@ mod tests {
     #[test]
     fn resolve_width_uses_synced_width() {
         let config = crate::config::Config::default();
-        // Synced width of 40 in a 200-col window should return 40
         assert_eq!(resolve_width_for(&config, 200, Some(40)), 40);
     }
 
     #[test]
     fn resolve_width_clamps_synced_to_window() {
         let config = crate::config::Config::default();
-        // Synced width of 80 in a 60-col window should clamp to 50 (60 - 10)
         assert_eq!(resolve_width_for(&config, 60, Some(80)), 50);
-        // Synced width of 5 should clamp to minimum 10
         assert_eq!(resolve_width_for(&config, 200, Some(5)), 10);
     }
 
     #[test]
     fn resolve_width_clamps_narrow_window() {
         let config = crate::config::Config::default();
-        // In a 25-col window, max is 15 (25 - 10), clamp 50 to [10, 15] = 15
         assert_eq!(resolve_width_for(&config, 25, Some(50)), 15);
     }
 
     #[test]
     fn resolve_width_falls_back_to_default_without_sync() {
         let config = crate::config::Config::default();
-        // Default is 10% of window width, clamped to [25, 50]
-        assert_eq!(resolve_width_for(&config, 200, None), 25); // 10% = 20, clamped to 25
-        assert_eq!(resolve_width_for(&config, 500, None), 50); // 10% = 50, at max
-        assert_eq!(resolve_width_for(&config, 400, None), 40); // 10% = 40
+        assert_eq!(resolve_width_for(&config, 200, None), 25);
+        assert_eq!(resolve_width_for(&config, 500, None), 50);
+        assert_eq!(resolve_width_for(&config, 400, None), 40);
     }
 
     #[test]
@@ -1046,7 +1083,6 @@ mod tests {
     fn resolve_width_uses_explicit_config_before_synced_width() {
         let mut config = crate::config::Config::default();
         config.sidebar.width = Some(crate::config::SidebarWidth::Percent(10));
-        // Synced width of 150 should be ignored; 10% of 200 = 20
         assert_eq!(resolve_width_for(&config, 200, Some(150)), 20);
     }
 
@@ -1055,5 +1091,20 @@ mod tests {
         let mut config = crate::config::Config::default();
         config.sidebar.width = Some(crate::config::SidebarWidth::Absolute(80));
         assert_eq!(resolve_width_for(&config, 100, None), 80);
+    }
+
+    #[test]
+    fn navigation_project_prefers_agent_workdir() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let repo = temp.path().join("alpha");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        let worktree = repo.join(".worktrees").join("feature");
+        std::fs::create_dir_all(&worktree).unwrap();
+
+        let agents = vec![test_agent_state("%1", worktree.to_str().unwrap())];
+        assert_eq!(
+            current_navigation_project("%1", &agents).as_deref(),
+            Some("alpha")
+        );
     }
 }

--- a/src/command/sidebar/mod.rs
+++ b/src/command/sidebar/mod.rs
@@ -30,9 +30,9 @@ mod snapshot;
 mod template;
 mod ui;
 
-use anyhow::{Result, anyhow};
 use crate::cmd::Cmd;
 use crate::config::SidebarPosition;
+use anyhow::{Result, anyhow};
 
 use self::daemon_ctrl::{ensure_daemon_running, kill_daemon, signal_daemon};
 use self::hooks::{install_hooks, remove_hooks};
@@ -773,43 +773,6 @@ fn compute_nav_target(action: &NavAction, current_idx: Option<usize>, len: usize
     })
 }
 
-fn current_navigation_project(
-    current_pane_id: &str,
-    current_window_id: &str,
-    pane_paths: &std::collections::HashMap<String, std::path::PathBuf>,
-    pane_window_ids: &std::collections::HashMap<String, String>,
-) -> Option<String> {
-    pane_paths
-        .get(current_pane_id)
-        .map(|p| crate::agent_display::extract_project_name(p))
-        .or_else(|| {
-            pane_paths
-                .iter()
-                .find(|(pane_id, _)| {
-                    pane_window_ids
-                        .get(*pane_id)
-                        .is_some_and(|window_id| window_id == current_window_id)
-                })
-                .map(|(_, path)| crate::agent_display::extract_project_name(path))
-        })
-        .or_else(|| {
-            Cmd::new("tmux")
-                .args(&[
-                    "display-message",
-                    "-p",
-                    "-t",
-                    current_pane_id,
-                    "#{pane_current_path}",
-                ])
-                .run_and_capture_stdout()
-                .ok()
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .map(std::path::PathBuf::from)
-                .map(|p| crate::agent_display::extract_project_name(&p))
-        })
-}
-
 fn pane_window_ids() -> std::collections::HashMap<String, String> {
     Cmd::new("tmux")
         .args(&["list-panes", "-a", "-F", "#{pane_id}\t#{window_id}"])
@@ -827,17 +790,17 @@ fn pane_window_ids() -> std::collections::HashMap<String, String> {
         .unwrap_or_default()
 }
 
-fn pane_paths() -> std::collections::HashMap<String, std::path::PathBuf> {
+fn pane_session_ids() -> std::collections::HashMap<String, String> {
     Cmd::new("tmux")
-        .args(&["list-panes", "-a", "-F", "#{pane_id}\t#{pane_current_path}"])
+        .args(&["list-panes", "-a", "-F", "#{pane_id}\t#{session_name}"])
         .run_and_capture_stdout()
         .ok()
         .map(|output| {
             output
                 .lines()
                 .filter_map(|line| {
-                    let (pane_id, path) = line.split_once('\t')?;
-                    Some((pane_id.to_string(), std::path::PathBuf::from(path)))
+                    let (pane_id, session_name) = line.split_once('\t')?;
+                    Some((pane_id.to_string(), session_name.to_string()))
                 })
                 .collect()
         })
@@ -872,8 +835,8 @@ fn navigation_anchor_pane<'a>(
 }
 
 /// Navigate to an agent by reading the daemon's ordered agent list from tmux.
-/// Respects the sidebar filter mode: when set to "project", only navigates
-/// among agents belonging to the same project as the current pane.
+/// Respects the sidebar filter mode: when set to "session", only navigates
+/// among agents in the current tmux session.
 pub fn navigate(action: NavAction) -> Result<()> {
     if std::env::var("TMUX").is_err() {
         return Err(anyhow!("Sidebar requires tmux"));
@@ -908,26 +871,24 @@ pub fn navigate(action: NavAction) -> Result<()> {
         .unwrap_or_default();
     let current_window_id = current_window_id.trim();
     let pane_window_ids = pane_window_ids();
-    let pane_paths = pane_paths();
+    let pane_session_ids = pane_session_ids();
 
-    // Apply project filter if active
+    // Apply session filter if active
     let filter_mode = Cmd::new("tmux")
         .args(&["show-option", "-gqv", "@workmux_sidebar_filter"])
         .run_and_capture_stdout()
         .unwrap_or_default();
-    if filter_mode.trim() == "project" {
-        if let Some(project) = current_navigation_project(
-            current_pane_id,
-            current_window_id,
-            &pane_paths,
-            &pane_window_ids,
-        ) {
-            panes.retain(|pane_id| {
-                pane_paths
-                    .get(*pane_id)
-                    .is_some_and(|path| crate::agent_display::extract_project_name(path) == project)
-            });
-        }
+    if app::SidebarFilterMode::from_str(filter_mode.trim()) == app::SidebarFilterMode::Session {
+        let current_session = Cmd::new("tmux")
+            .args(&["display-message", "-p", "#{session_name}"])
+            .run_and_capture_stdout()
+            .unwrap_or_default();
+        let current_session = current_session.trim();
+        panes.retain(|pane_id| {
+            pane_session_ids
+                .get(*pane_id)
+                .is_some_and(|session| session == current_session)
+        });
     }
 
     if panes.is_empty() {
@@ -1002,7 +963,6 @@ pub fn set_filter_mode(mode: Option<&str>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     #[test]
     fn parses_session_id_set() {
@@ -1158,28 +1118,6 @@ mod tests {
     }
 
     #[test]
-    fn navigation_project_prefers_agent_workdir() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let repo = temp.path().join("alpha");
-        std::fs::create_dir_all(repo.join(".git")).unwrap();
-        let worktree = repo.join(".worktrees").join("feature");
-        std::fs::create_dir_all(&worktree).unwrap();
-
-        let pane_paths =
-            std::collections::HashMap::from([("%1".to_string(), worktree.to_path_buf())]);
-        assert_eq!(
-            current_navigation_project(
-                "%1",
-                "@10",
-                &pane_paths,
-                &std::collections::HashMap::from([("%1".to_string(), "@10".to_string())]),
-            )
-            .as_deref(),
-            Some("alpha")
-        );
-    }
-
-    #[test]
     fn current_window_falls_back_to_listed_agent_pane() {
         let panes = vec!["%1", "%2"];
         let pane_window_ids = std::collections::HashMap::from([
@@ -1237,7 +1175,7 @@ mod tests {
     }
 
     #[test]
-    fn next_from_sidebar_in_filtered_two_window_project_advances_to_other_window() {
+    fn next_from_sidebar_in_filtered_two_window_session_advances_to_other_window() {
         let panes = vec!["%0", "%317"];
         let pane_window_ids = std::collections::HashMap::from([
             ("%sidebar".to_string(), "@0".to_string()),
@@ -1256,7 +1194,7 @@ mod tests {
     }
 
     #[test]
-    fn next_from_agent_in_filtered_two_window_project_advances_to_other_window() {
+    fn next_from_agent_in_filtered_two_window_session_advances_to_other_window() {
         let panes = vec!["%0", "%317"];
         let pane_window_ids = std::collections::HashMap::from([
             ("%0".to_string(), "@0".to_string()),
@@ -1270,27 +1208,6 @@ mod tests {
         assert_eq!(
             compute_nav_target(&NavAction::Next, current_idx, panes.len()),
             Some(1)
-        );
-    }
-
-    #[test]
-    fn navigation_project_falls_back_to_agent_in_current_window() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let repo = temp.path().join("alpha");
-        std::fs::create_dir_all(repo.join(".git")).unwrap();
-        let worktree = repo.join(".worktrees").join("feature");
-        std::fs::create_dir_all(&worktree).unwrap();
-
-        let pane_paths =
-            std::collections::HashMap::from([("%1".to_string(), worktree.to_path_buf())]);
-        let pane_window_ids = std::collections::HashMap::from([
-            ("%sidebar".to_string(), "@10".to_string()),
-            ("%1".to_string(), "@10".to_string()),
-        ]);
-
-        assert_eq!(
-            current_navigation_project("%sidebar", "@10", &pane_paths, &pane_window_ids).as_deref(),
-            Some("alpha")
         );
     }
 }

--- a/src/command/sidebar/mod.rs
+++ b/src/command/sidebar/mod.rs
@@ -776,12 +776,24 @@ fn compute_nav_target(action: &NavAction, current_idx: Option<usize>, len: usize
 
 fn current_navigation_project(
     current_pane_id: &str,
+    current_window_id: &str,
     agents: &[crate::state::AgentState],
+    pane_window_ids: &std::collections::HashMap<String, String>,
 ) -> Option<String> {
     agents
         .iter()
         .find(|a| a.pane_key.pane_id == current_pane_id)
         .map(|a| crate::agent_display::extract_project_name(&a.workdir))
+        .or_else(|| {
+            agents
+                .iter()
+                .find(|a| {
+                    pane_window_ids
+                        .get(&a.pane_key.pane_id)
+                        .is_some_and(|window_id| window_id == current_window_id)
+                })
+                .map(|a| crate::agent_display::extract_project_name(&a.workdir))
+        })
         .or_else(|| {
             Cmd::new("tmux")
                 .args(&[
@@ -798,6 +810,40 @@ fn current_navigation_project(
                 .map(std::path::PathBuf::from)
                 .map(|p| crate::agent_display::extract_project_name(&p))
         })
+}
+
+fn pane_window_ids() -> std::collections::HashMap<String, String> {
+    Cmd::new("tmux")
+        .args(&["list-panes", "-a", "-F", "#{pane_id}\t#{window_id}"])
+        .run_and_capture_stdout()
+        .ok()
+        .map(|output| {
+            output
+                .lines()
+                .filter_map(|line| {
+                    let (pane_id, window_id) = line.split_once('\t')?;
+                    Some((pane_id.to_string(), window_id.to_string()))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn current_listed_window_pane<'a>(
+    panes: &'a [&str],
+    current_pane_id: &'a str,
+    current_window_id: &str,
+    pane_window_ids: &std::collections::HashMap<String, String>,
+) -> Option<&'a str> {
+    if panes.contains(&current_pane_id) {
+        return Some(current_pane_id);
+    }
+
+    panes.iter().copied().find(|pane_id| {
+        pane_window_ids
+            .get(*pane_id)
+            .is_some_and(|window_id| window_id == current_window_id)
+    })
 }
 
 /// Navigate to an agent by reading the daemon's ordered agent list from tmux.
@@ -825,12 +871,18 @@ pub fn navigate(action: NavAction) -> Result<()> {
         anyhow::bail!("no sidebar agents found");
     }
 
-    // Find current agent by active pane ID
+    // Find current pane/window context
     let current_pane_id = Cmd::new("tmux")
         .args(&["display-message", "-p", "#{pane_id}"])
         .run_and_capture_stdout()
         .unwrap_or_default();
     let current_pane_id = current_pane_id.trim();
+    let current_window_id = Cmd::new("tmux")
+        .args(&["display-message", "-p", "#{window_id}"])
+        .run_and_capture_stdout()
+        .unwrap_or_default();
+    let current_window_id = current_window_id.trim();
+    let pane_window_ids = pane_window_ids();
 
     // Apply project filter if active
     let filter_mode = Cmd::new("tmux")
@@ -841,7 +893,12 @@ pub fn navigate(action: NavAction) -> Result<()> {
         && let Ok(store) = crate::state::StateStore::new()
         && let Ok(agents) = store.list_all_agents()
     {
-        if let Some(project) = current_navigation_project(current_pane_id, &agents) {
+        if let Some(project) = current_navigation_project(
+            current_pane_id,
+            current_window_id,
+            &agents,
+            &pane_window_ids,
+        ) {
             // Build set of pane IDs that belong to this project
             let project_panes: std::collections::HashSet<&str> = agents
                 .iter()
@@ -855,6 +912,18 @@ pub fn navigate(action: NavAction) -> Result<()> {
 
     if panes.is_empty() {
         anyhow::bail!("no matching agents found");
+    }
+
+    if let Some(current_window_pane) =
+        current_listed_window_pane(&panes, current_pane_id, current_window_id, &pane_window_ids)
+        && current_window_pane != current_pane_id
+        && !matches!(action, NavAction::Jump(_))
+    {
+        Cmd::new("tmux")
+            .args(&["switch-client", "-t", current_window_pane])
+            .run()?;
+        signal_daemon();
+        return Ok(());
     }
 
     let current_idx = panes.iter().position(|&pid| pid == current_pane_id);
@@ -1103,7 +1172,61 @@ mod tests {
 
         let agents = vec![test_agent_state("%1", worktree.to_str().unwrap())];
         assert_eq!(
-            current_navigation_project("%1", &agents).as_deref(),
+            current_navigation_project(
+                "%1",
+                "@10",
+                &agents,
+                &std::collections::HashMap::from([("%1".to_string(), "@10".to_string())]),
+            )
+            .as_deref(),
+            Some("alpha")
+        );
+    }
+
+    #[test]
+    fn current_window_falls_back_to_listed_agent_pane() {
+        let panes = vec!["%1", "%2"];
+        let pane_window_ids = std::collections::HashMap::from([
+            ("%1".to_string(), "@10".to_string()),
+            ("%2".to_string(), "@20".to_string()),
+        ]);
+
+        assert_eq!(
+            current_listed_window_pane(&panes, "%99", "@20", &pane_window_ids),
+            Some("%2")
+        );
+    }
+
+    #[test]
+    fn current_listed_pane_wins_over_window_fallback() {
+        let panes = vec!["%1", "%2"];
+        let pane_window_ids = std::collections::HashMap::from([
+            ("%1".to_string(), "@10".to_string()),
+            ("%2".to_string(), "@10".to_string()),
+        ]);
+
+        assert_eq!(
+            current_listed_window_pane(&panes, "%2", "@10", &pane_window_ids),
+            Some("%2")
+        );
+    }
+
+    #[test]
+    fn navigation_project_falls_back_to_agent_in_current_window() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let repo = temp.path().join("alpha");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        let worktree = repo.join(".worktrees").join("feature");
+        std::fs::create_dir_all(&worktree).unwrap();
+
+        let agents = vec![test_agent_state("%1", worktree.to_str().unwrap())];
+        let pane_window_ids = std::collections::HashMap::from([
+            ("%sidebar".to_string(), "@10".to_string()),
+            ("%1".to_string(), "@10".to_string()),
+        ]);
+
+        assert_eq!(
+            current_navigation_project("%sidebar", "@10", &agents, &pane_window_ids).as_deref(),
             Some("alpha")
         );
     }

--- a/src/command/sidebar/mod.rs
+++ b/src/command/sidebar/mod.rs
@@ -855,6 +855,25 @@ fn navigation_anchor_pane<'a>(
         .or(Some(current_pane_id).filter(|pane_id| panes.contains(pane_id)))
 }
 
+fn target_switch_command(
+    target_pane: &str,
+    current_session: &str,
+    pane_session_ids: &std::collections::HashMap<String, String>,
+    pane_window_ids: &std::collections::HashMap<String, String>,
+) -> (&'static str, Vec<String>) {
+    let target_session = pane_session_ids.get(target_pane).map(String::as_str);
+    if target_session.is_some_and(|session| session == current_session)
+        && let Some(target_window_id) = pane_window_ids.get(target_pane)
+    {
+        return (
+            "select-window-select-pane",
+            vec![target_window_id.clone(), target_pane.to_string()],
+        );
+    }
+
+    ("switch-client", vec![target_pane.to_string()])
+}
+
 /// Navigate to an agent by reading the daemon's ordered agent list from tmux.
 /// Respects the sidebar filter mode: when set to "session", only navigates
 /// among agents in the current tmux session.
@@ -893,14 +912,14 @@ pub fn navigate(action: NavAction) -> Result<()> {
     let current_window_id = current_window_id.trim();
     let pane_window_ids = pane_window_ids();
     let pane_session_ids = pane_session_ids();
+    let current_session = Cmd::new("tmux")
+        .args(&["display-message", "-p", "#{session_name}"])
+        .run_and_capture_stdout()
+        .unwrap_or_default();
+    let current_session = current_session.trim();
 
     // Apply session filter if active.
     if read_sidebar_filter_mode() == app::SidebarFilterMode::Session {
-        let current_session = Cmd::new("tmux")
-            .args(&["display-message", "-p", "#{session_name}"])
-            .run_and_capture_stdout()
-            .unwrap_or_default();
-        let current_session = current_session.trim();
         panes.retain(|pane_id| {
             pane_session_ids
                 .get(*pane_id)
@@ -926,14 +945,24 @@ pub fn navigate(action: NavAction) -> Result<()> {
     };
 
     let target_pane = panes[target_idx];
-    if let Some(target_window_id) = pane_window_ids.get(target_pane) {
+    let (command, args) = target_switch_command(
+        target_pane,
+        current_session,
+        &pane_session_ids,
+        &pane_window_ids,
+    );
+    if command == "select-window-select-pane" {
         Cmd::new("tmux")
-            .args(&["select-window", "-t", target_window_id])
+            .args(&["select-window", "-t", &args[0]])
+            .run()?;
+        Cmd::new("tmux")
+            .args(&["select-pane", "-t", &args[1]])
+            .run()?;
+    } else {
+        Cmd::new("tmux")
+            .args(&["switch-client", "-t", &args[0]])
             .run()?;
     }
-    Cmd::new("tmux")
-        .args(&["select-pane", "-t", target_pane])
-        .run()?;
 
     signal_daemon();
     Ok(())
@@ -1125,6 +1154,55 @@ mod tests {
         let mut config = crate::config::Config::default();
         config.sidebar.width = Some(crate::config::SidebarWidth::Absolute(80));
         assert_eq!(resolve_width_for(&config, 100, None), 80);
+    }
+
+    #[test]
+    fn target_switch_uses_select_window_inside_current_session() {
+        let pane_session_ids = std::collections::HashMap::from([
+            ("%1".to_string(), "work".to_string()),
+            ("%2".to_string(), "other".to_string()),
+        ]);
+        let pane_window_ids = std::collections::HashMap::from([
+            ("%1".to_string(), "@10".to_string()),
+            ("%2".to_string(), "@20".to_string()),
+        ]);
+
+        assert_eq!(
+            target_switch_command("%1", "work", &pane_session_ids, &pane_window_ids),
+            (
+                "select-window-select-pane",
+                vec!["@10".to_string(), "%1".to_string()]
+            )
+        );
+    }
+
+    #[test]
+    fn target_switch_uses_switch_client_across_sessions() {
+        let pane_session_ids = std::collections::HashMap::from([
+            ("%1".to_string(), "work".to_string()),
+            ("%2".to_string(), "other".to_string()),
+        ]);
+        let pane_window_ids = std::collections::HashMap::from([
+            ("%1".to_string(), "@10".to_string()),
+            ("%2".to_string(), "@20".to_string()),
+        ]);
+
+        assert_eq!(
+            target_switch_command("%2", "work", &pane_session_ids, &pane_window_ids),
+            ("switch-client", vec!["%2".to_string()])
+        );
+    }
+
+    #[test]
+    fn target_switch_uses_switch_client_when_session_lookup_is_missing() {
+        let pane_session_ids = std::collections::HashMap::new();
+        let pane_window_ids =
+            std::collections::HashMap::from([("%1".to_string(), "@10".to_string())]);
+
+        assert_eq!(
+            target_switch_command("%1", "work", &pane_session_ids, &pane_window_ids),
+            ("switch-client", vec!["%1".to_string()])
+        );
     }
 
     #[test]

--- a/src/command/sidebar/mod.rs
+++ b/src/command/sidebar/mod.rs
@@ -32,7 +32,7 @@ mod ui;
 
 use crate::cmd::Cmd;
 use crate::config::SidebarPosition;
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, bail};
 
 use self::daemon_ctrl::{ensure_daemon_running, kill_daemon, signal_daemon};
 use self::hooks::{install_hooks, remove_hooks};
@@ -807,6 +807,14 @@ fn pane_session_ids() -> std::collections::HashMap<String, String> {
         .unwrap_or_default()
 }
 
+fn parse_sidebar_filter_mode(raw: &str) -> Result<app::SidebarFilterMode> {
+    match raw.trim().to_lowercase().as_str() {
+        "none" | "all" => Ok(app::SidebarFilterMode::None),
+        "session" | "project" => Ok(app::SidebarFilterMode::Session),
+        other => bail!("invalid sidebar filter mode {other:?}; expected none or session"),
+    }
+}
+
 fn read_sidebar_filter_mode() -> app::SidebarFilterMode {
     if let Ok(output) = Cmd::new("tmux")
         .args(&["show-option", "-gqv", "@workmux_sidebar_filter"])
@@ -814,7 +822,7 @@ fn read_sidebar_filter_mode() -> app::SidebarFilterMode {
     {
         let trimmed = output.trim();
         if !trimmed.is_empty() {
-            return app::SidebarFilterMode::from_str(trimmed);
+            return parse_sidebar_filter_mode(trimmed).unwrap_or_default();
         }
     }
 
@@ -822,7 +830,7 @@ fn read_sidebar_filter_mode() -> app::SidebarFilterMode {
         && let Ok(settings) = store.load_settings()
         && let Some(ref mode) = settings.sidebar_filter
     {
-        return app::SidebarFilterMode::from_str(mode);
+        return parse_sidebar_filter_mode(mode).unwrap_or_default();
     }
 
     app::SidebarFilterMode::default()
@@ -853,25 +861,6 @@ fn navigation_anchor_pane<'a>(
 ) -> Option<&'a str> {
     current_listed_window_pane(panes, current_pane_id, current_window_id, pane_window_ids)
         .or(Some(current_pane_id).filter(|pane_id| panes.contains(pane_id)))
-}
-
-fn target_switch_command(
-    target_pane: &str,
-    current_session: &str,
-    pane_session_ids: &std::collections::HashMap<String, String>,
-    pane_window_ids: &std::collections::HashMap<String, String>,
-) -> (&'static str, Vec<String>) {
-    let target_session = pane_session_ids.get(target_pane).map(String::as_str);
-    if target_session.is_some_and(|session| session == current_session)
-        && let Some(target_window_id) = pane_window_ids.get(target_pane)
-    {
-        return (
-            "select-window-select-pane",
-            vec![target_window_id.clone(), target_pane.to_string()],
-        );
-    }
-
-    ("switch-client", vec![target_pane.to_string()])
 }
 
 /// Navigate to an agent by reading the daemon's ordered agent list from tmux.
@@ -945,24 +934,9 @@ pub fn navigate(action: NavAction) -> Result<()> {
     };
 
     let target_pane = panes[target_idx];
-    let (command, args) = target_switch_command(
-        target_pane,
-        current_session,
-        &pane_session_ids,
-        &pane_window_ids,
-    );
-    if command == "select-window-select-pane" {
-        Cmd::new("tmux")
-            .args(&["select-window", "-t", &args[0]])
-            .run()?;
-        Cmd::new("tmux")
-            .args(&["select-pane", "-t", &args[1]])
-            .run()?;
-    } else {
-        Cmd::new("tmux")
-            .args(&["switch-client", "-t", &args[0]])
-            .run()?;
-    }
+    Cmd::new("tmux")
+        .args(&["switch-client", "-t", target_pane])
+        .run()?;
 
     signal_daemon();
     Ok(())
@@ -970,30 +944,26 @@ pub fn navigate(action: NavAction) -> Result<()> {
 
 /// Set sidebar filter mode from CLI. Toggles if no mode is given.
 pub fn set_filter_mode(mode: Option<&str>) -> Result<()> {
-    use app::SidebarFilterMode;
-
     let new_mode = match mode {
-        Some(m) => SidebarFilterMode::from_str(m),
+        Some(m) => parse_sidebar_filter_mode(m)?,
         None => read_sidebar_filter_mode().toggle(),
     };
 
     // Write to tmux global
-    let _ = Cmd::new("tmux")
+    Cmd::new("tmux")
         .args(&[
             "set-option",
             "-g",
             "@workmux_sidebar_filter",
             new_mode.as_str(),
         ])
-        .run();
+        .run()?;
 
     // Persist to settings.json
-    if let Ok(store) = crate::state::StateStore::new()
-        && let Ok(mut settings) = store.load_settings()
-    {
-        settings.sidebar_filter = Some(new_mode.as_str().to_string());
-        let _ = store.save_settings(&settings);
-    }
+    let store = crate::state::StateStore::new()?;
+    let mut settings = store.load_settings()?;
+    settings.sidebar_filter = Some(new_mode.as_str().to_string());
+    store.save_settings(&settings)?;
 
     signal_daemon();
     Ok(())
@@ -1022,6 +992,11 @@ mod tests {
     fn serializes_session_id_set_deterministically() {
         let ids = parse_session_id_set("$2 $0 $1");
         assert_eq!(serialize_session_id_set(&ids), "$0 $1 $2");
+    }
+
+    #[test]
+    fn parse_sidebar_filter_mode_rejects_invalid_values() {
+        assert!(parse_sidebar_filter_mode("sessoin").is_err());
     }
 
     #[test]
@@ -1154,55 +1129,6 @@ mod tests {
         let mut config = crate::config::Config::default();
         config.sidebar.width = Some(crate::config::SidebarWidth::Absolute(80));
         assert_eq!(resolve_width_for(&config, 100, None), 80);
-    }
-
-    #[test]
-    fn target_switch_uses_select_window_inside_current_session() {
-        let pane_session_ids = std::collections::HashMap::from([
-            ("%1".to_string(), "work".to_string()),
-            ("%2".to_string(), "other".to_string()),
-        ]);
-        let pane_window_ids = std::collections::HashMap::from([
-            ("%1".to_string(), "@10".to_string()),
-            ("%2".to_string(), "@20".to_string()),
-        ]);
-
-        assert_eq!(
-            target_switch_command("%1", "work", &pane_session_ids, &pane_window_ids),
-            (
-                "select-window-select-pane",
-                vec!["@10".to_string(), "%1".to_string()]
-            )
-        );
-    }
-
-    #[test]
-    fn target_switch_uses_switch_client_across_sessions() {
-        let pane_session_ids = std::collections::HashMap::from([
-            ("%1".to_string(), "work".to_string()),
-            ("%2".to_string(), "other".to_string()),
-        ]);
-        let pane_window_ids = std::collections::HashMap::from([
-            ("%1".to_string(), "@10".to_string()),
-            ("%2".to_string(), "@20".to_string()),
-        ]);
-
-        assert_eq!(
-            target_switch_command("%2", "work", &pane_session_ids, &pane_window_ids),
-            ("switch-client", vec!["%2".to_string()])
-        );
-    }
-
-    #[test]
-    fn target_switch_uses_switch_client_when_session_lookup_is_missing() {
-        let pane_session_ids = std::collections::HashMap::new();
-        let pane_window_ids =
-            std::collections::HashMap::from([("%1".to_string(), "@10".to_string())]);
-
-        assert_eq!(
-            target_switch_command("%1", "work", &pane_session_ids, &pane_window_ids),
-            ("switch-client", vec!["%1".to_string()])
-        );
     }
 
     #[test]

--- a/src/command/sidebar/mod.rs
+++ b/src/command/sidebar/mod.rs
@@ -775,6 +775,8 @@ fn compute_nav_target(action: &NavAction, current_idx: Option<usize>, len: usize
 }
 
 /// Navigate to an agent by reading the daemon's ordered agent list from tmux.
+/// Respects the sidebar filter mode: when set to "project", only navigates
+/// among agents belonging to the same project as the current pane.
 pub fn navigate(action: NavAction) -> Result<()> {
     if std::env::var("TMUX").is_err() {
         return Err(anyhow!("Sidebar requires tmux"));
@@ -791,7 +793,7 @@ pub fn navigate(action: NavAction) -> Result<()> {
     }
 
     // Parse space-separated pane IDs
-    let panes: Vec<&str> = agents_str.split_whitespace().collect();
+    let mut panes: Vec<&str> = agents_str.split_whitespace().collect();
 
     if panes.is_empty() {
         anyhow::bail!("no sidebar agents found");
@@ -803,6 +805,37 @@ pub fn navigate(action: NavAction) -> Result<()> {
         .run_and_capture_stdout()
         .unwrap_or_default();
     let current_pane_id = current_pane_id.trim();
+
+    // Apply project filter if active
+    let filter_mode = Cmd::new("tmux")
+        .args(&["show-option", "-gqv", "@workmux_sidebar_filter"])
+        .run_and_capture_stdout()
+        .unwrap_or_default();
+    if filter_mode.trim() == "project"
+        && let Ok(store) = crate::state::StateStore::new()
+        && let Ok(agents) = store.list_all_agents()
+    {
+        // Get the current pane's project name
+        let current_project = agents.iter().find_map(|a| {
+            (a.pane_key.pane_id == current_pane_id)
+                .then(|| crate::agent_display::extract_project_name(&a.workdir))
+        });
+
+        if let Some(project) = current_project {
+            // Build set of pane IDs that belong to this project
+            let project_panes: std::collections::HashSet<&str> = agents
+                .iter()
+                .filter(|a| crate::agent_display::extract_project_name(&a.workdir) == project)
+                .map(|a| a.pane_key.pane_id.as_str())
+                .collect();
+
+            panes.retain(|p| project_panes.contains(p));
+        }
+    }
+
+    if panes.is_empty() {
+        anyhow::bail!("no matching agents found");
+    }
 
     let current_idx = panes.iter().position(|&pid| pid == current_pane_id);
 
@@ -818,6 +851,44 @@ pub fn navigate(action: NavAction) -> Result<()> {
     Cmd::new("tmux")
         .args(&["switch-client", "-t", target_pane])
         .run()?;
+
+    signal_daemon();
+    Ok(())
+}
+
+/// Set sidebar filter mode from CLI. Toggles if no mode is given.
+pub fn set_filter_mode(mode: Option<&str>) -> Result<()> {
+    use app::SidebarFilterMode;
+
+    let new_mode = match mode {
+        Some(m) => SidebarFilterMode::from_str(m),
+        None => {
+            // Read current mode from tmux and toggle
+            let current = Cmd::new("tmux")
+                .args(&["show-option", "-gqv", "@workmux_sidebar_filter"])
+                .run_and_capture_stdout()
+                .unwrap_or_default();
+            SidebarFilterMode::from_str(current.trim()).toggle()
+        }
+    };
+
+    // Write to tmux global
+    let _ = Cmd::new("tmux")
+        .args(&[
+            "set-option",
+            "-g",
+            "@workmux_sidebar_filter",
+            new_mode.as_str(),
+        ])
+        .run();
+
+    // Persist to settings.json
+    if let Ok(store) = crate::state::StateStore::new()
+        && let Ok(mut settings) = store.load_settings()
+    {
+        settings.sidebar_filter = Some(new_mode.as_str().to_string());
+        let _ = store.save_settings(&settings);
+    }
 
     signal_daemon();
     Ok(())

--- a/src/command/sidebar/runtime.rs
+++ b/src/command/sidebar/runtime.rs
@@ -271,6 +271,7 @@ fn process_event(
                 (KeyCode::Char('g'), _) => app.select_first(),
                 (KeyCode::Char('v'), _) => app.toggle_layout_mode(),
                 (KeyCode::Char('z'), _) => app.toggle_sleeping(),
+                (KeyCode::Char('p'), _) => app.toggle_filter_mode(),
                 _ => {}
             }
             *needs_render = true;

--- a/src/command/sidebar/runtime.rs
+++ b/src/command/sidebar/runtime.rs
@@ -271,7 +271,7 @@ fn process_event(
                 (KeyCode::Char('g'), _) => app.select_first(),
                 (KeyCode::Char('v'), _) => app.toggle_layout_mode(),
                 (KeyCode::Char('z'), _) => app.toggle_sleeping(),
-                (KeyCode::Char('s'), _) => app.toggle_filter_mode(),
+                (KeyCode::Char('f'), _) => app.toggle_filter_mode(),
                 _ => {}
             }
             *needs_render = true;

--- a/src/command/sidebar/runtime.rs
+++ b/src/command/sidebar/runtime.rs
@@ -271,7 +271,7 @@ fn process_event(
                 (KeyCode::Char('g'), _) => app.select_first(),
                 (KeyCode::Char('v'), _) => app.toggle_layout_mode(),
                 (KeyCode::Char('z'), _) => app.toggle_sleeping(),
-                (KeyCode::Char('p'), _) => app.toggle_filter_mode(),
+                (KeyCode::Char('s'), _) => app.toggle_filter_mode(),
                 _ => {}
             }
             *needs_render = true;

--- a/src/command/sidebar/snapshot.rs
+++ b/src/command/sidebar/snapshot.rs
@@ -207,6 +207,7 @@ mod tests {
             HashMap::new(),
             SidebarPosition::Left,
             SidebarLayoutMode::default(),
+            SidebarFilterMode::default(),
             &StatusIcons::default(),
             git_statuses,
             pr_statuses,

--- a/src/command/sidebar/snapshot.rs
+++ b/src/command/sidebar/snapshot.rs
@@ -10,7 +10,7 @@ use crate::git::GitStatus;
 use crate::github::PrSummary;
 use crate::multiplexer::{AgentPane, AgentStatus};
 
-use super::app::SidebarLayoutMode;
+use super::app::{SidebarFilterMode, SidebarLayoutMode};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct PrPathEntry {
@@ -23,6 +23,8 @@ pub(crate) struct PrPathEntry {
 pub struct SidebarSnapshot {
     pub position: SidebarPosition,
     pub layout_mode: SidebarLayoutMode,
+    #[serde(default)]
+    pub filter_mode: SidebarFilterMode,
     pub active_windows: HashSet<(String, String)>,
     #[serde(default)]
     pub active_pane_ids: HashSet<String>,
@@ -59,6 +61,7 @@ pub fn build_snapshot(
     window_pane_counts: HashMap<String, usize>,
     position: SidebarPosition,
     layout_mode: SidebarLayoutMode,
+    filter_mode: SidebarFilterMode,
     status_icons: &StatusIcons,
     git_statuses: HashMap<PathBuf, GitStatus>,
     pr_statuses: HashMap<PathBuf, PrPathEntry>,
@@ -137,6 +140,7 @@ pub fn build_snapshot(
     SidebarSnapshot {
         position,
         layout_mode,
+        filter_mode,
         active_windows,
         active_pane_ids,
         window_pane_counts,

--- a/src/command/sidebar/ui.rs
+++ b/src/command/sidebar/ui.rs
@@ -14,7 +14,7 @@ use crate::multiplexer::{AgentPane, AgentStatus};
 use crate::tmux_style;
 use crate::ui::theme::ThemePalette;
 
-use super::app::{SidebarApp, SidebarLayoutMode};
+use super::app::{SidebarApp, SidebarFilterMode, SidebarLayoutMode};
 use super::template::TokenId;
 use super::template::context::RowContext;
 use super::template::layout::{
@@ -466,12 +466,40 @@ pub fn render_sidebar(f: &mut Frame, app: &mut SidebarApp) {
 
     let inner = block.inner(area);
     f.render_widget(block, area);
-    let list_area = render_template_error(f, app, inner);
+    let inner = render_template_error(f, app, inner);
+
+    let (list_area, filter_area) = if app.filter_mode == SidebarFilterMode::Project {
+        if inner.height > 1 {
+            let list = Rect::new(inner.x, inner.y, inner.width, inner.height - 1);
+            let filter = Rect::new(inner.x, inner.y + inner.height - 1, inner.width, 1);
+            (list, Some(filter))
+        } else {
+            (inner, None)
+        }
+    } else {
+        (inner, None)
+    };
     app.list_area = list_area;
 
     match app.layout_mode {
         SidebarLayoutMode::Compact => render_compact_list(f, app, list_area),
         SidebarLayoutMode::Tiles => render_tile_list(f, app, list_area),
+    }
+
+    if let Some(filter_rect) = filter_area {
+        let label = app
+            .host_project_name()
+            .map(|p| format!("[project: {}]", p))
+            .unwrap_or_else(|| "[project]".to_string());
+        let label = truncate_to_width(&label, filter_rect.width as usize);
+        let line = Line::from(Span::styled(
+            label,
+            Style::default()
+                .fg(app.palette.dimmed)
+                .add_modifier(Modifier::DIM),
+        ))
+        .alignment(Alignment::Center);
+        f.render_widget(line, filter_rect);
     }
 }
 
@@ -682,6 +710,20 @@ fn status_icon_extra_width(ctx: &RowContext<'_>) -> usize {
     } else {
         0
     }
+}
+
+fn truncate_to_width(s: &str, max_width: usize) -> String {
+    let mut out = String::new();
+    let mut width = 0;
+    for ch in s.chars() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(1);
+        if width + ch_width > max_width {
+            break;
+        }
+        out.push(ch);
+        width += ch_width;
+    }
+    out
 }
 
 /// Compact single-line-per-agent list (original layout).

--- a/src/command/sidebar/ui.rs
+++ b/src/command/sidebar/ui.rs
@@ -468,7 +468,7 @@ pub fn render_sidebar(f: &mut Frame, app: &mut SidebarApp) {
     f.render_widget(block, area);
     let inner = render_template_error(f, app, inner);
 
-    let (list_area, filter_area) = if app.filter_mode == SidebarFilterMode::Project {
+    let (list_area, filter_area) = if app.filter_mode == SidebarFilterMode::Session {
         if inner.height > 1 {
             let list = Rect::new(inner.x, inner.y, inner.width, inner.height - 1);
             let filter = Rect::new(inner.x, inner.y + inner.height - 1, inner.width, 1);
@@ -488,9 +488,9 @@ pub fn render_sidebar(f: &mut Frame, app: &mut SidebarApp) {
 
     if let Some(filter_rect) = filter_area {
         let label = app
-            .host_project_name()
-            .map(|p| format!("[project: {}]", p))
-            .unwrap_or_else(|| "[project]".to_string());
+            .host_session()
+            .map(|s| format!("[session: {}]", s))
+            .unwrap_or_else(|| "[session]".to_string());
         let label = truncate_to_width(&label, filter_rect.width as usize);
         let line = Line::from(Span::styled(
             label,

--- a/src/command/sidebar/ui.rs
+++ b/src/command/sidebar/ui.rs
@@ -1034,6 +1034,7 @@ mod tests {
             location: "tiles[0]".to_string(),
             message: "unknown token 'pr_status' at column 1".to_string(),
         });
+        app.filter_mode = super::SidebarFilterMode::None;
 
         terminal.draw(|f| render_sidebar(f, &mut app)).unwrap();
 

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -684,6 +684,7 @@ mod tests {
             sidebar_layout: None,
             sidebar_width: None,
             sidebar_height: None,
+            sidebar_filter: None,
         };
 
         store.save_settings(&settings).unwrap();

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -10,6 +10,19 @@ use tracing::{info, trace, warn};
 use super::types::{AgentState, GlobalSettings, PaneKey};
 use crate::config::SandboxRuntime;
 
+fn is_shell_command(command: &str) -> bool {
+    let token = crate::multiplexer::agent::find_executable_token(command);
+    let stem = Path::new(token)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(token);
+
+    matches!(
+        stem,
+        "bash" | "zsh" | "sh" | "dash" | "fish" | "nu" | "nushell" | "pwsh" | "powershell"
+    )
+}
+
 /// Manages filesystem-based state persistence for workmux agents.
 ///
 /// Directory structure:
@@ -456,6 +469,29 @@ impl StateStore {
                         let _ = mux.clear_status(&state.pane_key.pane_id);
                     }
                 }
+                Some(live)
+                    if live
+                        .current_command
+                        .as_deref()
+                        .is_some_and(is_shell_command)
+                        || is_shell_command(&state.command) =>
+                {
+                    if state.boot_id.is_some() && state.boot_id != current_boot_id {
+                        trace!(
+                            pane_id,
+                            "reconcile: preserving shell pane state from previous server lifecycle"
+                        );
+                    } else {
+                        info!(
+                            pane_id,
+                            stored_command = state.command,
+                            live_command = live.current_command.as_deref().unwrap_or(""),
+                            "reconcile: removing agent, foreground command is a shell"
+                        );
+                        self.delete_agent(&state.pane_key)?;
+                        let _ = mux.clear_status(&state.pane_key.pane_id);
+                    }
+                }
                 Some(live) => {
                     // Valid - include in dashboard
                     let mut agent_pane = state.to_agent_pane(
@@ -759,6 +795,17 @@ mod tests {
 
         let agents = store.list_all_agents().unwrap();
         assert_eq!(agents.len(), 1);
+    }
+
+    #[test]
+    fn shell_command_detection_matches_common_shells() {
+        assert!(is_shell_command("bash"));
+        assert!(is_shell_command("/bin/zsh"));
+        assert!(is_shell_command("env FOO=bar fish -l"));
+        assert!(is_shell_command("nu"));
+        assert!(!is_shell_command("node"));
+        assert!(!is_shell_command("claude"));
+        assert!(!is_shell_command("codex exec"));
     }
 
     #[test]

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -12,10 +12,10 @@ use crate::config::SandboxRuntime;
 
 fn is_shell_command(command: &str) -> bool {
     let token = crate::multiplexer::agent::find_executable_token(command);
-    let stem = Path::new(token)
+    let stem = Path::new(&token)
         .file_stem()
         .and_then(|s| s.to_str())
-        .unwrap_or(token);
+        .unwrap_or(token.as_str());
 
     matches!(
         stem,

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -10,19 +10,6 @@ use tracing::{info, trace, warn};
 use super::types::{AgentState, GlobalSettings, PaneKey};
 use crate::config::SandboxRuntime;
 
-fn is_shell_command(command: &str) -> bool {
-    let token = crate::multiplexer::agent::find_executable_token(command);
-    let stem = Path::new(&token)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or(token.as_str());
-
-    matches!(
-        stem,
-        "bash" | "zsh" | "sh" | "dash" | "fish" | "nu" | "nushell" | "pwsh" | "powershell"
-    )
-}
-
 /// Manages filesystem-based state persistence for workmux agents.
 ///
 /// Directory structure:
@@ -469,29 +456,6 @@ impl StateStore {
                         let _ = mux.clear_status(&state.pane_key.pane_id);
                     }
                 }
-                Some(live)
-                    if live
-                        .current_command
-                        .as_deref()
-                        .is_some_and(is_shell_command)
-                        || is_shell_command(&state.command) =>
-                {
-                    if state.boot_id.is_some() && state.boot_id != current_boot_id {
-                        trace!(
-                            pane_id,
-                            "reconcile: preserving shell pane state from previous server lifecycle"
-                        );
-                    } else {
-                        info!(
-                            pane_id,
-                            stored_command = state.command,
-                            live_command = live.current_command.as_deref().unwrap_or(""),
-                            "reconcile: removing agent, foreground command is a shell"
-                        );
-                        self.delete_agent(&state.pane_key)?;
-                        let _ = mux.clear_status(&state.pane_key.pane_id);
-                    }
-                }
                 Some(live) => {
                     // Valid - include in dashboard
                     let mut agent_pane = state.to_agent_pane(
@@ -795,17 +759,6 @@ mod tests {
 
         let agents = store.list_all_agents().unwrap();
         assert_eq!(agents.len(), 1);
-    }
-
-    #[test]
-    fn shell_command_detection_matches_common_shells() {
-        assert!(is_shell_command("bash"));
-        assert!(is_shell_command("/bin/zsh"));
-        assert!(is_shell_command("env FOO=bar fish -l"));
-        assert!(is_shell_command("nu"));
-        assert!(!is_shell_command("node"));
-        assert!(!is_shell_command("claude"));
-        assert!(!is_shell_command("codex exec"));
     }
 
     #[test]

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -190,7 +190,7 @@ pub struct GlobalSettings {
     #[serde(default)]
     pub sidebar_height: Option<u16>,
 
-    /// Sidebar filter mode: "all" or "project"
+    /// Sidebar filter mode: "none" or "session"
     #[serde(default)]
     pub sidebar_filter: Option<String>,
 }

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -189,6 +189,10 @@ pub struct GlobalSettings {
     /// Sidebar height in rows (manual override synced across windows)
     #[serde(default)]
     pub sidebar_height: Option<u16>,
+
+    /// Sidebar filter mode: "all" or "project"
+    #[serde(default)]
+    pub sidebar_filter: Option<String>,
 }
 
 /// Tracks which pane last-done navigated to, so repeated presses cycle


### PR DESCRIPTION
## Summary

- Adds a project filter to the sidebar, toggled with `p` key or `workmux sidebar filter [none|project]` CLI command
- When active, filters the sidebar to only show agents belonging to the same project as the current window
- Navigation hotkeys (alt-j/k, jump) respect the filter
- Project is detected from the host agent's path, falling back to the host pane's working directory for non-agent windows
- Filter state persists via tmux global and settings.json

## Test plan

- [x] `just check` passes (format, clippy, build, 917 tests, ruff, pyright)
- [x] Manual: press `p` in sidebar to toggle filter, verify agents are filtered by project
- [x] Manual: `workmux sidebar filter project` / `workmux sidebar filter none` from CLI
- [x] Manual: alt-j/k only cycles through filtered agents when filter is active
- [x] Manual: non-agent windows (plain zsh) correctly detect project from cwd