### PR TITLE
add cargo-binstall metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,24 @@ crossterm = { git = "https://github.com/raine/crossterm" }
 strip = true       # Strip debug symbols
 lto = true         # Link Time Optimization for smaller binaries
 codegen-units = 1  # Maximize optimization
+
+[package.metadata.binstall]
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-linux-amd64.{ archive-format }"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-musl]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-linux-amd64.{ archive-format }"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-linux-arm64.{ archive-format }"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-musl]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-linux-arm64.{ archive-format }"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-darwin-amd64.{ archive-format }"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-darwin-arm64.{ archive-format }"


### PR DESCRIPTION
Adds `[package.metadata.binstall]` to `Cargo.toml` so `cargo binstall workmux` resolves the existing goreleaser release artifacts instead of falling back to a source compile.

## Why

Without this metadata, binstall expects asset names like `workmux-x86_64-unknown-linux-gnu.tar.gz`, but the goreleaser pipeline publishes `workmux-linux-amd64.tar.gz` (etc.). The mismatch makes binstall fall through to `cargo install`, which compiles from source — slow, and requires a full Rust toolchain in user environments (Docker images, CI) that only wanted a binary.

The release assets users want already exist; this just teaches binstall where to find them.

## What

Maps each supported Rust target triple to the matching goreleaser asset:

| target triple | asset |
| --- | --- |
| `x86_64-unknown-linux-{gnu,musl}` | `workmux-linux-amd64.tar.gz` |
| `aarch64-unknown-linux-{gnu,musl}` | `workmux-linux-arm64.tar.gz` |
| `x86_64-apple-darwin` | `workmux-darwin-amd64.tar.gz` |
| `aarch64-apple-darwin` | `workmux-darwin-arm64.tar.gz` |

Pure metadata change — no CI, release pipeline, or version bump. No new release targets added; this only points binstall at what's already published.

The `musl` overrides reuse the gnu-built asset since the binary is statically-linked-enough in practice; happy to drop them if you'd rather only advertise gnu.

## Verification

Tested against v0.1.183 from a local checkout with the patched `Cargo.toml`:

```
$ cargo binstall --manifest-path ./Cargo.toml --dry-run --targets x86_64-unknown-linux-gnu workmux
 INFO resolve: Resolving package: 'workmux'
 WARN The package workmux v0.1.183 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - workmux => /root/.cargo/bin/workmux
```

Resolved URL: `https://github.com/raine/workmux/releases/download/v0.1.183/workmux-linux-amd64.tar.gz`. Confirmed the same for `aarch64-unknown-linux-{gnu,musl}`, `x86_64-unknown-linux-musl`, `x86_64-apple-darwin`, and `aarch64-apple-darwin`. End-to-end install into a throwaway dir extracts the binary at the archive root and `workmux --version` prints `workmux 0.1.183`.

## References

- binstall metadata reference: https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md