### PR TITLE
Handle Codex SubagentStop status cleanup

### DIFF
--- a/.codex/hooks/workmux-status.json
+++ b/.codex/hooks/workmux-status.json
@@ -29,6 +29,16 @@
           }
         ]
       }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status done"
+          }
+        ]
+      }
     ]
   }
 }

--- a/src/agent_setup/codex.rs
+++ b/src/agent_setup/codex.rs
@@ -254,6 +254,7 @@ mod tests {
         assert!(hooks.contains_key("UserPromptSubmit"));
         assert!(hooks.contains_key("PostToolUse"));
         assert!(hooks.contains_key("Stop"));
+        assert!(hooks.contains_key("SubagentStop"));
     }
 
     #[test]
@@ -304,6 +305,7 @@ mod tests {
         assert!(obj.contains_key("UserPromptSubmit"));
         assert!(obj.contains_key("PostToolUse"));
         assert!(obj.contains_key("Stop"));
+        assert!(obj.contains_key("SubagentStop"));
     }
 
     #[test]
@@ -319,7 +321,7 @@ mod tests {
         }
 
         let hooks = config.get("hooks").unwrap().as_object().unwrap();
-        assert_eq!(hooks.len(), 3);
+        assert_eq!(hooks.len(), 4);
     }
 
     #[test]
@@ -407,9 +409,9 @@ mod tests {
             .unwrap();
         assert_eq!(stop.len(), 2);
 
-        // All 3 events should be present
+        // All 4 events should be present
         let hooks = config.get("hooks").unwrap().as_object().unwrap();
-        assert_eq!(hooks.len(), 3);
+        assert_eq!(hooks.len(), 4);
     }
 
     #[test]

--- a/src/command/set_window_status.rs
+++ b/src/command/set_window_status.rs
@@ -23,7 +23,7 @@ pub fn run(cmd: SetWindowStatusCommand) -> Result<()> {
     }
 
     // Codex compatibility: hook stdin may identify a specific parent/subagent
-    // turn. Use it to avoid a child Stop hook marking the pane done early.
+    // turn. Use it to avoid child cleanup marking the pane done early.
     let codex_run_id = crate::state::codex_status::detect_run_id_from_stdin();
 
     // Inside a sandbox guest, route through RPC to the host supervisor

--- a/src/state/codex_status.rs
+++ b/src/state/codex_status.rs
@@ -1,14 +1,14 @@
 //! Codex-specific workaround for nested hook status updates.
 //!
 //! Codex currently runs Workmux status hooks for both a parent agent and its
-//! spawned subagents in the same tmux pane. A subagent `Stop` hook can therefore
+//! spawned subagents in the same tmux pane. A subagent cleanup hook can therefore
 //! run before the parent `Stop` hook and incorrectly mark the pane/window as
 //! done while the parent is still active.
 //!
-//! Codex hook payloads do not currently expose an explicit root/subagent marker
-//! such as `agent_path`, `parent_thread_id`, or `is_subagent`. Until they do,
 //! Workmux tracks active Codex turns by `session_id` + `turn_id` and renders the
-//! pane as working while any tracked Codex turn is active.
+//! pane as working while any tracked Codex turn is active. Subagent cleanup is
+//! handled through Codex's `SubagentStop` event, which includes `agent_id` and
+//! `agent_type` metadata but still carries the turn id to remove.
 //!
 //! Keep this module isolated so it can be removed or replaced if Codex adds
 //! official hook metadata for subagent/root detection.
@@ -105,15 +105,20 @@ pub(crate) fn clear_pane_with_store(store: &StateStore, pane_key: &PaneKey) -> R
 fn detect_run_id(input: &str) -> Option<String> {
     let payload: CodexHookProbe = serde_json::from_str(input).ok()?;
 
-    if payload.agent_id.is_some() || payload.agent_type.is_some() {
-        return None;
-    }
-
     let event = payload.hook_event_name.as_deref()?;
     if !matches!(
         event,
-        "UserPromptSubmit" | "PreToolUse" | "PermissionRequest" | "PostToolUse" | "Stop"
+        "UserPromptSubmit"
+            | "PreToolUse"
+            | "PermissionRequest"
+            | "PostToolUse"
+            | "Stop"
+            | "SubagentStop"
     ) {
+        return None;
+    }
+
+    if event != "SubagentStop" && (payload.agent_id.is_some() || payload.agent_type.is_some()) {
         return None;
     }
 
@@ -350,6 +355,20 @@ mod tests {
         }"#;
 
         assert!(detect_run_id(input).is_none());
+    }
+
+    #[test]
+    fn detects_subagent_stop_with_agent_metadata() {
+        let input = r#"{
+            "hook_event_name":"SubagentStop",
+            "session_id":"session",
+            "turn_id":"turn",
+            "model":"gpt-5.5",
+            "agent_id":"agent",
+            "agent_type":"worker"
+        }"#;
+
+        assert_eq!(detect_run_id(input).as_deref(), Some("session:turn"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- install a bundled Codex `SubagentStop` hook that clears Workmux status when a thread-spawned child agent finishes
- treat `SubagentStop` hook payloads as Codex turn-scoped cleanup events even though they include `agent_id` / `agent_type`
- keep rejecting agent-metadata payloads for other Codex events so non-root child hooks do not mark the pane done early
- update Codex hook setup tests for the additional event

## Why

Codex thread-spawned subagents complete through `SubagentStop`, not the normal `Stop` hook. Workmux already tracks active Codex turns by `session_id` + `turn_id`, but without the bundled `SubagentStop` hook and parser support, child-agent cleanup can be missed and the pane/sidebar status can remain stuck as working.

This keeps the change limited to the cleanup event that Workmux can handle directly. Cases where Codex aborts a turn without running a stop hook are intentionally left out.

Fixes #170.

## Validation

Ran in an isolated Docker environment with a temporary home/XDG state/config and an isolated tmux server, without touching the host Workmux/Codex/tmux configuration.

- `cargo fmt --check`
- `cargo test --locked --bin workmux codex_status -- --nocapture`
  - 15 passed
- `cargo test --locked --bin workmux agent_setup::codex -- --nocapture`
  - 18 passed
- synthetic tmux hook replay against this branch:
  - parent `UserPromptSubmit` renders `working`
  - child `SubagentStop` keeps the pane/agent `working` while the parent run remains active
  - parent `Stop` renders `done` and clears Codex runtime state
- synthetic tmux hook replay against `origin/main` as a control:
  - the same child `SubagentStop` payload renders `done` while the parent run is still active, reproducing the old behavior
