### PR TITLE
chore: update pi extension import to @earendil-works

### DIFF
--- a/.pi/extensions/workmux-status.ts
+++ b/.pi/extensions/workmux-status.ts
@@ -5,7 +5,7 @@
  * See: https://workmux.raine.dev/guide/status-tracking
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export default function (pi: ExtensionAPI) {
   function setStatus(status: string) {


### PR DESCRIPTION
The `pi-coding-agent` npm package moved from `@mariozechner` to `@earendil-works` (now installed via `npm install -g @earendil-works/pi-coding-agent`).

Updates the `ExtensionAPI` type import in `.pi/extensions/workmux-status.ts` so the extension keeps type-checking against the current package.

https://pi.dev/news/2026/5/7/pi-has-a-new-home