### PR TITLE
ci: block PRs on fmt/clippy/test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets --all-features
+        continue-on-error: true
+      - run: cargo test --all-features


### PR DESCRIPTION
I noticed there was no CI, so I added this CI workflow  with `cargo fmt --check`, `cargo clippy` (non-blocking until the existing lints are cleaned up) and `cargo test` run on every PR, push to `main`, and merge-queue entry. This will make the `test` ci job required. We can use this ci check for automated github dependency updates

Here some instructions on how setup required checks after merging:

```bash
export REPO=raine/workmux

# allow PRs to use auto-merge
gh api -X PATCH "repos/$REPO" -f allow_auto_merge=true

# require the `test` check on the default branch via a ruleset
# integration_id 15368 = GitHub Actions, actor_id 5 = repo admin (bypass)
gh api -X POST "repos/$REPO/rulesets" --input - <<'JSON'
{
  "name": "main",
  "target": "branch",
  "enforcement": "active",
  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
  "bypass_actors": [
    { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always" }
  ],
  "rules": [
    { "type": "deletion" },
    { "type": "non_fast_forward" },
    { "type": "required_status_checks",
      "parameters": {
        "strict_required_status_checks_policy": false,
        "required_status_checks": [
          { "context": "test", "integration_id": 15368 }
        ]
      }
    }
  ]
}
JSON
```

