### PR TITLE
pr: fetch refs/pull/<N>/head instead of guessing fork remotes

### DIFF
--- a/src/command/add.rs
+++ b/src/command/add.rs
@@ -281,64 +281,58 @@ pub fn run(
 
     // Handle auto-name: load prompt first, generate branch name
     // In multi-worktree mode with auto-name, we defer LLM generation to the loop
-    let (final_branch_name, preloaded_prompt, remote_branch_for_pr, deferred_auto_name) =
-        if auto_name {
-            // Use editor if no prompt source specified, otherwise use provided source
-            let use_editor = prompt_args.prompt.is_none() && prompt_args.prompt_file.is_none();
+    let (final_branch_name, preloaded_prompt, deferred_auto_name) = if auto_name {
+        // Use editor if no prompt source specified, otherwise use provided source
+        let use_editor = prompt_args.prompt.is_none() && prompt_args.prompt_file.is_none();
 
-            // Cannot use interactive editor when stdin is piped (editor can't read terminal)
-            if has_stdin && (prompt_args.prompt_editor || use_editor) {
-                return Err(anyhow!(
-                    "Cannot use interactive prompt editor when piping input from stdin.\n\
+        // Cannot use interactive editor when stdin is piped (editor can't read terminal)
+        if has_stdin && (prompt_args.prompt_editor || use_editor) {
+            return Err(anyhow!(
+                "Cannot use interactive prompt editor when piping input from stdin.\n\
                     Please provide a prompt via --prompt or --prompt-file."
-                ));
-            }
+            ));
+        }
 
-            let prompt = load_prompt(&PromptLoadArgs {
-                prompt_editor: use_editor || prompt_args.prompt_editor,
-                prompt_inline: prompt_args.prompt.as_deref(),
-                prompt_file: prompt_args.prompt_file.as_ref(),
-            })?
-            .ok_or_else(|| anyhow!("Prompt is required for --auto-name"))?;
+        let prompt = load_prompt(&PromptLoadArgs {
+            prompt_editor: use_editor || prompt_args.prompt_editor,
+            prompt_inline: prompt_args.prompt.as_deref(),
+            prompt_file: prompt_args.prompt_file.as_ref(),
+        })?
+        .ok_or_else(|| anyhow!("Prompt is required for --auto-name"))?;
 
-            // Check if we need to defer auto-name generation to the loop
-            // This happens when we have multi-worktree mode OR frontmatter foreach
-            let prompt_doc_preview = parse_prompt_with_frontmatter(&prompt, true)?;
-            let has_frontmatter_foreach = prompt_doc_preview.meta.foreach.is_some();
+        // Check if we need to defer auto-name generation to the loop
+        // This happens when we have multi-worktree mode OR frontmatter foreach
+        let prompt_doc_preview = parse_prompt_with_frontmatter(&prompt, true)?;
+        let has_frontmatter_foreach = prompt_doc_preview.meta.foreach.is_some();
 
-            if is_explicit_multi || has_frontmatter_foreach {
-                // Defer LLM generation - use placeholder branch name
-                ("deferred".to_string(), Some(prompt), None, true)
-            } else {
-                // Single worktree mode - generate branch name now
-                let prompt_text = prompt.read_content()?;
-                let config = config::Config::load(multi.agent.first().map(|s| s.as_str()))?;
-                let generated = generate_branch_name_with_spinner(Some(&prompt_text), &config)?;
-                (generated, Some(prompt), None, false)
-            }
-        } else if let Some(pr_number) = pr {
-            // Handle PR checkout if --pr flag is provided
-            let result = workflow::pr::resolve_pr_ref(pr_number, branch_name)?;
-            (result.local_branch, None, Some(result.remote_branch), false)
+        if is_explicit_multi || has_frontmatter_foreach {
+            // Defer LLM generation - use placeholder branch name
+            ("deferred".to_string(), Some(prompt), true)
         } else {
-            // Normal flow: use provided branch name
-            (
-                branch_name
-                    .expect("branch_name required when --pr and --auto-name not provided")
-                    .to_string(),
-                None,
-                None,
-                false,
-            )
-        };
+            // Single worktree mode - generate branch name now
+            let prompt_text = prompt.read_content()?;
+            let config = config::Config::load(multi.agent.first().map(|s| s.as_str()))?;
+            let generated = generate_branch_name_with_spinner(Some(&prompt_text), &config)?;
+            (generated, Some(prompt), false)
+        }
+    } else if let Some(pr_number) = pr {
+        // resolve_pr_ref fetches the pull ref into a local branch directly.
+        let result = workflow::pr::resolve_pr_ref(pr_number, branch_name, false)?;
+        (result.local_branch, None, false)
+    } else {
+        // Normal flow: use provided branch name
+        (
+            branch_name
+                .expect("branch_name required when --pr and --auto-name not provided")
+                .to_string(),
+            None,
+            false,
+        )
+    };
 
     // Use the determined branch name and override base if from PR
     let branch_name = &final_branch_name;
-    let cli_base = if remote_branch_for_pr.is_some() {
-        None
-    } else {
-        base
-    };
+    let cli_base = if pr.is_some() { None } else { base };
     let config_base = initial_config.base_branch.as_deref();
 
     // Validate --with-changes compatibility
@@ -441,8 +435,8 @@ pub fn run(
     // If we have a PR remote branch, use that; otherwise detect from branch_name
     // Only pass CLI --base to detect_remote_branch; config base_branch should not
     // interfere with remote/fork branch detection.
-    let (remote_branch, template_base_name) = if let Some(ref pr_remote) = remote_branch_for_pr {
-        (Some(pr_remote.clone()), branch_name.to_string())
+    let (remote_branch, template_base_name) = if pr.is_some() {
+        (None, branch_name.to_string())
     } else {
         detect_remote_branch(branch_name, cli_base)?
     };

--- a/src/command/dashboard/app/worktrees.rs
+++ b/src/command/dashboard/app/worktrees.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use anyhow::Context as _;
-
 use crate::git;
 use crate::workflow;
 
@@ -1103,27 +1101,8 @@ impl App {
             let result = (|| -> anyhow::Result<String> {
                 std::env::set_current_dir(&repo_path)?;
 
-                // Quiet PR resolution (no println/spinner like resolve_pr_ref)
-                let pr_details = crate::github::get_pr_details(pr_number)
-                    .with_context(|| format!("Failed to fetch PR #{}", pr_number))?;
-
-                let current_repo_owner =
-                    git::get_repo_owner().context("Failed to determine repository owner")?;
-                let is_fork = pr_details.is_fork(&current_repo_owner);
-                let fork_owner = &pr_details.head_repository_owner.login;
-
-                let remote_name = if is_fork {
-                    git::ensure_fork_remote(fork_owner)?
-                } else {
-                    "origin".to_string()
-                };
-
-                let local_branch = if is_fork {
-                    format!("{}-{}", fork_owner, pr_details.head_ref_name)
-                } else {
-                    pr_details.head_ref_name.clone()
-                };
-                let remote_branch = format!("{}/{}", remote_name, pr_details.head_ref_name);
+                let result = workflow::pr::resolve_pr_ref(pr_number, None, true)?;
+                let local_branch = result.local_branch;
 
                 let ctx = workflow::WorkflowContext::new(config.clone(), mux, None)?;
                 let handle = crate::naming::derive_handle(&local_branch, None, &config)?;
@@ -1137,7 +1116,7 @@ impl App {
                         branch_name: &local_branch,
                         handle: &handle,
                         base_branch: None,
-                        remote_branch: Some(&remote_branch),
+                        remote_branch: None,
                         prompt: None,
                         options,
                         agent: None,

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -303,6 +303,32 @@ pub fn get_gone_branches() -> Result<HashSet<String>> {
     Ok(gone)
 }
 
+/// Resolve a ref to its commit SHA.
+pub fn rev_parse(rev: &str) -> Result<String> {
+    Cmd::new("git")
+        .args(&["rev-parse", "--verify", rev])
+        .run_and_capture_stdout()
+        .with_context(|| format!("Failed to resolve ref '{}'", rev))
+}
+
+/// Configure a branch to track a ref on a remote given by URL (no named remote).
+///
+/// Mirrors what `gh pr checkout` does so that `git pull`/`git push` on the
+/// branch talk directly to the PR's head repository.
+pub fn set_branch_tracking_url(branch: &str, remote_url: &str, merge_ref: &str) -> Result<()> {
+    for (key, val) in [
+        (format!("branch.{}.remote", branch), remote_url),
+        (format!("branch.{}.pushRemote", branch), remote_url),
+        (format!("branch.{}.merge", branch), merge_ref),
+    ] {
+        Cmd::new("git")
+            .args(&["config", "--local", &key, val])
+            .run()
+            .with_context(|| format!("Failed to set {}", key))?;
+    }
+    Ok(())
+}
+
 /// Unset the upstream tracking for a branch
 pub fn unset_branch_upstream(branch_name: &str) -> Result<()> {
     if !branch_has_upstream(branch_name)? {

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use git_url_parse::GitUrl;
 use git_url_parse::types::provider::GenericProvider;
 use tracing::info;
@@ -31,6 +31,15 @@ pub fn fetch_remote(remote: &str) -> Result<()> {
         .args(&["fetch", remote])
         .run()
         .with_context(|| format!("Failed to fetch from remote '{}'", remote))?;
+    Ok(())
+}
+
+/// Fetch a specific refspec from a remote name or URL.
+pub fn fetch_refspec(source: &str, refspec: &str) -> Result<()> {
+    Cmd::new("git")
+        .args(&["fetch", source, refspec])
+        .run()
+        .with_context(|| format!("Failed to fetch '{}' from '{}'", refspec, source))?;
     Ok(())
 }
 
@@ -72,14 +81,43 @@ pub fn get_remote_url(remote: &str) -> Result<String> {
         .with_context(|| format!("Failed to get URL for remote '{}'", remote))
 }
 
+/// Find an existing remote whose URL points at `owner` (and `repo_name` if given).
+///
+/// This lets us reuse remotes the user already configured (e.g. `upstream`
+/// pointing at the parent repo) instead of synthesizing a `fork-<owner>` remote
+/// with a guessed URL.
+pub fn find_remote_for(owner: &str, repo_name: Option<&str>) -> Result<Option<String>> {
+    for remote in list_remotes()? {
+        let Ok(url) = get_remote_url(&remote) else {
+            continue;
+        };
+        let Ok(parsed) = GitUrl::parse(&url) else {
+            continue;
+        };
+        let Ok(provider): std::result::Result<GenericProvider, _> = parsed.provider_info() else {
+            continue;
+        };
+        if !provider.owner().eq_ignore_ascii_case(owner) {
+            continue;
+        }
+        if let Some(repo) = repo_name
+            && !provider.repo().eq_ignore_ascii_case(repo)
+        {
+            continue;
+        }
+        return Ok(Some(remote));
+    }
+    Ok(None)
+}
+
 /// Ensure a remote exists for a specific fork owner.
-/// Returns the name of the remote (e.g., "origin" or "fork-username").
-/// If the remote needs to be created, it constructs the URL based on the origin URL's scheme.
-pub fn ensure_fork_remote(fork_owner: &str) -> Result<String> {
-    // If the fork owner is the same as the origin owner, just use origin
-    let current_owner = get_repo_owner().unwrap_or_default();
-    if !current_owner.is_empty() && fork_owner == current_owner {
-        return Ok("origin".to_string());
+/// Returns the name of the remote (e.g., "origin", "upstream", or "fork-username").
+///
+/// `repo_name` overrides the repo name guessed from `origin`, which may differ
+/// from the fork's actual name.
+pub fn ensure_fork_remote(fork_owner: &str, repo_name: Option<&str>) -> Result<String> {
+    if let Some(existing) = find_remote_for(fork_owner, repo_name)? {
+        return Ok(existing);
     }
 
     let remote_name = format!("fork-{}", fork_owner);
@@ -99,7 +137,7 @@ pub fn ensure_fork_remote(fork_owner: &str) -> Result<String> {
     let provider: GenericProvider = parsed_url
         .provider_info()
         .with_context(|| "Failed to extract provider info from origin URL")?;
-    let repo_name = provider.repo();
+    let repo_name = repo_name.unwrap_or_else(|| provider.repo());
 
     let fork_url = match scheme {
         "https" => format!("https://{}/{}/{}.git", host, fork_owner, repo_name),
@@ -125,132 +163,4 @@ pub fn ensure_fork_remote(fork_owner: &str) -> Result<String> {
     }
 
     Ok(remote_name)
-}
-
-/// Parse the repository owner from a git remote URL
-/// Supports both HTTPS and SSH formats for github.com and GitHub Enterprise domains
-fn parse_owner_from_git_url(url: &str) -> Option<&str> {
-    if let Some(https_part) = url
-        .strip_prefix("https://")
-        .or_else(|| url.strip_prefix("http://"))
-    {
-        // HTTPS format: https://github.com/owner/repo.git or https://github.enterprise.com/owner/repo.git
-        https_part.split('/').nth(1)
-    } else if url.starts_with("git@") {
-        // SSH format: git@github.com:owner/repo.git or git@github.enterprise.com:owner/repo.git
-        url.split(':')
-            .nth(1)
-            .and_then(|path| path.split('/').next())
-    } else {
-        None
-    }
-}
-
-/// Get the repository owner from the origin remote URL
-pub fn get_repo_owner() -> Result<String> {
-    let url = get_remote_url("origin")?;
-
-    parse_owner_from_git_url(&url)
-        .ok_or_else(|| anyhow!("Could not parse repository owner from origin URL: {}", url))
-        .map(|s| s.to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::parse_owner_from_git_url;
-
-    #[test]
-    fn test_parse_repo_owner_https_github_com() {
-        assert_eq!(
-            parse_owner_from_git_url("https://github.com/owner/repo.git"),
-            Some("owner")
-        );
-    }
-
-    #[test]
-    fn test_parse_repo_owner_https_github_com_no_git_suffix() {
-        assert_eq!(
-            parse_owner_from_git_url("https://github.com/owner/repo"),
-            Some("owner")
-        );
-    }
-
-    #[test]
-    fn test_parse_repo_owner_http_github_com() {
-        assert_eq!(
-            parse_owner_from_git_url("http://github.com/owner/repo.git"),
-            Some("owner")
-        );
-    }
-
-    #[test]
-    fn test_parse_repo_owner_ssh_github_com() {
-        assert_eq!(
-            parse_owner_from_git_url("git@github.com:owner/repo.git"),
-            Some("owner")
-        );
-    }
-
-    #[test]
-    fn test_parse_repo_owner_ssh_github_com_no_git_suffix() {
-        assert_eq!(
-            parse_owner_from_git_url("git@github.com:owner/repo"),
-            Some("owner")
-        );
-    }
-
-    #[test]
-    fn test_parse_repo_owner_https_github_enterprise() {
-        assert_eq!(
-            parse_owner_from_git_url("https://github.enterprise.com/owner/repo.git"),
-            Some("owner")
-        );
-    }
-
-    #[test]
-    fn test_parse_repo_owner_ssh_github_enterprise() {
-        assert_eq!(
-            parse_owner_from_git_url("git@github.enterprise.net:org/project.git"),
-            Some("org")
-        );
-    }
-
-    #[test]
-    fn test_parse_repo_owner_https_github_enterprise_subdomain() {
-        assert_eq!(
-            parse_owner_from_git_url("https://github.company.internal/team/project.git"),
-            Some("team")
-        );
-    }
-
-    #[test]
-    fn test_parse_repo_owner_with_nested_path() {
-        assert_eq!(
-            parse_owner_from_git_url("https://github.com/owner/repo/subpath"),
-            Some("owner")
-        );
-    }
-
-    #[test]
-    fn test_parse_repo_owner_ssh_with_nested_path() {
-        assert_eq!(
-            parse_owner_from_git_url("git@github.com:owner/repo/subpath"),
-            Some("owner")
-        );
-    }
-
-    #[test]
-    fn test_parse_repo_owner_invalid_format() {
-        assert_eq!(parse_owner_from_git_url("not-a-valid-url"), None);
-    }
-
-    #[test]
-    fn test_parse_repo_owner_local_path() {
-        assert_eq!(parse_owner_from_git_url("/local/path/to/repo"), None);
-    }
-
-    #[test]
-    fn test_parse_repo_owner_file_protocol() {
-        assert_eq!(parse_owner_from_git_url("file:///local/path/to/repo"), None);
-    }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -12,6 +12,11 @@ pub struct PrDetails {
     pub head_ref_name: String,
     #[serde(rename = "headRepositoryOwner")]
     pub head_repository_owner: RepositoryOwner,
+    #[serde(rename = "headRepository")]
+    pub head_repository: Option<Repository>,
+    #[serde(rename = "isCrossRepository")]
+    pub is_cross_repository: bool,
+    pub url: String,
     pub state: String,
     #[serde(rename = "isDraft")]
     pub is_draft: bool,
@@ -25,14 +30,13 @@ pub struct RepositoryOwner {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Author {
-    pub login: String,
+pub struct Repository {
+    pub name: String,
 }
 
-impl PrDetails {
-    pub fn is_fork(&self, current_repo_owner: &str) -> bool {
-        self.head_repository_owner.login != current_repo_owner
-    }
+#[derive(Debug, Deserialize)]
+pub struct Author {
+    pub login: String,
 }
 
 /// Aggregated status of PR checks
@@ -398,7 +402,7 @@ pub fn get_pr_details(pr_number: u32) -> Result<PrDetails> {
             "view",
             &pr_number.to_string(),
             "--json",
-            "headRefName,headRepositoryOwner,state,isDraft,title,author",
+            "headRefName,headRepository,headRepositoryOwner,isCrossRepository,url,state,isDraft,title,author",
         ])
         .output();
 

--- a/src/workflow/pr.rs
+++ b/src/workflow/pr.rs
@@ -45,70 +45,105 @@ fn fork_local_branch_name(owner: &str, branch: &str) -> String {
 /// Result of resolving a PR checkout.
 pub struct PrCheckoutResult {
     pub local_branch: String,
-    pub remote_branch: String,
 }
 
-/// Resolve a PR reference and prepare for checkout.
+/// Parse `owner` and `repo` out of a GitHub PR URL like
+/// `https://github.com/owner/repo/pull/123`.
+fn parse_base_repo_from_pr_url(url: &str) -> Option<(String, String, String)> {
+    let stripped = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let mut parts = stripped.splitn(4, '/');
+    let host = parts.next()?.to_string();
+    let owner = parts.next()?.to_string();
+    let repo = parts.next()?.to_string();
+    Some((host, owner, repo))
+}
+
+/// Resolve a PR reference and prepare a local branch for checkout.
 ///
-/// Fetches PR details, sets up the remote if it's a fork, and returns
-/// the branch information needed to create a worktree.
+/// Mirrors `gh pr checkout`: fetches `refs/pull/<N>/head` from the base repo
+/// into a local branch and points the branch's upstream at the head repo URL.
+/// This avoids creating named remotes and works even when the head branch has
+/// been deleted (merged/closed PRs).
 pub fn resolve_pr_ref(
     pr_number: u32,
     custom_branch_name: Option<&str>,
+    quiet: bool,
 ) -> Result<PrCheckoutResult> {
-    let pr_details = spinner::with_spinner(&format!("Fetching PR #{}", pr_number), || {
-        github::get_pr_details(pr_number)
-    })
+    let fetch_details = || github::get_pr_details(pr_number);
+    let pr_details = if quiet {
+        fetch_details()
+    } else {
+        spinner::with_spinner(&format!("Fetching PR #{}", pr_number), fetch_details)
+    }
     .with_context(|| format!("Failed to fetch details for PR #{}", pr_number))?;
 
-    // Display PR information
-    println!("PR #{}: {}", pr_number, pr_details.title);
-    println!("Author: {}", pr_details.author.login);
-    println!("Branch: {}", pr_details.head_ref_name);
-
-    // Warn about PR state
-    if pr_details.state != "OPEN" {
-        eprintln!(
-            "⚠️  Warning: PR #{} is {}. Proceeding with checkout...",
-            pr_number, pr_details.state
-        );
+    if !quiet {
+        println!("PR #{}: {}", pr_number, pr_details.title);
+        println!("Author: {}", pr_details.author.login);
+        println!("Branch: {}", pr_details.head_ref_name);
+        if pr_details.state != "OPEN" {
+            eprintln!(
+                "⚠️  Warning: PR #{} is {}. Proceeding with checkout...",
+                pr_number, pr_details.state
+            );
+        }
+        if pr_details.is_draft {
+            eprintln!("⚠️  Warning: PR #{} is a DRAFT.", pr_number);
+        }
     }
-    if pr_details.is_draft {
-        eprintln!("⚠️  Warning: PR #{} is a DRAFT.", pr_number);
-    }
 
-    // Determine if this is a fork PR and ensure remote exists
-    let current_repo_owner =
-        git::get_repo_owner().context("Failed to determine repository owner from origin remote")?;
+    let head_owner = &pr_details.head_repository_owner.login;
+    let is_fork = pr_details.is_cross_repository;
 
-    let is_fork = pr_details.is_fork(&current_repo_owner);
-    let fork_owner = &pr_details.head_repository_owner.login;
-
-    let remote_name = if is_fork {
-        git::ensure_fork_remote(fork_owner)?
-    } else {
-        "origin".to_string()
-    };
-
-    // Determine local branch name.
-    // For fork PRs, prefix with the fork owner to avoid conflicts with common
-    // branch names like "main", matching resolve_fork_branch behavior.
+    // Prefix cross-repo PRs with head owner to avoid colliding with e.g. "main".
     let local_branch = custom_branch_name.map(String::from).unwrap_or_else(|| {
         if is_fork {
-            fork_local_branch_name(fork_owner, &pr_details.head_ref_name)
+            fork_local_branch_name(head_owner, &pr_details.head_ref_name)
         } else {
             pr_details.head_ref_name.clone()
         }
     });
 
-    // Note: We do not fetch here. The `create` workflow handles fetching
-    // the remote branch to ensure the worktree base is up to date.
-    let remote_branch = format!("{}/{}", remote_name, pr_details.head_ref_name);
+    // Don't clobber an existing local branch; create() will attach a worktree.
+    if git::branch_exists(&local_branch)? {
+        return Ok(PrCheckoutResult { local_branch });
+    }
 
-    Ok(PrCheckoutResult {
-        local_branch,
-        remote_branch,
-    })
+    // Pull refs live on the base repo, not the fork.
+    let (host, base_owner, base_repo) = parse_base_repo_from_pr_url(&pr_details.url)
+        .with_context(|| format!("Could not parse base repo from PR URL '{}'", pr_details.url))?;
+
+    let fetch_source = git::find_remote_for(&base_owner, Some(&base_repo))?
+        .unwrap_or_else(|| format!("https://{}/{}/{}.git", host, base_owner, base_repo));
+
+    let refspec = format!("refs/pull/{}/head:refs/heads/{}", pr_number, local_branch);
+    let do_fetch = || git::fetch_refspec(&fetch_source, &refspec);
+    if quiet {
+        do_fetch()
+    } else {
+        spinner::with_spinner(&format!("Fetching pull/{}/head", pr_number), do_fetch)
+    }
+    .with_context(|| format!("Failed to fetch PR #{} from '{}'", pr_number, fetch_source))?;
+
+    // Record the fetched commit as workmux-base so removal's unmerged check
+    // only flags commits the user adds on top, not the PR's own commits.
+    if let Ok(sha) = git::rev_parse(&format!("refs/heads/{}", local_branch)) {
+        let _ = git::set_branch_base(&local_branch, &sha);
+    }
+
+    // Track the head repo URL so `git pull`/`git push` work without a named remote.
+    if let Some(head_repo) = &pr_details.head_repository {
+        let head_url = format!("git@{}:{}/{}.git", host, head_owner, head_repo.name);
+        git::set_branch_tracking_url(
+            &local_branch,
+            &head_url,
+            &format!("refs/heads/{}", pr_details.head_ref_name),
+        )?;
+    }
+
+    Ok(PrCheckoutResult { local_branch })
 }
 
 /// Result of resolving a fork branch.
@@ -134,7 +169,7 @@ pub fn resolve_fork_branch(fork_spec: &git::ForkBranchSpec) -> Result<ForkBranch
     }
 
     // Ensure the fork remote exists
-    let remote_name = git::ensure_fork_remote(&fork_spec.owner)?;
+    let remote_name = git::ensure_fork_remote(&fork_spec.owner, None)?;
 
     // Note: We do not fetch or verify the branch exists here.
     // The `create` workflow will perform the fetch and fail if the branch is missing.

--- a/tests/test_workmux_pr.py
+++ b/tests/test_workmux_pr.py
@@ -14,18 +14,46 @@ from .conftest import (
 )
 
 
+GITHUB_URL = "https://github.com/testowner/testrepo.git"
+PR_URL_BASE = "https://github.com/testowner/testrepo/pull"
+
+
+def same_repo_pr_data(
+    pr_number: int,
+    head_ref: str,
+    *,
+    title: str = "Add new feature",
+    state: str = "OPEN",
+    is_draft: bool = False,
+) -> dict:
+    """PR JSON for a same-repo (non-fork) PR against testowner/testrepo."""
+    return {
+        "headRefName": head_ref,
+        "headRepositoryOwner": {"login": "testowner"},
+        "headRepository": {"name": "testrepo"},
+        "isCrossRepository": False,
+        "url": f"{PR_URL_BASE}/{pr_number}",
+        "state": state,
+        "isDraft": is_draft,
+        "title": title,
+        "author": {"login": "contributor"},
+    }
+
+
 def setup_pr_remote_and_branch(
     env: MuxEnvironment,
     repo_path: Path,
     remote_repo_path: Path,
     branch_name: str,
+    pr_number: int,
 ):
-    """Helper to set up a fetchable remote with a PR branch"""
-    # Use a fake GitHub URL for the remote so get_repo_owner() can parse it
-    github_url = "https://github.com/testowner/testrepo.git"
+    """Set up a fetchable origin and publish a PR head as refs/pull/<n>/head.
 
+    workmux fetches PRs via the GitHub-style pull ref rather than the head
+    branch, so the bare remote must expose that ref.
+    """
     env.run_command(
-        ["git", "remote", "add", "origin", github_url],
+        ["git", "remote", "add", "origin", GITHUB_URL],
         cwd=repo_path,
     )
     # Set pushurl to the local path so git operations actually work
@@ -35,18 +63,23 @@ def setup_pr_remote_and_branch(
     )
     # Also need to configure insteadOf for fetch operations
     env.run_command(
-        ["git", "config", f"url.{remote_repo_path}.insteadOf", github_url],
+        ["git", "config", f"url.{remote_repo_path}.insteadOf", GITHUB_URL],
         cwd=repo_path,
     )
     env.run_command(["git", "push", "-u", "origin", "main"], cwd=repo_path)
 
-    # Create and push the PR branch
+    # Create the PR head commit and publish it as refs/pull/<n>/head on the
+    # remote. We do not push the branch itself, mirroring the case where the
+    # head branch was deleted after merge.
     env.run_command(["git", "checkout", "-b", branch_name], cwd=repo_path)
     env.run_command(
         ["git", "commit", "--allow-empty", "-m", "PR changes"],
         cwd=repo_path,
     )
-    env.run_command(["git", "push", "-u", "origin", branch_name], cwd=repo_path)
+    env.run_command(
+        ["git", "push", "origin", f"HEAD:refs/pull/{pr_number}/head"],
+        cwd=repo_path,
+    )
     env.run_command(["git", "checkout", "main"], cwd=repo_path)
     # Delete the local branch so workmux can create it fresh (matching gh pr checkout behavior)
     env.run_command(["git", "branch", "-D", branch_name], cwd=repo_path)
@@ -58,16 +91,9 @@ def test_add_pr_from_same_repo(mux_server, workmux_exe_path, remote_repo_path):
     repo_path = env.tmp_path
     setup_git_repo(repo_path, env.env)
 
-    setup_pr_remote_and_branch(env, repo_path, remote_repo_path, "feature-branch")
+    setup_pr_remote_and_branch(env, repo_path, remote_repo_path, "feature-branch", 123)
 
-    pr_data = {
-        "headRefName": "feature-branch",
-        "headRepositoryOwner": {"login": "testowner"},
-        "state": "OPEN",
-        "isDraft": False,
-        "title": "Add new feature",
-        "author": {"login": "contributor"},
-    }
+    pr_data = same_repo_pr_data(123, "feature-branch")
     install_fake_gh_cli(env, pr_number=123, json_response=pr_data)
 
     result = run_workmux_command(env, workmux_exe_path, repo_path, "add --pr 123")
@@ -90,16 +116,9 @@ def test_add_pr_with_custom_branch_name(mux_server, workmux_exe_path, remote_rep
     repo_path = env.tmp_path
     setup_git_repo(repo_path, env.env)
 
-    setup_pr_remote_and_branch(env, repo_path, remote_repo_path, "feature-branch")
+    setup_pr_remote_and_branch(env, repo_path, remote_repo_path, "feature-branch", 123)
 
-    pr_data = {
-        "headRefName": "feature-branch",
-        "headRepositoryOwner": {"login": "testowner"},
-        "state": "OPEN",
-        "isDraft": False,
-        "title": "Add new feature",
-        "author": {"login": "contributor"},
-    }
+    pr_data = same_repo_pr_data(123, "feature-branch")
     install_fake_gh_cli(env, pr_number=123, json_response=pr_data)
 
     result = run_workmux_command(
@@ -122,16 +141,11 @@ def test_add_pr_merged_state_warning(mux_server, workmux_exe_path, remote_repo_p
     repo_path = env.tmp_path
     setup_git_repo(repo_path, env.env)
 
-    setup_pr_remote_and_branch(env, repo_path, remote_repo_path, "merged-branch")
+    setup_pr_remote_and_branch(env, repo_path, remote_repo_path, "merged-branch", 456)
 
-    pr_data = {
-        "headRefName": "merged-branch",
-        "headRepositoryOwner": {"login": "testowner"},
-        "state": "MERGED",
-        "isDraft": False,
-        "title": "Already merged PR",
-        "author": {"login": "contributor"},
-    }
+    pr_data = same_repo_pr_data(
+        456, "merged-branch", title="Already merged PR", state="MERGED"
+    )
     install_fake_gh_cli(env, pr_number=456, json_response=pr_data)
 
     result = run_workmux_command(env, workmux_exe_path, repo_path, "add --pr 456")
@@ -149,16 +163,11 @@ def test_add_pr_draft_warning(mux_server, workmux_exe_path, remote_repo_path):
     repo_path = env.tmp_path
     setup_git_repo(repo_path, env.env)
 
-    setup_pr_remote_and_branch(env, repo_path, remote_repo_path, "draft-branch")
+    setup_pr_remote_and_branch(env, repo_path, remote_repo_path, "draft-branch", 789)
 
-    pr_data = {
-        "headRefName": "draft-branch",
-        "headRepositoryOwner": {"login": "testowner"},
-        "state": "OPEN",
-        "isDraft": True,
-        "title": "WIP: Work in progress",
-        "author": {"login": "contributor"},
-    }
+    pr_data = same_repo_pr_data(
+        789, "draft-branch", title="WIP: Work in progress", is_draft=True
+    )
     install_fake_gh_cli(env, pr_number=789, json_response=pr_data)
 
     result = run_workmux_command(env, workmux_exe_path, repo_path, "add --pr 789")
@@ -246,57 +255,22 @@ def test_add_pr_conflicts_with_base_flag(
 
 
 def test_add_pr_fork_with_main_branch(mux_server, workmux_exe_path, remote_repo_path):
-    """Test that fork PRs with branch 'main' get prefixed with owner to avoid conflict"""
+    """Cross-repo PR with head branch 'main' is fetched via pull ref and
+    checked out under an owner-prefixed name to avoid clobbering local main."""
     env = mux_server
     repo_path = env.tmp_path
     setup_git_repo(repo_path, env.env)
 
-    # Set up origin with a GitHub-style URL
-    github_url = "https://github.com/testowner/testrepo.git"
-    env.run_command(
-        ["git", "remote", "add", "origin", github_url],
-        cwd=repo_path,
-    )
-    env.run_command(
-        ["git", "remote", "set-url", "--push", "origin", str(remote_repo_path)],
-        cwd=repo_path,
-    )
-    env.run_command(
-        ["git", "config", f"url.{remote_repo_path}.insteadOf", github_url],
-        cwd=repo_path,
-    )
-    env.run_command(["git", "push", "-u", "origin", "main"], cwd=repo_path)
+    # Origin = base repo. Publish the fork's commit as refs/pull/16/head there;
+    # workmux never needs to talk to the fork directly.
+    setup_pr_remote_and_branch(env, repo_path, remote_repo_path, "fork-work", 16)
 
-    # Create a separate "fork" bare repo that has a "main" branch with a commit
-    fork_repo_path = repo_path.parent / "fork_repo.git"
-    env.run_command(
-        ["git", "clone", "--bare", str(remote_repo_path), str(fork_repo_path)]
-    )
-
-    # Create a commit on main in the fork (via a temp checkout)
-    fork_work = repo_path.parent / "fork_work"
-    env.run_command(
-        ["git", "clone", str(fork_repo_path), str(fork_work)], cwd=repo_path
-    )
-    env.run_command(["git", "config", "user.name", "Fork User"], cwd=fork_work)
-    env.run_command(["git", "config", "user.email", "fork@example.com"], cwd=fork_work)
-    env.run_command(
-        ["git", "commit", "--allow-empty", "-m", "Fork PR changes"],
-        cwd=fork_work,
-    )
-    env.run_command(["git", "push", "origin", "main"], cwd=fork_work)
-
-    # Map the fork URL that ensure_fork_remote will construct
-    fork_github_url = "https://github.com/forkowner/testrepo.git"
-    env.run_command(
-        ["git", "config", f"url.{fork_repo_path}.insteadOf", fork_github_url],
-        cwd=repo_path,
-    )
-
-    # PR data: fork PR where head branch is "main" from a different owner
     pr_data = {
         "headRefName": "main",
         "headRepositoryOwner": {"login": "forkowner"},
+        "headRepository": {"name": "testrepo"},
+        "isCrossRepository": True,
+        "url": f"{PR_URL_BASE}/16",
         "state": "OPEN",
         "isDraft": False,
         "title": "Use ANSI palette colors",
@@ -320,6 +294,12 @@ def test_add_pr_fork_with_main_branch(mux_server, workmux_exe_path, remote_repo_
     windows = env.list_windows()
     assert window_name in windows
 
+    # Upstream tracking should point at the fork's URL so push/pull target it.
+    remote = env.run_command(
+        ["git", "config", "branch.forkowner-main.remote"], cwd=repo_path
+    ).stdout.strip()
+    assert remote == "git@github.com:forkowner/testrepo.git"
+
 
 def test_add_pr_fails_when_worktree_exists(
     mux_server, workmux_exe_path, remote_repo_path
@@ -329,16 +309,9 @@ def test_add_pr_fails_when_worktree_exists(
     repo_path = env.tmp_path
     setup_git_repo(repo_path, env.env)
 
-    setup_pr_remote_and_branch(env, repo_path, remote_repo_path, "feature-branch")
+    setup_pr_remote_and_branch(env, repo_path, remote_repo_path, "feature-branch", 123)
 
-    pr_data = {
-        "headRefName": "feature-branch",
-        "headRepositoryOwner": {"login": "testowner"},
-        "state": "OPEN",
-        "isDraft": False,
-        "title": "Add new feature",
-        "author": {"login": "contributor"},
-    }
+    pr_data = same_repo_pr_data(123, "feature-branch")
     install_fake_gh_cli(env, pr_number=123, json_response=pr_data)
 
     # First checkout should succeed


### PR DESCRIPTION
less code and less state...

Deriving a `fork-<owner>` remote from the local `origin` URL produced bogus URLs when origin's repo name differs from upstream (e.g. `Mic92/nix-1` → `NixOS/nix-1.git`), and failed for merged PRs whose head branch was deleted.

Do what `gh pr checkout` does: fetch `refs/pull/<N>/head` from the base repo into a local branch and point its upstream at the head repo URL, so `git pull`/`git push` work without a named remote.
