### PR TITLE
Show agent identity badges in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ description: Release notes and version history for workmux
 
 # Changelog
 
+## Unreleased
+
+- Add optional agent identity badges to the tmux sidebar, configurable with
+  `sidebar.agent_identity` and `sidebar.agent_icons`
+
 ## v0.1.189 (2026-04-27)
 
 - Fix pi agents lingering in the dashboard after exit ([#143](https://github.com/raine/workmux/issues/143))

--- a/README.md
+++ b/README.md
@@ -1686,6 +1686,7 @@ workmux sidebar --session  # Toggle sidebar for current session only
 The sidebar displays:
 
 - Status icon (working/waiting/done with spinner animation)
+- Optional agent identity badge (Claude, Codex, OpenCode, Gemini, etc.)
 - Project and worktree name (e.g. `myproject/fix-bug`)
 - Elapsed time since last status change
 
@@ -1703,6 +1704,11 @@ Configure width and layout in `.workmux.yaml`:
 sidebar:
   width: 40 # absolute columns, or "15%" for percentage
   layout: tiles # "compact" or "tiles" (default)
+  agent_identity: both # "off" (default), "icon", "label", or "both"
+  agent_icons:
+    claude: "✳"
+    codex: "CX"
+    opencode: "OC"
 ```
 
 #### Example tmux binding

--- a/docs/guide/dashboard/sidebar.md
+++ b/docs/guide/dashboard/sidebar.md
@@ -41,6 +41,7 @@ bind C-t run-shell "workmux sidebar"
 Each agent is displayed as a tile showing:
 
 - Status icon with spinner animation (working/waiting/done)
+- Optional agent identity badge (Claude, Codex, OpenCode, Gemini, etc.)
 - Worktree name and elapsed time since last status change
 - Project name and git diff stats (committed + uncommitted lines)
 - Agent task description
@@ -58,10 +59,24 @@ sidebar:
 
   # Layout mode: "compact" or "tiles" (default)
   layout: tiles
+
+  # Agent identity badge: "off" (default), "icon", "label", or "both"
+  agent_identity: both
+
+  # Optional custom identity icons
+  agent_icons:
+    claude: "✳"
+    codex: "CX"
+    opencode: "OC"
 ```
 
 Width defaults to 10% of terminal width, clamped between 25 and 50 columns.
 When set explicitly, the clamp is removed (minimum 10 columns).
+
+Agent identity badges are detected from the command recorded by status tracking.
+The sidebar currently recognizes Claude, Codex, OpenCode, Gemini, Copilot, Pi,
+Kiro, and Vibe agents. When space is tight, the sidebar preserves the worktree
+name first and hides or shortens the identity badge.
 
 ## Layout modes
 

--- a/docs/reference/commands/sidebar.md
+++ b/docs/reference/commands/sidebar.md
@@ -18,6 +18,7 @@ workmux sidebar --session  # Toggle sidebar for current session only
 Each agent row displays:
 
 - Status icon (working/waiting/done with spinner animation)
+- Optional agent identity badge (Claude, Codex, OpenCode, Gemini, etc.)
 - Project and worktree name (e.g. `myproject/fix-bug`)
 - Elapsed time since last status change
 
@@ -68,11 +69,20 @@ sidebar:
   width: 40 # absolute columns (default: "10%", clamped 25-50)
   # width: "15%"  # or percentage of terminal width
   layout: tiles # "compact" or "tiles" (default)
+  agent_identity: both # "off" (default), "icon", "label", or "both"
+  agent_icons:
+    claude: "✳"
+    codex: "CX"
+    opencode: "OC"
 ```
 
 Explicit width values bypass the default 25-50 column clamp (minimum 10
 columns). Layout preference can also be toggled at runtime with `v` and is
 persisted across restarts.
+
+Agent identity badges are detected from the command recorded by status tracking.
+If the sidebar is too narrow, worktree names take priority and the identity badge
+is hidden or shortened.
 
 ## How it works
 

--- a/src/agent_identity.rs
+++ b/src/agent_identity.rs
@@ -1,0 +1,153 @@
+//! Agent identity detection for display surfaces.
+
+use std::path::Path;
+
+/// Supported agent identities for compact UI display.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentKind {
+    Claude,
+    Codex,
+    OpenCode,
+    Gemini,
+    Copilot,
+    Pi,
+    KiroCli,
+    Vibe,
+    Unknown,
+}
+
+impl AgentKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Claude => "Claude",
+            Self::Codex => "Codex",
+            Self::OpenCode => "OpenCode",
+            Self::Gemini => "Gemini",
+            Self::Copilot => "Copilot",
+            Self::Pi => "Pi",
+            Self::KiroCli => "Kiro",
+            Self::Vibe => "Vibe",
+            Self::Unknown => "Agent",
+        }
+    }
+
+    pub fn default_icon(self) -> &'static str {
+        match self {
+            Self::Claude => "✳",
+            Self::Codex => "CX",
+            Self::OpenCode => "OC",
+            Self::Gemini => "◆",
+            Self::Copilot => "CP",
+            Self::Pi => "π",
+            Self::KiroCli => "K",
+            Self::Vibe => "V",
+            Self::Unknown => "?",
+        }
+    }
+}
+
+/// Classify an agent from the stored command string.
+pub fn classify_agent_command(command: Option<&str>) -> Option<AgentKind> {
+    let command = command?.trim();
+    if command.is_empty() {
+        return None;
+    }
+
+    let argv = shlex::split(command)
+        .filter(|parts| !parts.is_empty())
+        .unwrap_or_else(|| {
+            command
+                .split_whitespace()
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        });
+
+    let executable = argv
+        .first()
+        .map(|arg| executable_name(arg))
+        .unwrap_or_default();
+    let executable = normalize(&executable);
+    let command_lower = command.to_ascii_lowercase();
+
+    if matches_agent(&executable, &command_lower, &["claude", "claude-code"]) {
+        Some(AgentKind::Claude)
+    } else if matches_agent(&executable, &command_lower, &["codex"]) {
+        Some(AgentKind::Codex)
+    } else if matches_agent(&executable, &command_lower, &["opencode", "opencode-ai"]) {
+        Some(AgentKind::OpenCode)
+    } else if matches_agent(&executable, &command_lower, &["gemini"]) {
+        Some(AgentKind::Gemini)
+    } else if matches_agent(&executable, &command_lower, &["copilot", "github-copilot"]) {
+        Some(AgentKind::Copilot)
+    } else if executable == "pi" {
+        Some(AgentKind::Pi)
+    } else if matches_agent(&executable, &command_lower, &["kiro-cli", "kiro"]) {
+        Some(AgentKind::KiroCli)
+    } else if executable == "vibe" {
+        Some(AgentKind::Vibe)
+    } else {
+        Some(AgentKind::Unknown)
+    }
+}
+
+fn executable_name(arg: &str) -> String {
+    let path = Path::new(arg);
+    path.file_stem()
+        .or_else(|| path.file_name())
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| arg.to_string())
+}
+
+fn normalize(value: &str) -> String {
+    value
+        .trim()
+        .trim_start_matches('.')
+        .to_ascii_lowercase()
+        .replace('_', "-")
+}
+
+fn matches_agent(executable: &str, command: &str, names: &[&str]) -> bool {
+    names
+        .iter()
+        .any(|name| executable == *name || command.contains(name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AgentKind, classify_agent_command};
+
+    #[test]
+    fn classifies_known_agent_commands() {
+        assert_eq!(
+            classify_agent_command(Some("claude --dangerously-skip-permissions")),
+            Some(AgentKind::Claude)
+        );
+        assert_eq!(
+            classify_agent_command(Some("/opt/homebrew/bin/codex exec")),
+            Some(AgentKind::Codex)
+        );
+        assert_eq!(
+            classify_agent_command(Some("opencode run")),
+            Some(AgentKind::OpenCode)
+        );
+        assert_eq!(
+            classify_agent_command(Some("gemini -m gemini-2.5-flash-lite")),
+            Some(AgentKind::Gemini)
+        );
+        assert_eq!(
+            classify_agent_command(Some("kiro-cli chat --no-interactive")),
+            Some(AgentKind::KiroCli)
+        );
+        assert_eq!(classify_agent_command(Some("pi")), Some(AgentKind::Pi));
+    }
+
+    #[test]
+    fn handles_empty_and_unknown_commands() {
+        assert_eq!(classify_agent_command(None), None);
+        assert_eq!(classify_agent_command(Some("   ")), None);
+        assert_eq!(
+            classify_agent_command(Some("custom-agent --flag")),
+            Some(AgentKind::Unknown)
+        );
+    }
+}

--- a/src/command/sidebar/app.rs
+++ b/src/command/sidebar/app.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use crate::agent_display::{extract_project_name, extract_worktree_name};
 use crate::cmd::Cmd;
-use crate::config::{Config, StatusIcons};
+use crate::config::{AgentIcons, AgentIdentityDisplay, Config, StatusIcons};
 use crate::git::GitStatus;
 
 use crate::multiplexer::{AgentPane, Multiplexer};
@@ -53,6 +53,8 @@ pub struct SidebarApp {
     pub quit_reason: Option<String>,
     pub palette: ThemePalette,
     pub status_icons: StatusIcons,
+    pub agent_identity: AgentIdentityDisplay,
+    pub agent_icons: AgentIcons,
     pub spinner_frame: u8,
     pub stale_threshold_secs: u64,
     pub layout_mode: SidebarLayoutMode,
@@ -92,6 +94,8 @@ impl SidebarApp {
         let palette = ThemePalette::from_config(&config.theme, theme_mode);
         let window_prefix = config.window_prefix().to_string();
         let status_icons = config.status_icons.clone();
+        let agent_identity = config.sidebar.agent_identity.unwrap_or_default();
+        let agent_icons = config.sidebar.agent_icons.clone();
 
         let (host_session, host_window_id) = detect_host_window();
 
@@ -103,6 +107,8 @@ impl SidebarApp {
             quit_reason: None,
             palette,
             status_icons,
+            agent_identity,
+            agent_icons,
             spinner_frame: 0,
             stale_threshold_secs: 60 * 60, // 60 minutes
             layout_mode: SidebarLayoutMode::default(),

--- a/src/command/sidebar/daemon.rs
+++ b/src/command/sidebar/daemon.rs
@@ -1315,6 +1315,7 @@ mod tests {
             window_id: String::new(),
             path: PathBuf::new(),
             pane_title: None,
+            agent_command: Some("claude".to_string()),
             status: Some(AgentStatus::Working),
             status_ts: Some(100),
             updated_ts: Some(updated_ts),

--- a/src/command/sidebar/ui.rs
+++ b/src/command/sidebar/ui.rs
@@ -10,6 +10,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use unicode_width::UnicodeWidthChar;
 
 use crate::agent_display::{extract_project_name, extract_worktree_name, strip_oc_title_prefix};
+use crate::agent_identity::classify_agent_command;
+use crate::config::AgentIdentityDisplay;
 use crate::git::GitStatus;
 use crate::multiplexer::{AgentPane, AgentStatus};
 use crate::tmux_style;
@@ -251,11 +253,24 @@ fn render_compact_list(f: &mut Frame, app: &mut SidebarApp, area: Rect) {
                 String::new()
             };
 
-            // Calculate available width for the name
-            // Layout: "{icon}{pad} {name} {elapsed}"
+            // Calculate available width for the name.
+            // Layout: "{icon}{pad} {identity} {name} {elapsed}"
             let elapsed_width = elapsed.len();
-            // Reserve: 2 (icon slot) + 1 (space) + 1 (space) + elapsed
-            let reserved = 2 + 1 + 1 + elapsed_width;
+            let base_reserved = 2 + 1 + 1 + elapsed_width;
+            let min_name_width = 8.min(display_width(&worktree_name));
+            let identity_max_width = (area.width as usize)
+                .saturating_sub(base_reserved)
+                .saturating_sub(min_name_width)
+                .saturating_sub(1);
+            let identity = agent_identity_text(app, agent, identity_max_width);
+            let identity_width = display_width(&identity);
+            let identity_reserved = if identity.is_empty() {
+                0
+            } else {
+                identity_width + 1
+            };
+            // Reserve: base + optional identity + separating space
+            let reserved = base_reserved + identity_reserved;
             let name_width = (area.width as usize).saturating_sub(reserved);
 
             let display_name = truncate_to_width(&worktree_name, name_width);
@@ -285,9 +300,12 @@ fn render_compact_list(f: &mut Frame, app: &mut SidebarApp, area: Rect) {
                 .into_iter()
                 .map(|(text, style)| Span::styled(text, style))
                 .collect();
+            line_spans.extend([Span::raw(icon_pad), Span::raw(" ")]);
+            if !identity.is_empty() {
+                line_spans.push(Span::styled(identity, identity_style(app, is_stale)));
+                line_spans.push(Span::raw(" "));
+            }
             line_spans.extend([
-                Span::raw(icon_pad),
-                Span::raw(" "),
                 Span::styled(display_name, name_style),
                 Span::raw(" ".repeat(padding)),
                 Span::raw(" "),
@@ -389,9 +407,23 @@ fn render_tile_list(f: &mut Frame, app: &mut SidebarApp, area: Rect) {
                 String::new()
             };
 
-            // Line 1 content width: area - stripe(2) - icon(2+pad) - space(1) - space(1) - elapsed - space(1)
+            // Line 1 content width:
+            // area - stripe(2) - icon slot(2) - spaces - optional identity - elapsed.
+            let base_line1_reserved = 2 + 2 + 1 + 1 + 1 + elapsed.len();
+            let min_name_width = 8.min(display_width(&display_worktree));
+            let identity_max_width = (area.width as usize)
+                .saturating_sub(base_line1_reserved)
+                .saturating_sub(min_name_width)
+                .saturating_sub(1);
+            let identity = agent_identity_text(app, agent, identity_max_width);
+            let identity_width = display_width(&identity);
+            let identity_reserved = if identity.is_empty() {
+                0
+            } else {
+                identity_width + 1
+            };
             let line1_name_width =
-                (area.width as usize).saturating_sub(2 + 2 + 1 + 1 + 1 + elapsed.len());
+                (area.width as usize).saturating_sub(base_line1_reserved + identity_reserved);
             // Body lines indent to align with worktree name: icon(2) + gap(1) = 3
             let body_indent = "   ";
             let body_width = (area.width as usize).saturating_sub(2 + body_indent.len());
@@ -476,6 +508,7 @@ fn render_tile_list(f: &mut Frame, app: &mut SidebarApp, area: Rect) {
                 + icon_cols
                 + (2usize.saturating_sub(icon_cols))
                 + 1
+                + identity_reserved
                 + full_width
                 + name_padding
                 + 1
@@ -499,6 +532,16 @@ fn render_tile_list(f: &mut Frame, app: &mut SidebarApp, area: Rect) {
             line1_spans.extend([
                 Span::styled(icon_pad, pad_style),
                 Span::styled(" ", pad_style),
+            ]);
+            if !identity.is_empty() {
+                let mut identity_style = identity_style(app, is_stale);
+                if let Some(bg_color) = bg {
+                    identity_style = identity_style.bg(bg_color);
+                }
+                line1_spans.push(Span::styled(identity, identity_style));
+                line1_spans.push(Span::styled(" ", pad_style));
+            }
+            line1_spans.extend([
                 Span::styled(display_name_part, name_style),
                 Span::styled(display_suffix_part, suffix_style),
                 Span::styled(" ".repeat(name_padding), pad_style),
@@ -609,6 +652,60 @@ fn render_tile_list(f: &mut Frame, app: &mut SidebarApp, area: Rect) {
     let list = List::new(items);
 
     f.render_stateful_widget(list, area, &mut app.list_state);
+}
+
+/// Build the agent identity badge text for the configured display mode.
+fn agent_identity_text(app: &SidebarApp, agent: &AgentPane, max_width: usize) -> String {
+    if max_width == 0 || app.agent_identity == AgentIdentityDisplay::Off {
+        return String::new();
+    }
+
+    let Some(kind) = classify_agent_command(agent.agent_command.as_deref()) else {
+        return String::new();
+    };
+
+    let icon = app.agent_icons.icon_for(kind);
+    let label = kind.label();
+
+    choose_identity_text(app.agent_identity, icon, label, max_width)
+}
+
+fn choose_identity_text(
+    mode: AgentIdentityDisplay,
+    icon: &str,
+    label: &str,
+    max_width: usize,
+) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+
+    let candidates: Vec<String> = match mode {
+        AgentIdentityDisplay::Off => return String::new(),
+        AgentIdentityDisplay::Icon => vec![icon.to_string()],
+        AgentIdentityDisplay::Label => vec![label.to_string()],
+        AgentIdentityDisplay::Both => vec![
+            format!("{} {}", icon, label),
+            icon.to_string(),
+            label.to_string(),
+        ],
+    };
+
+    candidates
+        .iter()
+        .find(|candidate| display_width(candidate) <= max_width)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn identity_style(app: &SidebarApp, is_stale: bool) -> Style {
+    if is_stale {
+        Style::default()
+            .fg(app.palette.dimmed)
+            .add_modifier(Modifier::DIM)
+    } else {
+        Style::default().fg(app.palette.accent)
+    }
 }
 
 /// Get the status icon as parsed styled spans and the base style for an agent.
@@ -780,8 +877,9 @@ fn truncate_with_ellipsis(s: &str, max_width: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::sanitize_pane_title;
+    use super::{choose_identity_text, sanitize_pane_title};
     use crate::agent_display::strip_oc_title_prefix;
+    use crate::config::AgentIdentityDisplay;
 
     #[test]
     fn strips_oc_prefixes() {
@@ -820,6 +918,30 @@ mod tests {
         assert_eq!(
             sanitize_pane_title(Some("⠋⠙ OC | Investigating..."), "worktree", "project"),
             Some("Investigating...")
+        );
+    }
+
+    #[test]
+    fn identity_text_degrades_to_fit_available_width() {
+        assert_eq!(
+            choose_identity_text(AgentIdentityDisplay::Both, "CX", "Codex", 8),
+            "CX Codex"
+        );
+        assert_eq!(
+            choose_identity_text(AgentIdentityDisplay::Both, "CX", "Codex", 2),
+            "CX"
+        );
+        assert_eq!(
+            choose_identity_text(AgentIdentityDisplay::Both, "CX", "Codex", 1),
+            ""
+        );
+        assert_eq!(
+            choose_identity_text(AgentIdentityDisplay::Label, "CX", "Codex", 4),
+            ""
+        );
+        assert_eq!(
+            choose_identity_text(AgentIdentityDisplay::Off, "CX", "Codex", 8),
+            ""
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use tracing::debug;
 
+use crate::agent_identity::AgentKind;
 use crate::{cmd, git, nerdfont};
 use which::{which, which_in};
 
@@ -127,6 +128,60 @@ pub struct SidebarConfig {
 
     /// Layout mode: "compact" or "tiles". Default: "tiles"
     pub layout: Option<String>,
+
+    /// Agent identity display mode. Default: off.
+    #[serde(default)]
+    pub agent_identity: Option<AgentIdentityDisplay>,
+
+    /// Custom icons for agent identity badges.
+    #[serde(default)]
+    pub agent_icons: AgentIcons,
+}
+
+/// How much agent identity to show in the sidebar.
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentIdentityDisplay {
+    /// Hide agent identity badges.
+    #[default]
+    Off,
+    /// Show only the agent icon.
+    Icon,
+    /// Show only the agent label.
+    Label,
+    /// Show icon and label.
+    Both,
+}
+
+/// Custom icons for agent identity display.
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+pub struct AgentIcons {
+    pub claude: Option<String>,
+    pub codex: Option<String>,
+    pub opencode: Option<String>,
+    pub gemini: Option<String>,
+    pub copilot: Option<String>,
+    pub pi: Option<String>,
+    pub kiro_cli: Option<String>,
+    pub vibe: Option<String>,
+    pub unknown: Option<String>,
+}
+
+impl AgentIcons {
+    pub fn icon_for(&self, kind: AgentKind) -> &str {
+        match kind {
+            AgentKind::Claude => self.claude.as_deref(),
+            AgentKind::Codex => self.codex.as_deref(),
+            AgentKind::OpenCode => self.opencode.as_deref(),
+            AgentKind::Gemini => self.gemini.as_deref(),
+            AgentKind::Copilot => self.copilot.as_deref(),
+            AgentKind::Pi => self.pi.as_deref(),
+            AgentKind::KiroCli => self.kiro_cli.as_deref(),
+            AgentKind::Vibe => self.vibe.as_deref(),
+            AgentKind::Unknown => self.unknown.as_deref(),
+        }
+        .unwrap_or_else(|| kind.default_icon())
+    }
 }
 
 /// Sidebar width: either absolute columns or a percentage of terminal width.
@@ -2104,6 +2159,57 @@ impl Config {
         merged.sidebar = SidebarConfig {
             width: project.sidebar.width.or(self.sidebar.width),
             layout: project.sidebar.layout.or(self.sidebar.layout),
+            agent_identity: project
+                .sidebar
+                .agent_identity
+                .or(self.sidebar.agent_identity),
+            agent_icons: AgentIcons {
+                claude: project
+                    .sidebar
+                    .agent_icons
+                    .claude
+                    .or(self.sidebar.agent_icons.claude),
+                codex: project
+                    .sidebar
+                    .agent_icons
+                    .codex
+                    .or(self.sidebar.agent_icons.codex),
+                opencode: project
+                    .sidebar
+                    .agent_icons
+                    .opencode
+                    .or(self.sidebar.agent_icons.opencode),
+                gemini: project
+                    .sidebar
+                    .agent_icons
+                    .gemini
+                    .or(self.sidebar.agent_icons.gemini),
+                copilot: project
+                    .sidebar
+                    .agent_icons
+                    .copilot
+                    .or(self.sidebar.agent_icons.copilot),
+                pi: project
+                    .sidebar
+                    .agent_icons
+                    .pi
+                    .or(self.sidebar.agent_icons.pi),
+                kiro_cli: project
+                    .sidebar
+                    .agent_icons
+                    .kiro_cli
+                    .or(self.sidebar.agent_icons.kiro_cli),
+                vibe: project
+                    .sidebar
+                    .agent_icons
+                    .vibe
+                    .or(self.sidebar.agent_icons.vibe),
+                unknown: project
+                    .sidebar
+                    .agent_icons
+                    .unknown
+                    .or(self.sidebar.agent_icons.unknown),
+            },
         };
 
         // Sandbox config: per-field override with nested struct merging
@@ -2530,6 +2636,16 @@ pub const EXAMPLE_PROJECT_CONFIG: &str = r#"# workmux project configuration
 #   # Layout mode: "compact" (single line per agent) or "tiles" (cards).
 #   # Default: "tiles". Can be toggled at runtime with 'v' key.
 #   layout: tiles
+#
+#   # Agent identity display in the sidebar: off, icon, label, or both.
+#   # Default: off.
+#   agent_identity: both
+#
+#   # Optional custom identity icons.
+#   agent_icons:
+#     claude: "✳"
+#     codex: "CX"
+#     opencode: "OC"
 
 #-------------------------------------------------------------------------------
 # Sandbox
@@ -2666,10 +2782,10 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{
-        Config, ContainerConfig, ContainerDevice, ExtraMount, LayoutConfig, LimaConfig,
-        NetworkConfig, NetworkPolicy, PaneConfig, SandboxConfig, SandboxRuntime, SandboxTarget,
-        SplitDirection, ToolchainMode, is_agent_command, split_first_token, validate_domain,
-        validate_group_add_entry, validate_layouts_config,
+        AgentIdentityDisplay, Config, ContainerConfig, ContainerDevice, ExtraMount, LayoutConfig,
+        LimaConfig, NetworkConfig, NetworkPolicy, PaneConfig, SandboxConfig, SandboxRuntime,
+        SandboxTarget, SplitDirection, ToolchainMode, is_agent_command, split_first_token,
+        validate_domain, validate_group_add_entry, validate_layouts_config,
     };
 
     #[test]
@@ -2757,6 +2873,82 @@ mod tests {
     fn is_agent_command_env_wrapped_mismatch() {
         assert!(!is_agent_command("env -u FOO claude", "gemini"));
         assert!(!is_agent_command("env -u FOO vim", "claude"));
+    }
+
+    #[test]
+    fn parses_sidebar_agent_identity_config() {
+        let yaml = r#"
+sidebar:
+  width: 38
+  layout: tiles
+  agent_identity: both
+  agent_icons:
+    claude: "C"
+    codex: "X"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!(
+            config.sidebar.agent_identity,
+            Some(AgentIdentityDisplay::Both)
+        );
+        assert_eq!(
+            config
+                .sidebar
+                .agent_icons
+                .icon_for(crate::agent_identity::AgentKind::Claude),
+            "C"
+        );
+        assert_eq!(
+            config
+                .sidebar
+                .agent_icons
+                .icon_for(crate::agent_identity::AgentKind::Codex),
+            "X"
+        );
+    }
+
+    #[test]
+    fn merges_sidebar_agent_identity_config_per_field() {
+        let global: Config = serde_yaml::from_str(
+            r#"
+sidebar:
+  agent_identity: icon
+  agent_icons:
+    claude: "C"
+    codex: "X"
+"#,
+        )
+        .unwrap();
+        let project: Config = serde_yaml::from_str(
+            r#"
+sidebar:
+  agent_identity: label
+  agent_icons:
+    codex: "CDX"
+"#,
+        )
+        .unwrap();
+
+        let merged = global.merge(project);
+        assert_eq!(
+            merged.sidebar.agent_identity,
+            Some(AgentIdentityDisplay::Label)
+        );
+        assert_eq!(
+            merged
+                .sidebar
+                .agent_icons
+                .icon_for(crate::agent_identity::AgentKind::Claude),
+            "C"
+        );
+        assert_eq!(
+            merged
+                .sidebar
+                .agent_icons
+                .icon_for(crate::agent_identity::AgentKind::Codex),
+            "CDX"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod agent_display;
+mod agent_identity;
 mod agent_setup;
 mod claude;
 mod cli;

--- a/src/multiplexer/types.rs
+++ b/src/multiplexer/types.rs
@@ -48,6 +48,9 @@ pub struct AgentPane {
     pub path: PathBuf,
     /// Pane title (set by Claude Code to show session summary)
     pub pane_title: Option<String>,
+    /// Command that identified the agent when status was last recorded.
+    #[serde(default)]
+    pub agent_command: Option<String>,
     /// Current agent status
     pub status: Option<AgentStatus>,
     /// Unix timestamp when status was last set

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -130,6 +130,11 @@ impl AgentState {
             window_id: String::new(),
             path: self.workdir.clone(),
             pane_title: self.pane_title.clone(),
+            agent_command: if self.command.is_empty() {
+                None
+            } else {
+                Some(self.command.clone())
+            },
             status: self.status,
             status_ts: self.status_ts,
             updated_ts: Some(self.updated_ts),


### PR DESCRIPTION
Adds optional agent identity badges to the tmux sidebar so users can see both the worktree/task and the underlying tool type (Claude, Codex, OpenCode, Gemini, etc.). The display is opt-in via `sidebar.agent_identity`, supports custom `sidebar.agent_icons`, and degrades to shorter badges before crowding the worktree name.

The status metadata now carries the recorded agent command into `AgentPane`, while existing sidebar behavior remains unchanged unless identity display is enabled.
