### PR TITLE
Add Gemini CLI status tracking hooks

### DIFF
--- a/.gemini/hooks/workmux-status.json
+++ b/.gemini/hooks/workmux-status.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status waiting"
+          }
+        ]
+      }
+    ],
     "BeforeAgent": [
       {
         "hooks": [

--- a/.gemini/hooks/workmux-status.json
+++ b/.gemini/hooks/workmux-status.json
@@ -1,0 +1,45 @@
+{
+  "hooks": {
+    "BeforeAgent": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status working"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "ToolPermission",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status waiting"
+          }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status working"
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status done"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/guide/status-tracking.md
+++ b/docs/guide/status-tracking.md
@@ -19,7 +19,7 @@ Workmux can display the status of the agent in your tmux window list, giving you
 | Codex        | ✅ Supported\*                                                              |
 | Copilot CLI  | ✅ Supported\*                                                              |
 | Pi           | ✅ Supported\*                                                              |
-| Gemini CLI   | [In progress](https://github.com/google-gemini/gemini-cli/issues/9070)      |
+| Gemini CLI   | ✅ Supported                                                                |
 | Kiro         | [Tracking issue](https://github.com/kirodotdev/Kiro/issues/5440)            |
 | Mistral Vibe | [Tracking issue](https://github.com/mistralai/mistral-vibe/discussions/334) |
 
@@ -44,7 +44,7 @@ Run `workmux setup` to automatically detect your agent CLIs and install status t
 workmux setup
 ```
 
-This detects Claude Code, Copilot CLI, OpenCode, and Pi by checking for their configuration directories, then offers to install the appropriate hooks. Workmux will also prompt you on first run if it detects an agent without status tracking configured.
+This detects Claude Code, Gemini CLI, Copilot CLI, OpenCode, and Pi by checking for their configuration directories, then offers to install the appropriate hooks. Workmux will also prompt you on first run if it detects an agent without status tracking configured.
 
 Workmux automatically modifies your tmux `window-status-format` to display the status icons. This happens once per session and only affects the current tmux session (not your global config).
 
@@ -82,6 +82,26 @@ curl -o ~/.config/opencode/plugin/workmux-status.ts \
 ```
 
 Restart OpenCode for the plugin to take effect.
+
+## Gemini CLI setup
+
+If you prefer manual setup, add the workmux hooks to your Gemini settings:
+
+```bash
+# Download and merge hooks into ~/.gemini/settings.json
+curl -s https://raw.githubusercontent.com/raine/workmux/main/.gemini/hooks/workmux-status.json \
+  | python3 -c "
+import json, sys, pathlib
+hooks = json.load(sys.stdin)['hooks']
+p = pathlib.Path.home() / '.gemini/settings.json'
+s = json.loads(p.read_text()) if p.exists() else {}
+s.setdefault('hooks', {}).update(hooks)
+p.write_text(json.dumps(s, indent=2) + '\n')
+print('Installed hooks to', p)
+"
+```
+
+Alternatively, manually copy the hook entries from [.gemini/hooks/workmux-status.json](https://github.com/raine/workmux/blob/main/.gemini/hooks/workmux-status.json) into your `~/.gemini/settings.json`.
 
 ## Codex setup
 

--- a/src/agent_setup/gemini.rs
+++ b/src/agent_setup/gemini.rs
@@ -161,6 +161,7 @@ mod tests {
         let parsed: serde_json::Value =
             serde_json::from_str(HOOKS_JSON).expect("embedded hooks config is valid JSON");
         let hooks = parsed.get("hooks").unwrap().as_object().unwrap();
+        assert!(hooks.contains_key("SessionStart"));
         assert!(hooks.contains_key("BeforeAgent"));
         assert!(hooks.contains_key("AfterTool"));
         assert!(hooks.contains_key("AfterAgent"));
@@ -212,6 +213,7 @@ mod tests {
     fn test_load_hooks() {
         let hooks = load_hooks().unwrap();
         let obj = hooks.as_object().unwrap();
+        assert!(obj.contains_key("SessionStart"));
         assert!(obj.contains_key("BeforeAgent"));
         assert!(obj.contains_key("AfterTool"));
         assert!(obj.contains_key("AfterAgent"));
@@ -231,7 +233,7 @@ mod tests {
         }
 
         let hooks = config.get("hooks").unwrap().as_object().unwrap();
-        assert_eq!(hooks.len(), 4);
+        assert_eq!(hooks.len(), 5);
     }
 
     #[test]
@@ -320,6 +322,6 @@ mod tests {
 
         // All 4 events should be present
         let hooks = config.get("hooks").unwrap().as_object().unwrap();
-        assert_eq!(hooks.len(), 4);
+        assert_eq!(hooks.len(), 5);
     }
 }

--- a/src/agent_setup/gemini.rs
+++ b/src/agent_setup/gemini.rs
@@ -1,0 +1,325 @@
+//! Gemini CLI status tracking setup.
+//!
+//! Detects Gemini CLI via the `~/.gemini/` directory.
+//! Installs hooks by merging into `~/.gemini/settings.json`.
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::fs;
+use std::path::PathBuf;
+
+use super::StatusCheck;
+
+/// Hooks configuration embedded at compile time.
+const HOOKS_JSON: &str = include_str!("../../.gemini/hooks/workmux-status.json");
+
+fn gemini_dir() -> Option<PathBuf> {
+    home::home_dir().map(|h| h.join(".gemini"))
+}
+
+fn settings_path() -> Option<PathBuf> {
+    gemini_dir().map(|d| d.join("settings.json"))
+}
+
+/// Detect if Gemini CLI is present via filesystem.
+pub fn detect() -> Option<&'static str> {
+    if gemini_dir().is_some_and(|d| d.is_dir()) {
+        return Some("found ~/.gemini/");
+    }
+    None
+}
+
+/// Check if workmux hooks are installed in Gemini settings.json.
+pub fn check() -> Result<StatusCheck> {
+    let Some(path) = settings_path() else {
+        return Ok(StatusCheck::NotInstalled);
+    };
+
+    if !path.exists() {
+        return Ok(StatusCheck::NotInstalled);
+    }
+
+    let content = fs::read_to_string(&path).context("Failed to read ~/.gemini/settings.json")?;
+    let config: Value =
+        serde_json::from_str(&content).context("~/.gemini/settings.json is not valid JSON")?;
+
+    if has_workmux_hooks(&config) {
+        Ok(StatusCheck::Installed)
+    } else {
+        Ok(StatusCheck::NotInstalled)
+    }
+}
+
+/// Check if the hooks object contains any workmux set-window-status commands.
+fn has_workmux_hooks(config: &Value) -> bool {
+    let Some(hooks) = config.get("hooks").and_then(|v| v.as_object()) else {
+        return false;
+    };
+
+    for (_event, groups) in hooks {
+        let Some(groups_arr) = groups.as_array() else {
+            continue;
+        };
+        for group in groups_arr {
+            let Some(hook_list) = group.get("hooks").and_then(|v| v.as_array()) else {
+                continue;
+            };
+            for hook in hook_list {
+                if let Some(cmd) = hook.get("command").and_then(|v| v.as_str())
+                    && cmd.contains("workmux set-window-status")
+                {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+/// Load the hooks portion from the embedded config.
+fn load_hooks() -> Result<Value> {
+    let config: Value =
+        serde_json::from_str(HOOKS_JSON).expect("embedded hooks config is valid JSON");
+    config
+        .get("hooks")
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("hooks config missing hooks key"))
+}
+
+/// Install workmux hooks into `~/.gemini/settings.json`.
+///
+/// Merges hook groups into existing hooks without clobbering or creating
+/// duplicates. Returns a description of what was done.
+pub fn install() -> Result<String> {
+    let path =
+        settings_path().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+
+    // Read existing settings or start fresh
+    let mut config: Value = if path.exists() {
+        let content =
+            fs::read_to_string(&path).context("Failed to read ~/.gemini/settings.json")?;
+        serde_json::from_str(&content).context("~/.gemini/settings.json is not valid JSON")?
+    } else {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).context("Failed to create ~/.gemini/ directory")?;
+        }
+        Value::Object(serde_json::Map::new())
+    };
+
+    let hooks_to_add = load_hooks()?;
+
+    // Ensure config.hooks exists as an object
+    let config_obj = config
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("settings.json root is not an object"))?;
+
+    if !config_obj.contains_key("hooks") {
+        config_obj.insert("hooks".to_string(), Value::Object(serde_json::Map::new()));
+    }
+
+    let existing_hooks = config_obj
+        .get_mut("hooks")
+        .and_then(|v| v.as_object_mut())
+        .ok_or_else(|| anyhow::anyhow!("settings.json hooks is not an object"))?;
+
+    // Merge each hook event, deduplicating by value equality
+    let hooks_map = hooks_to_add.as_object().expect("hooks is an object");
+    for (event, hook_groups) in hooks_map {
+        let Some(new_groups) = hook_groups.as_array() else {
+            continue;
+        };
+
+        if let Some(existing_groups) = existing_hooks.get_mut(event) {
+            let arr = existing_groups
+                .as_array_mut()
+                .ok_or_else(|| anyhow::anyhow!("hooks.{event} is not an array"))?;
+            for group in new_groups {
+                if !arr.contains(group) {
+                    arr.push(group.clone());
+                }
+            }
+        } else {
+            existing_hooks.insert(event.clone(), hook_groups.clone());
+        }
+    }
+
+    // Write back with pretty formatting
+    let output = serde_json::to_string_pretty(&config)?;
+    fs::write(&path, output + "\n").context("Failed to write ~/.gemini/settings.json")?;
+
+    Ok("Installed hooks to ~/.gemini/settings.json".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_hooks_json_is_valid() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(HOOKS_JSON).expect("embedded hooks config is valid JSON");
+        let hooks = parsed.get("hooks").unwrap().as_object().unwrap();
+        assert!(hooks.contains_key("BeforeAgent"));
+        assert!(hooks.contains_key("AfterTool"));
+        assert!(hooks.contains_key("AfterAgent"));
+        assert!(hooks.contains_key("Notification"));
+    }
+
+    #[test]
+    fn test_hooks_json_contains_workmux_command() {
+        assert!(HOOKS_JSON.contains("workmux set-window-status"));
+    }
+
+    #[test]
+    fn test_has_workmux_hooks_empty() {
+        let config = json!({});
+        assert!(!has_workmux_hooks(&config));
+    }
+
+    #[test]
+    fn test_has_workmux_hooks_present() {
+        let config = json!({
+            "hooks": {
+                "AfterAgent": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": "workmux set-window-status done"
+                    }]
+                }]
+            }
+        });
+        assert!(has_workmux_hooks(&config));
+    }
+
+    #[test]
+    fn test_has_workmux_hooks_other_hooks_only() {
+        let config = json!({
+            "hooks": {
+                "AfterAgent": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": "python3 my-script.py"
+                    }]
+                }]
+            }
+        });
+        assert!(!has_workmux_hooks(&config));
+    }
+
+    #[test]
+    fn test_load_hooks() {
+        let hooks = load_hooks().unwrap();
+        let obj = hooks.as_object().unwrap();
+        assert!(obj.contains_key("BeforeAgent"));
+        assert!(obj.contains_key("AfterTool"));
+        assert!(obj.contains_key("AfterAgent"));
+        assert!(obj.contains_key("Notification"));
+    }
+
+    #[test]
+    fn test_merge_into_empty_config() {
+        let mut config = json!({ "hooks": {} });
+        let hooks_to_add = load_hooks().unwrap();
+        let hooks_map = hooks_to_add.as_object().unwrap();
+
+        let existing_hooks = config.get_mut("hooks").unwrap().as_object_mut().unwrap();
+
+        for (event, hook_groups) in hooks_map {
+            existing_hooks.insert(event.clone(), hook_groups.clone());
+        }
+
+        let hooks = config.get("hooks").unwrap().as_object().unwrap();
+        assert_eq!(hooks.len(), 4);
+    }
+
+    #[test]
+    fn test_merge_deduplicates() {
+        let mut config = json!({
+            "hooks": {
+                "AfterAgent": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": "workmux set-window-status done"
+                    }]
+                }]
+            }
+        });
+
+        let hooks_to_add = load_hooks().unwrap();
+        let hooks_map = hooks_to_add.as_object().unwrap();
+
+        let existing_hooks = config.get_mut("hooks").unwrap().as_object_mut().unwrap();
+
+        for (event, hook_groups) in hooks_map {
+            let new_groups = hook_groups.as_array().unwrap();
+            if let Some(existing_groups) = existing_hooks.get_mut(event) {
+                let arr = existing_groups.as_array_mut().unwrap();
+                for group in new_groups {
+                    if !arr.contains(group) {
+                        arr.push(group.clone());
+                    }
+                }
+            } else {
+                existing_hooks.insert(event.clone(), hook_groups.clone());
+            }
+        }
+
+        let stop = config
+            .get("hooks")
+            .unwrap()
+            .get("AfterAgent")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(stop.len(), 1);
+    }
+
+    #[test]
+    fn test_merge_preserves_existing_hooks() {
+        let mut config = json!({
+            "hooks": {
+                "AfterAgent": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": "python3 my-stop-hook.py"
+                    }]
+                }]
+            }
+        });
+
+        let hooks_to_add = load_hooks().unwrap();
+        let hooks_map = hooks_to_add.as_object().unwrap();
+
+        let existing_hooks = config.get_mut("hooks").unwrap().as_object_mut().unwrap();
+
+        for (event, hook_groups) in hooks_map {
+            let new_groups = hook_groups.as_array().unwrap();
+            if let Some(existing_groups) = existing_hooks.get_mut(event) {
+                let arr = existing_groups.as_array_mut().unwrap();
+                for group in new_groups {
+                    if !arr.contains(group) {
+                        arr.push(group.clone());
+                    }
+                }
+            } else {
+                existing_hooks.insert(event.clone(), hook_groups.clone());
+            }
+        }
+
+        // AfterAgent should have 2 groups (original + workmux)
+        let stop = config
+            .get("hooks")
+            .unwrap()
+            .get("AfterAgent")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(stop.len(), 2);
+
+        // All 4 events should be present
+        let hooks = config.get("hooks").unwrap().as_object().unwrap();
+        assert_eq!(hooks.len(), 4);
+    }
+}

--- a/src/agent_setup/mod.rs
+++ b/src/agent_setup/mod.rs
@@ -7,6 +7,7 @@
 pub mod claude;
 pub mod codex;
 pub mod copilot;
+pub mod gemini;
 pub mod opencode;
 pub mod pi;
 
@@ -25,6 +26,7 @@ pub enum Agent {
     Claude,
     Codex,
     Copilot,
+    Gemini,
     OpenCode,
     Pi,
 }
@@ -35,6 +37,7 @@ impl Agent {
             Agent::Claude => "Claude Code",
             Agent::Codex => "Codex",
             Agent::Copilot => "Copilot CLI",
+            Agent::Gemini => "Gemini CLI",
             Agent::OpenCode => "OpenCode",
             Agent::Pi => "pi",
         }
@@ -90,6 +93,18 @@ pub fn check_all() -> Vec<AgentCheck> {
         });
     }
 
+    if let Some(reason) = gemini::detect() {
+        let status = match gemini::check() {
+            Ok(s) => s,
+            Err(e) => StatusCheck::Error(e.to_string()),
+        };
+        results.push(AgentCheck {
+            agent: Agent::Gemini,
+            reason,
+            status,
+        });
+    }
+
     if let Some(reason) = copilot::detect() {
         let status = match copilot::check() {
             Ok(s) => s,
@@ -135,6 +150,7 @@ pub fn install(agent: Agent) -> Result<String> {
         Agent::Claude => claude::install(),
         Agent::Codex => codex::install(),
         Agent::Copilot => copilot::install(),
+        Agent::Gemini => gemini::install(),
         Agent::OpenCode => opencode::install(),
         Agent::Pi => pi::install(),
     }
@@ -393,6 +409,7 @@ mod tests {
         assert_eq!(Agent::Claude.name(), "Claude Code");
         assert_eq!(Agent::Codex.name(), "Codex");
         assert_eq!(Agent::Copilot.name(), "Copilot CLI");
+        assert_eq!(Agent::Gemini.name(), "Gemini CLI");
         assert_eq!(Agent::OpenCode.name(), "OpenCode");
         assert_eq!(Agent::Pi.name(), "pi");
     }
@@ -405,6 +422,7 @@ mod tests {
             serde_json::to_string(&Agent::Copilot).unwrap(),
             "\"copilot\""
         );
+        assert_eq!(serde_json::to_string(&Agent::Gemini).unwrap(), "\"gemini\"");
         assert_eq!(
             serde_json::to_string(&Agent::OpenCode).unwrap(),
             "\"opencode\""
@@ -420,6 +438,8 @@ mod tests {
         assert_eq!(agent, Agent::Codex);
         let agent: Agent = serde_json::from_str("\"copilot\"").unwrap();
         assert_eq!(agent, Agent::Copilot);
+        let agent: Agent = serde_json::from_str("\"gemini\"").unwrap();
+        assert_eq!(agent, Agent::Gemini);
         let agent: Agent = serde_json::from_str("\"opencode\"").unwrap();
         assert_eq!(agent, Agent::OpenCode);
         let agent: Agent = serde_json::from_str("\"pi\"").unwrap();
@@ -448,12 +468,13 @@ mod tests {
         let mut state = SetupState::default();
         state.declined.insert(Agent::Claude);
         state.declined.insert(Agent::Codex);
+        state.declined.insert(Agent::Gemini);
         state.declined.insert(Agent::OpenCode);
         state.declined.insert(Agent::Pi);
 
         let json = serde_json::to_string_pretty(&state).unwrap();
         let deserialized: SetupState = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.declined.len(), 4);
+        assert_eq!(deserialized.declined.len(), 5);
         assert!(deserialized.declined.contains(&Agent::Claude));
         assert!(deserialized.declined.contains(&Agent::Codex));
         assert!(deserialized.declined.contains(&Agent::OpenCode));

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -59,6 +59,7 @@ pub fn skills_dir(agent: Agent) -> Option<PathBuf> {
             };
             Some(pi_dir.join("skills"))
         }
+        Agent::Gemini => Some(home.join(".gemini/skills")),
         Agent::Codex | Agent::Copilot => None,
     }
 }


### PR DESCRIPTION
## Summary

- Add Gemini CLI to the `Agent` enum and wire up detect/check/install in `agent_setup`
- Add `.gemini/hooks/workmux-status.json` with hooks for `SessionStart` (waiting), `BeforeAgent` (working), `AfterTool` (working), `Notification`/`ToolPermission` (waiting), and `AfterAgent` (done)
- Add Gemini skills directory support (`~/.gemini/skills`)
- Update status tracking docs: mark Gemini as supported, add manual setup section

Closes https://github.com/google-gemini/gemini-cli/issues/9070

## Event mapping

| Status  | Gemini event     | Notes                          |
|---------|------------------|--------------------------------|
| waiting | `SessionStart`   | Immediate status on launch     |
| working | `BeforeAgent`    | User submits prompt            |
| working | `AfterTool`      | Tool completes, agent continues|
| waiting | `Notification`   | `ToolPermission` matcher       |
| done    | `AfterAgent`     | Agent turn completes           |

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo test` — 930 passed, 0 failed
- [x] Verified hooks fire correctly with Gemini CLI 0.36.0