### PR TITLE
docs: add mise as an installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Requires Rust. Install via [rustup](https://rustup.rs/) if you don't have it.
 cargo install workmux
 ```
 
+### [mise](https://mise.jdx.dev/)
+
+```bash
+mise use -g cargo:raine/workmux
+```
+
 ### Nix
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds [mise](https://mise.jdx.dev/) as an installation option in the README, between Cargo and Nix sections.
- mise can install cargo-based tools globally via `mise use -g cargo:raine/workmux`, providing a convenient alternative for users who already use mise as their toolchain manager.