### PR TITLE
Fix: sanitize container name for paths with spaces

### DIFF
--- a/src/command/sandbox_run.rs
+++ b/src/command/sandbox_run.rs
@@ -349,13 +349,15 @@ fn run_container(
 
     // Generate container name from worktree directory name so cleanup can find it.
     // Include PID to allow multiple agents in the same worktree (e.g., open -n).
-    let handle = slug::slugify(
-        worktree_root
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("unknown"),
-    );
-    let container_name = format!("wm-{}-{}", handle, std::process::id());
+    let handle = worktree_root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+    // Slugify only the container name; the raw handle is used as the state store key
+    // so cleanup (which derives the handle from the directory name without slugifying)
+    // can find it.
+    let container_name = format!("wm-{}-{}", slug::slugify(&handle), std::process::id());
 
     // Register container in state store so cleanup can find it without docker ps
     if let Ok(store) = StateStore::new()

--- a/src/command/sandbox_run.rs
+++ b/src/command/sandbox_run.rs
@@ -349,11 +349,12 @@ fn run_container(
 
     // Generate container name from worktree directory name so cleanup can find it.
     // Include PID to allow multiple agents in the same worktree (e.g., open -n).
-    let handle = worktree_root
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("unknown")
-        .to_string();
+    let handle = slug::slugify(
+        worktree_root
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown"),
+    );
     let container_name = format!("wm-{}-{}", handle, std::process::id());
 
     // Register container in state store so cleanup can find it without docker ps


### PR DESCRIPTION
## Summary

- `workmux sandbox run '/path/AI Enablement'` fails because Docker rejects the container name `wm-AI Enablement-12345` (spaces not allowed in container names)
- Fix: apply `slug::slugify()` (already a dependency) to the directory basename before building the container name
- `AI Enablement` → `ai-enablement` → `wm-ai-enablement-12345`

## Change

One-line change in `src/command/sandbox_run.rs` — wraps the existing `file_name()` extraction in `slug::slugify()`.

## Test plan

- [x] `cargo build --release` succeeds
- [x] `workmux sandbox run '/path/with spaces/' -- echo test` no longer fails with "Invalid container name"
- [x] Paths without spaces are unaffected (slugify is a no-op on clean names)