### PR TITLE
fix(pi): remove session_shutdown status update

### DIFF
--- a/.pi/extensions/workmux-status.ts
+++ b/.pi/extensions/workmux-status.ts
@@ -19,8 +19,4 @@ export default function (pi: ExtensionAPI) {
   pi.on("agent_end", async () => {
     setStatus("done");
   });
-
-  pi.on("session_shutdown", async () => {
-    setStatus("done");
-  });
 }


### PR DESCRIPTION
Fixes #143

## Summary

The pi extension's `session_shutdown` handler calls `workmux set-window-status done` without awaiting the subprocess. Pi exits before workmux reads `pane_current_command`, so the state file ends up with `command: "zsh"` (or whatever the user's shel is). Reconciliation in `load_reconciled_agents` then matches live `zsh` against stored `zsh`, never removes the agent, and the dashboard shows a stale "ghost" entry indefinitely.

## Fix

Remove the `session_shutdown` handler. Reconciliation observes the shell takeover on its own on the next dashboard tick, matching how Claude Code is handled (no shutdown hook in its plugin either).

`agent_end` already sets status to "done" while pi is still the foreground process, so the dashboard icon remains correct before shutdown.

## Changes

- `.pi/extensions/workmux-status.ts`: drop the `session_shutdown` handler. `agent_start` and `agent_end` are unchanged.

## Verification

- Simulated the race in isolation: state file written with `"command": "zsh"`; two consecutive `workmux list` calls keep the entry. Patching the same file to `"command": "node"` (the post-fix value) and re-reconciling removes it, confirming the command-mismatch branch works as intended.
- End-to-end with real pi: with the handler removed, the dashboard clears the agent within one reconcile tick of `/quit`.

Issue #143 has the full step-by-step root cause analysis.