### PR TITLE
docs: document proxy rejection log location

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -23,6 +23,8 @@ workmux respects the [XDG Base Directory Specification](https://specifications.f
 
 All workmux files live under a `workmux/` subdirectory within these base directories. If you have an existing config at the default location and later set a custom `XDG_CONFIG_HOME`, workmux will fall back to reading from `~/.config/workmux/` if no config exists at the new location.
 
+The host-side log lives at `$XDG_STATE_HOME/workmux/workmux.log` and includes sandbox network-proxy rejections — see [Debugging blocked requests](./sandbox/features.md#debugging-blocked-requests).
+
 ## Global configuration example
 
 `~/.config/workmux/config.yaml`:

--- a/docs/guide/sandbox/features.md
+++ b/docs/guide/sandbox/features.md
@@ -46,7 +46,7 @@ Any allowed command can execute code from project files. For example, an agent c
 ```yaml
 # ~/.config/workmux/config.yaml
 sandbox:
-  host_commands: ["just", "cargo", "npm"]
+  host_commands: ['just', 'cargo', 'npm']
 ```
 
 `host_commands` is only read from your global config. If set in a project's `.workmux.yaml`, it is ignored and a warning is logged. This ensures that only you control which commands get host access, not the projects you clone.
@@ -166,6 +166,18 @@ Requests are authenticated with a per-session token passed via the `WM_RPC_TOKEN
 Claude stores auth in macOS Keychain, so it must authenticate separately inside containers and VMs. Other agents (Gemini, Codex, OpenCode) use file-based credentials that are shared with the host automatically.
 
 If credentials are missing, start a shell in the sandbox with `workmux sandbox shell` and run the agent to trigger authentication. Credentials written inside the sandbox persist to the host.
+
+### Debugging blocked requests
+
+Network proxy rejections are logged on the host at `$XDG_STATE_HOME/workmux/workmux.log`, or `~/.local/state/workmux/workmux.log` by default.
+
+To watch rejections while reproducing an issue:
+
+```bash
+tail -f ~/.local/state/workmux/workmux.log | grep rejected
+```
+
+Rejected entries include the denied hostname. Add any expected hosts to your sandbox's `network.domains` list and retry.
 
 ## Installing local builds
 


### PR DESCRIPTION
Addresses #159.

Adds a short `### Debugging blocked requests` subsection under the existing Troubleshooting heading in `docs/guide/sandbox/features.md`, covering: where the proxy writes rejections (`~/.local/state/workmux/workmux.log`, with `$XDG_STATE_HOME` override), an example `WARN rejected: ...` line, the `tail -f | grep rejected` live-debug recipe, and a note that `RUST_LOG` controls verbosity but doesn't redirect to stderr (the logger is file-only).

Also a one-line cross-link from the XDG table in `docs/guide/configuration.md` so readers landing on the config page can find the log path.

Docs-only — no code changes.