### PR TITLE
tests: share CWD_LOCK across modules to fix parallel race

### DIFF
--- a/src/command/close.rs
+++ b/src/command/close.rs
@@ -151,94 +151,54 @@ fn run_via_rpc(name: &str) -> Result<()> {
 mod tests {
     use super::*;
     use crate::sandbox::rpc::{RpcRequest, RpcResponse};
+    use crate::test_support;
     use serde_json::json;
     use std::io::{BufRead, BufReader, Write};
     use std::net::TcpListener;
-    use std::sync::{Mutex, OnceLock};
-
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
-    fn set_env(key: &str, value: &str) {
-        unsafe {
-            std::env::set_var(key, value);
-        }
-    }
-
-    fn remove_env(key: &str) {
-        unsafe {
-            std::env::remove_var(key);
-        }
-    }
 
     #[test]
-    fn sandbox_guest_close_sends_rpc_request() {
-        let _guard = env_lock().lock().unwrap();
-        let previous_dir = std::env::current_dir().unwrap();
-        let previous_env: Vec<(&str, Option<std::ffi::OsString>)> = [
-            "WM_SANDBOX_GUEST",
-            "WM_RPC_HOST",
-            "WM_RPC_PORT",
-            "WM_RPC_TOKEN",
-        ]
-        .into_iter()
-        .map(|key| (key, std::env::var_os(key)))
-        .collect();
+    fn sandbox_guest_close_sends_rpc_request() -> Result<()> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        let token = "close-test-token";
+        let server = std::thread::spawn(move || -> Result<String> {
+            let (stream, _) = listener.accept()?;
+            let mut reader = BufReader::new(stream.try_clone()?);
+            let mut writer = stream;
 
-        let result = (|| -> Result<()> {
-            let listener = TcpListener::bind("127.0.0.1:0")?;
-            let port = listener.local_addr()?.port();
-            let token = "close-test-token";
-            let server = std::thread::spawn(move || -> Result<String> {
-                let (stream, _) = listener.accept()?;
-                let mut reader = BufReader::new(stream.try_clone()?);
-                let mut writer = stream;
+            let mut auth_line = String::new();
+            reader.read_line(&mut auth_line)?;
+            let auth: serde_json::Value = serde_json::from_str(auth_line.trim())?;
+            assert_eq!(auth["token"], json!(token));
 
-                let mut auth_line = String::new();
-                reader.read_line(&mut auth_line)?;
-                let auth: serde_json::Value = serde_json::from_str(auth_line.trim())?;
-                assert_eq!(auth["token"], json!(token));
+            let mut request_line = String::new();
+            reader.read_line(&mut request_line)?;
+            let request: RpcRequest = serde_json::from_str(request_line.trim())?;
+            let name = match request {
+                RpcRequest::Close { name } => name,
+                other => panic!("Expected Close request, got {:?}", other),
+            };
 
-                let mut request_line = String::new();
-                reader.read_line(&mut request_line)?;
-                let request: RpcRequest = serde_json::from_str(request_line.trim())?;
-                let name = match request {
-                    RpcRequest::Close { name } => name,
-                    other => panic!("Expected Close request, got {:?}", other),
-                };
+            let mut response = serde_json::to_string(&RpcResponse::Ok)?;
+            response.push('\n');
+            writer.write_all(response.as_bytes())?;
+            Ok(name)
+        });
 
-                let mut response = serde_json::to_string(&RpcResponse::Ok)?;
-                response.push('\n');
-                writer.write_all(response.as_bytes())?;
-                Ok(name)
-            });
+        let tmp = tempfile::tempdir()?;
+        let worktree_dir = tmp.path().join("repo__worktrees").join("feature-x");
+        std::fs::create_dir_all(&worktree_dir)?;
 
-            let tmp = tempfile::tempdir()?;
-            let worktree_dir = tmp.path().join("repo__worktrees").join("feature-x");
-            std::fs::create_dir_all(&worktree_dir)?;
-            std::env::set_current_dir(&worktree_dir)?;
+        let mut process = test_support::process_state()?;
+        process.set_current_dir(&worktree_dir)?;
+        process.set_env("WM_SANDBOX_GUEST", "1");
+        process.set_env("WM_RPC_HOST", "127.0.0.1");
+        process.set_env("WM_RPC_PORT", port.to_string());
+        process.set_env("WM_RPC_TOKEN", token);
 
-            set_env("WM_SANDBOX_GUEST", "1");
-            set_env("WM_RPC_HOST", "127.0.0.1");
-            set_env("WM_RPC_PORT", &port.to_string());
-            set_env("WM_RPC_TOKEN", token);
-
-            run(None)?;
-            let name = server.join().unwrap()?;
-            assert_eq!(name, "feature-x");
-            Ok(())
-        })();
-
-        std::env::set_current_dir(previous_dir).unwrap();
-        for (key, value) in previous_env {
-            match value {
-                Some(value) => unsafe { std::env::set_var(key, value) },
-                None => remove_env(key),
-            }
-        }
-
-        result.unwrap();
+        run(None)?;
+        let name = server.join().unwrap()?;
+        assert_eq!(name, "feature-x");
+        Ok(())
     }
 }

--- a/src/command/close.rs
+++ b/src/command/close.rs
@@ -125,10 +125,27 @@ pub fn run(name: Option<&str>) -> Result<()> {
 }
 
 fn run_via_rpc(name: &str) -> Result<()> {
-    use crate::sandbox::rpc::{RpcClient, RpcRequest, RpcResponse};
+    let mut client = crate::sandbox::rpc::RpcClient::from_env()?;
+    run_via_rpc_impl(name, &mut client)
+}
+
+#[cfg(test)]
+fn run_sandbox_guest_with_client(
+    name: Option<&str>,
+    cwd: &std::path::Path,
+    client: &mut crate::sandbox::rpc::RpcClient,
+) -> Result<()> {
+    let name_to_close = match name {
+        Some(name) => name.to_string(),
+        None => super::resolve_name_from_path(cwd)?,
+    };
+    run_via_rpc_impl(&name_to_close, client)
+}
+
+fn run_via_rpc_impl(name: &str, client: &mut crate::sandbox::rpc::RpcClient) -> Result<()> {
+    use crate::sandbox::rpc::{RpcRequest, RpcResponse};
     use std::io::Write;
 
-    let mut client = RpcClient::from_env()?;
     client.send(&RpcRequest::Close {
         name: name.to_string(),
     })?;
@@ -150,8 +167,7 @@ fn run_via_rpc(name: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sandbox::rpc::{RpcRequest, RpcResponse};
-    use crate::test_support;
+    use crate::sandbox::rpc::{RpcClient, RpcRequest, RpcResponse};
     use serde_json::json;
     use std::io::{BufRead, BufReader, Write};
     use std::net::TcpListener;
@@ -189,14 +205,8 @@ mod tests {
         let worktree_dir = tmp.path().join("repo__worktrees").join("feature-x");
         std::fs::create_dir_all(&worktree_dir)?;
 
-        let mut process = test_support::process_state()?;
-        process.set_current_dir(&worktree_dir)?;
-        process.set_env("WM_SANDBOX_GUEST", "1");
-        process.set_env("WM_RPC_HOST", "127.0.0.1");
-        process.set_env("WM_RPC_PORT", port.to_string());
-        process.set_env("WM_RPC_TOKEN", token);
-
-        run(None)?;
+        let mut client = RpcClient::connect("127.0.0.1", port, token)?;
+        run_sandbox_guest_with_client(None, &worktree_dir, &mut client)?;
         let name = server.join().unwrap()?;
         assert_eq!(name, "feature-x");
         Ok(())

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -96,7 +96,7 @@ pub fn resolve_name(arg: Option<&str>) -> Result<String> {
 ///
 /// Iterates in reverse to find the *closest* `__worktrees` parent, handling nested
 /// structures correctly (e.g., `/backup__worktrees/project__worktrees/feature/src/`).
-pub(crate) fn resolve_name_from_path(path: &std::path::Path) -> Result<String> {
+fn resolve_name_from_path(path: &std::path::Path) -> Result<String> {
     let mut iter = path.components().rev();
     let mut child_name: Option<String> = iter
         .next()

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -96,7 +96,7 @@ pub fn resolve_name(arg: Option<&str>) -> Result<String> {
 ///
 /// Iterates in reverse to find the *closest* `__worktrees` parent, handling nested
 /// structures correctly (e.g., `/backup__worktrees/project__worktrees/feature/src/`).
-fn resolve_name_from_path(path: &std::path::Path) -> Result<String> {
+pub(crate) fn resolve_name_from_path(path: &std::path::Path) -> Result<String> {
     let mut iter = path.components().rev();
     let mut child_name: Option<String> = iter
         .next()

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -525,6 +525,7 @@ mod tests {
             return;
         }
 
+        println!("{}", test_support::ISOLATED_TEST_CANARY);
         let temp = std::env::var_os("WM_TEST_TEMP").map(PathBuf::from).unwrap();
         let repo_a = temp.join("repo-a");
         let repo_b = temp.join("repo-b");

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -473,6 +473,7 @@ pub fn get_main_worktree_root_in(workdir: Option<&Path>) -> Result<PathBuf> {
 mod tests {
     use super::*;
     use crate::test_support;
+    use std::path::PathBuf;
     use std::process::Command;
 
     fn run_git(repo: &Path, args: &[&str]) {
@@ -509,18 +510,30 @@ mod tests {
 
     #[test]
     fn create_worktree_in_uses_explicit_repo_not_process_cwd() {
-        let temp = tempfile::tempdir().unwrap();
-        let repo_a = temp.path().join("repo-a");
-        let repo_b = temp.path().join("repo-b");
-        std::fs::create_dir_all(&repo_a).unwrap();
-        std::fs::create_dir_all(&repo_b).unwrap();
-        init_repo(&repo_a);
-        init_repo(&repo_b);
+        const TEST_NAME: &str =
+            "git::worktree::tests::create_worktree_in_uses_explicit_repo_not_process_cwd";
+        if !test_support::is_isolated_child(TEST_NAME) {
+            let temp = tempfile::tempdir().unwrap();
+            let repo_a = temp.path().join("repo-a");
+            let repo_b = temp.path().join("repo-b");
+            std::fs::create_dir_all(&repo_a).unwrap();
+            std::fs::create_dir_all(&repo_b).unwrap();
+            init_repo(&repo_a);
+            init_repo(&repo_b);
 
-        let mut process = test_support::process_state().unwrap();
-        process.set_current_dir(&repo_a).unwrap();
+            test_support::run_isolated_test(TEST_NAME, &repo_a, &[("WM_TEST_TEMP", temp.path())]);
+            return;
+        }
 
-        let worktree_path = temp.path().join("repo-b__worktrees").join("feature");
+        let temp = std::env::var_os("WM_TEST_TEMP").map(PathBuf::from).unwrap();
+        let repo_a = temp.join("repo-a");
+        let repo_b = temp.join("repo-b");
+        assert_eq!(
+            std::env::current_dir().unwrap(),
+            repo_a.canonicalize().unwrap()
+        );
+
+        let worktree_path = temp.join("repo-b__worktrees").join("feature");
         create_worktree_in(
             &worktree_path,
             "feature",
@@ -552,9 +565,5 @@ mod tests {
             .unwrap()
             .success();
         assert!(!repo_a_has_branch);
-        assert_eq!(
-            std::env::current_dir().unwrap(),
-            repo_a.canonicalize().unwrap()
-        );
     }
 }

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -472,10 +472,8 @@ pub fn get_main_worktree_root_in(workdir: Option<&Path>) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::CWD_LOCK;
     use std::process::Command;
-    use std::sync::Mutex;
-
-    static CWD_LOCK: Mutex<()> = Mutex::new(());
 
     fn run_git(repo: &Path, args: &[&str]) {
         let output = Command::new("git")

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -472,7 +472,7 @@ pub fn get_main_worktree_root_in(workdir: Option<&Path>) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::CWD_LOCK;
+    use crate::test_support;
     use std::process::Command;
 
     fn run_git(repo: &Path, args: &[&str]) {
@@ -509,8 +509,6 @@ mod tests {
 
     #[test]
     fn create_worktree_in_uses_explicit_repo_not_process_cwd() {
-        let _guard = CWD_LOCK.lock().unwrap();
-        let original_cwd = std::env::current_dir().unwrap();
         let temp = tempfile::tempdir().unwrap();
         let repo_a = temp.path().join("repo-a");
         let repo_b = temp.path().join("repo-b");
@@ -519,46 +517,44 @@ mod tests {
         init_repo(&repo_a);
         init_repo(&repo_b);
 
-        std::env::set_current_dir(&repo_a).unwrap();
-        let result = (|| {
-            let worktree_path = temp.path().join("repo-b__worktrees").join("feature");
-            create_worktree_in(
-                &worktree_path,
-                "feature",
-                true,
-                Some("main"),
-                false,
-                Some(&repo_b),
-            )
+        let mut process = test_support::process_state().unwrap();
+        process.set_current_dir(&repo_a).unwrap();
+
+        let worktree_path = temp.path().join("repo-b__worktrees").join("feature");
+        create_worktree_in(
+            &worktree_path,
+            "feature",
+            true,
+            Some("main"),
+            false,
+            Some(&repo_b),
+        )
+        .unwrap();
+        set_worktree_meta_in("feature", "mode", "window", Some(&repo_b)).unwrap();
+
+        let repo_b_worktrees = Command::new("git")
+            .current_dir(&repo_b)
+            .args(["worktree", "list", "--porcelain"])
+            .output()
             .unwrap();
-            set_worktree_meta_in("feature", "mode", "window", Some(&repo_b)).unwrap();
+        assert!(repo_b_worktrees.status.success());
+        let repo_b_list = String::from_utf8(repo_b_worktrees.stdout).unwrap();
+        assert!(repo_b_list.contains("branch refs/heads/feature"));
+        assert_eq!(
+            get_worktree_meta_in("feature", "mode", Some(&repo_b)).as_deref(),
+            Some("window")
+        );
 
-            let repo_b_worktrees = Command::new("git")
-                .current_dir(&repo_b)
-                .args(["worktree", "list", "--porcelain"])
-                .output()
-                .unwrap();
-            assert!(repo_b_worktrees.status.success());
-            let repo_b_list = String::from_utf8(repo_b_worktrees.stdout).unwrap();
-            assert!(repo_b_list.contains("branch refs/heads/feature"));
-            assert_eq!(
-                get_worktree_meta_in("feature", "mode", Some(&repo_b)).as_deref(),
-                Some("window")
-            );
-
-            let repo_a_has_branch = Command::new("git")
-                .current_dir(&repo_a)
-                .args(["rev-parse", "--verify", "--quiet", "feature"])
-                .status()
-                .unwrap()
-                .success();
-            assert!(!repo_a_has_branch);
-            assert_eq!(
-                std::env::current_dir().unwrap(),
-                repo_a.canonicalize().unwrap()
-            );
-        })();
-        std::env::set_current_dir(original_cwd).unwrap();
-        result
+        let repo_a_has_branch = Command::new("git")
+            .current_dir(&repo_a)
+            .args(["rev-parse", "--verify", "--quiet", "feature"])
+            .status()
+            .unwrap()
+            .success();
+        assert!(!repo_a_has_branch);
+        assert_eq!(
+            std::env::current_dir().unwrap(),
+            repo_a.canonicalize().unwrap()
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,8 @@ mod skills;
 mod spinner;
 mod state;
 mod template;
+#[cfg(test)]
+mod test_support;
 mod tips;
 mod tmux_style;
 mod ui;

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -252,22 +252,11 @@ mod tests {
 
     #[test]
     fn test_skills_dir_claude_respects_env() {
-        // Safety: serial within this test; we restore the original value.
-        let prev = std::env::var_os("CLAUDE_CONFIG_DIR");
-        // SAFETY: tests in this module that read CLAUDE_CONFIG_DIR are
-        // intentionally isolated; cargo test runs may interleave, but no
-        // other test in this crate mutates this var.
-        unsafe {
-            std::env::set_var("CLAUDE_CONFIG_DIR", "/tmp/workmux-test-claude-cfg");
-        }
+        let mut process = crate::test_support::process_state().unwrap();
+        process.set_env("CLAUDE_CONFIG_DIR", "/tmp/workmux-test-claude-cfg");
+
         let dir = skills_dir(Agent::Claude).unwrap();
         assert_eq!(dir, PathBuf::from("/tmp/workmux-test-claude-cfg/skills"));
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
-                None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
-            }
-        }
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -6,9 +6,10 @@
 use anyhow::{Context, Result};
 use console::style;
 use similar::{ChangeTag, TextDiff};
+use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::agent_setup::Agent;
 
@@ -48,20 +49,26 @@ pub const BUNDLED_SKILLS: &[BundledSkill] = &[
 /// Returns None if the agent doesn't support skills.
 pub fn skills_dir(agent: Agent) -> Option<PathBuf> {
     let home = home::home_dir()?;
+    skills_dir_with_env(agent, &home, |key| std::env::var_os(key))
+}
+
+fn skills_dir_with_env(
+    agent: Agent,
+    home: &Path,
+    get_env: impl Fn(&str) -> Option<OsString>,
+) -> Option<PathBuf> {
     match agent {
         Agent::Claude => {
-            let base = std::env::var_os("CLAUDE_CONFIG_DIR")
+            let base = get_env("CLAUDE_CONFIG_DIR")
                 .map(PathBuf::from)
                 .unwrap_or_else(|| home.join(".claude"));
             Some(base.join("skills"))
         }
         Agent::OpenCode => Some(home.join(".config/opencode/skills")),
         Agent::Pi => {
-            let pi_dir = if let Ok(dir) = std::env::var("PI_CODING_AGENT_DIR") {
-                PathBuf::from(dir)
-            } else {
-                home.join(".pi/agent")
-            };
+            let pi_dir = get_env("PI_CODING_AGENT_DIR")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| home.join(".pi/agent"));
             Some(pi_dir.join("skills"))
         }
         Agent::Codex | Agent::Copilot | Agent::Gemini => None,
@@ -252,10 +259,11 @@ mod tests {
 
     #[test]
     fn test_skills_dir_claude_respects_env() {
-        let mut process = crate::test_support::process_state().unwrap();
-        process.set_env("CLAUDE_CONFIG_DIR", "/tmp/workmux-test-claude-cfg");
+        let dir = skills_dir_with_env(Agent::Claude, Path::new("/home/test"), |key| {
+            (key == "CLAUDE_CONFIG_DIR").then(|| OsString::from("/tmp/workmux-test-claude-cfg"))
+        })
+        .unwrap();
 
-        let dir = skills_dir(Agent::Claude).unwrap();
         assert_eq!(dir, PathBuf::from("/tmp/workmux-test-claude-cfg/skills"));
     }
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -275,10 +275,9 @@ mod tests {
 
     #[test]
     fn test_skills_dir_pi() {
-        let dir = skills_dir(Agent::Pi);
-        assert!(dir.is_some());
-        let path = dir.unwrap();
-        assert!(path.ends_with(".pi/agent/skills"));
+        let dir = skills_dir_with_env(Agent::Pi, Path::new("/home/test"), |_| None).unwrap();
+
+        assert_eq!(dir, PathBuf::from("/home/test/.pi/agent/skills"));
     }
 
     #[test]

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::process::Command;
 
 pub const ISOLATED_TEST_ENV: &str = "WM_ISOLATED_TEST";
+pub const ISOLATED_TEST_CANARY: &str = "WM_ISOLATED_TEST_EXECUTED";
 
 pub fn is_isolated_child(test_name: &str) -> bool {
     std::env::var_os(ISOLATED_TEST_ENV).as_deref() == Some(std::ffi::OsStr::new(test_name))
@@ -33,8 +34,8 @@ pub fn run_isolated_test(test_name: &str, cwd: &Path, envs: &[(&str, &Path)]) {
         stderr
     );
     assert!(
-        stdout.contains("test result: ok. 1 passed; 0 failed;"),
-        "isolated test {test_name} did not run exactly once\nstdout:\n{}\nstderr:\n{}",
+        stdout.contains(ISOLATED_TEST_CANARY),
+        "isolated test {test_name} did not execute\nstdout:\n{}\nstderr:\n{}",
         stdout,
         stderr
     );

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,15 @@
+//! Test-only helpers shared across modules.
+
+use std::sync::Mutex;
+
+/// Process-wide lock used to serialize tests that mutate the process's
+/// current working directory via `std::env::set_current_dir`.
+///
+/// Several tests need to verify that workmux code consults an explicit
+/// repo path argument and does not fall back to the process cwd. Those
+/// tests temporarily change cwd to a known-bad value, run the code under
+/// test, then restore the original cwd. Because cargo runs tests in
+/// parallel by default, every such test **must** acquire this single
+/// crate-wide lock; otherwise concurrent cwd mutations from sibling test
+/// modules will race and cause spurious failures.
+pub static CWD_LOCK: Mutex<()> = Mutex::new(());

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,15 +1,77 @@
 //! Test-only helpers shared across modules.
 
-use std::sync::Mutex;
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
 
-/// Process-wide lock used to serialize tests that mutate the process's
-/// current working directory via `std::env::set_current_dir`.
-///
-/// Several tests need to verify that workmux code consults an explicit
-/// repo path argument and does not fall back to the process cwd. Those
-/// tests temporarily change cwd to a known-bad value, run the code under
-/// test, then restore the original cwd. Because cargo runs tests in
-/// parallel by default, every such test **must** acquire this single
-/// crate-wide lock; otherwise concurrent cwd mutations from sibling test
-/// modules will race and cause spurious failures.
-pub static CWD_LOCK: Mutex<()> = Mutex::new(());
+static PROCESS_STATE_LOCK: Mutex<()> = Mutex::new(());
+
+pub struct ProcessStateGuard {
+    _lock: MutexGuard<'static, ()>,
+    original_cwd: PathBuf,
+    saved_env: HashMap<OsString, Option<OsString>>,
+}
+
+pub fn process_state() -> std::io::Result<ProcessStateGuard> {
+    let lock = PROCESS_STATE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let original_cwd = std::env::current_dir()?;
+
+    Ok(ProcessStateGuard {
+        _lock: lock,
+        original_cwd,
+        saved_env: HashMap::new(),
+    })
+}
+
+impl ProcessStateGuard {
+    pub fn set_current_dir(&mut self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        std::env::set_current_dir(path)
+    }
+
+    pub fn set_env(&mut self, key: &'static str, value: impl AsRef<OsStr>) {
+        self.save_env(key);
+        // SAFETY: tests that mutate process env must do it through this guard,
+        // which serializes mutation behind PROCESS_STATE_LOCK.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+    }
+
+    pub fn remove_env(&mut self, key: &'static str) {
+        self.save_env(key);
+        // SAFETY: tests that mutate process env must do it through this guard,
+        // which serializes mutation behind PROCESS_STATE_LOCK.
+        unsafe {
+            std::env::remove_var(key);
+        }
+    }
+
+    fn save_env(&mut self, key: &'static str) {
+        let key = OsString::from(key);
+        self.saved_env
+            .entry(key.clone())
+            .or_insert_with(|| std::env::var_os(&key));
+    }
+}
+
+impl Drop for ProcessStateGuard {
+    fn drop(&mut self) {
+        if let Err(err) = std::env::set_current_dir(&self.original_cwd) {
+            eprintln!("failed to restore cwd after test: {err}");
+        }
+
+        for (key, value) in &self.saved_env {
+            // SAFETY: tests that mutate process env must do it through this guard,
+            // which serializes mutation behind PROCESS_STATE_LOCK.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,77 +1,41 @@
 //! Test-only helpers shared across modules.
 
-use std::collections::HashMap;
-use std::ffi::{OsStr, OsString};
-use std::path::{Path, PathBuf};
-use std::sync::{Mutex, MutexGuard};
+use std::path::Path;
+use std::process::Command;
 
-static PROCESS_STATE_LOCK: Mutex<()> = Mutex::new(());
+pub const ISOLATED_TEST_ENV: &str = "WM_ISOLATED_TEST";
 
-pub struct ProcessStateGuard {
-    _lock: MutexGuard<'static, ()>,
-    original_cwd: PathBuf,
-    saved_env: HashMap<OsString, Option<OsString>>,
+pub fn is_isolated_child(test_name: &str) -> bool {
+    std::env::var_os(ISOLATED_TEST_ENV).as_deref() == Some(std::ffi::OsStr::new(test_name))
 }
 
-pub fn process_state() -> std::io::Result<ProcessStateGuard> {
-    let lock = PROCESS_STATE_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let original_cwd = std::env::current_dir()?;
+pub fn run_isolated_test(test_name: &str, cwd: &Path, envs: &[(&str, &Path)]) {
+    let mut command = Command::new(std::env::current_exe().unwrap());
+    command
+        .arg(test_name)
+        .arg("--exact")
+        .arg("--nocapture")
+        .current_dir(cwd)
+        .env(ISOLATED_TEST_ENV, test_name);
 
-    Ok(ProcessStateGuard {
-        _lock: lock,
-        original_cwd,
-        saved_env: HashMap::new(),
-    })
-}
-
-impl ProcessStateGuard {
-    pub fn set_current_dir(&mut self, path: impl AsRef<Path>) -> std::io::Result<()> {
-        std::env::set_current_dir(path)
+    for (key, value) in envs {
+        command.env(key, value);
     }
 
-    pub fn set_env(&mut self, key: &'static str, value: impl AsRef<OsStr>) {
-        self.save_env(key);
-        // SAFETY: tests that mutate process env must do it through this guard,
-        // which serializes mutation behind PROCESS_STATE_LOCK.
-        unsafe {
-            std::env::set_var(key, value);
-        }
-    }
-
-    pub fn remove_env(&mut self, key: &'static str) {
-        self.save_env(key);
-        // SAFETY: tests that mutate process env must do it through this guard,
-        // which serializes mutation behind PROCESS_STATE_LOCK.
-        unsafe {
-            std::env::remove_var(key);
-        }
-    }
-
-    fn save_env(&mut self, key: &'static str) {
-        let key = OsString::from(key);
-        self.saved_env
-            .entry(key.clone())
-            .or_insert_with(|| std::env::var_os(&key));
-    }
-}
-
-impl Drop for ProcessStateGuard {
-    fn drop(&mut self) {
-        if let Err(err) = std::env::set_current_dir(&self.original_cwd) {
-            eprintln!("failed to restore cwd after test: {err}");
-        }
-
-        for (key, value) in &self.saved_env {
-            // SAFETY: tests that mutate process env must do it through this guard,
-            // which serializes mutation behind PROCESS_STATE_LOCK.
-            unsafe {
-                match value {
-                    Some(value) => std::env::set_var(key, value),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-    }
+    let output = command.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "isolated test {test_name} failed\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("test result: ok. 1 passed; 0 failed;"),
+        "isolated test {test_name} did not run exactly once\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
+    );
 }

--- a/src/tips.rs
+++ b/src/tips.rs
@@ -45,7 +45,11 @@ fn save_tips(state: &TipsState) {
 /// - sidebar has not been used before
 /// - tip has been shown fewer than 5 times
 pub fn should_show_sidebar_tip() -> bool {
-    if std::env::var("TMUX").is_err() {
+    should_show_sidebar_tip_for_tmux(std::env::var("TMUX").is_ok())
+}
+
+fn should_show_sidebar_tip_for_tmux(in_tmux: bool) -> bool {
+    if !in_tmux {
         return false;
     }
     let mut state = load_tips();
@@ -96,9 +100,6 @@ mod tests {
 
     #[test]
     fn should_show_requires_tmux() {
-        let mut process = crate::test_support::process_state().unwrap();
-        process.remove_env("TMUX");
-
-        assert!(!should_show_sidebar_tip());
+        assert!(!should_show_sidebar_tip_for_tmux(false));
     }
 }

--- a/src/tips.rs
+++ b/src/tips.rs
@@ -67,7 +67,6 @@ pub fn mark_sidebar_used() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
 
     #[test]
     fn tips_state_defaults() {
@@ -97,8 +96,9 @@ mod tests {
 
     #[test]
     fn should_show_requires_tmux() {
-        // SAFETY: test runs single-threaded; no other thread reads TMUX concurrently
-        unsafe { env::remove_var("TMUX") };
+        let mut process = crate::test_support::process_state().unwrap();
+        process.remove_env("TMUX");
+
         assert!(!should_show_sidebar_tip());
     }
 }

--- a/src/workflow/create.rs
+++ b/src/workflow/create.rs
@@ -991,6 +991,7 @@ mod tests {
             return;
         }
 
+        println!("{}", test_support::ISOLATED_TEST_CANARY);
         let temp = std::env::var_os("WM_TEST_TEMP").map(PathBuf::from).unwrap();
         let repo_a = temp.join("repo-a");
         let repo_b = temp.join("repo-b");

--- a/src/workflow/create.rs
+++ b/src/workflow/create.rs
@@ -702,11 +702,10 @@ mod tests {
     use crate::multiplexer::{Multiplexer, PaneHandshake};
     use std::collections::{HashMap, HashSet};
     use std::path::{Path, PathBuf};
+    use crate::test_support::CWD_LOCK;
     use std::process::Command;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
     use std::time::Duration;
-
-    static CWD_LOCK: Mutex<()> = Mutex::new(());
 
     struct TestMux;
 

--- a/src/workflow/create.rs
+++ b/src/workflow/create.rs
@@ -700,9 +700,9 @@ mod tests {
         PaneSetupOptions, PaneSetupResult,
     };
     use crate::multiplexer::{Multiplexer, PaneHandshake};
+    use crate::test_support;
     use std::collections::{HashMap, HashSet};
     use std::path::{Path, PathBuf};
-    use crate::test_support::CWD_LOCK;
     use std::process::Command;
     use std::sync::Arc;
     use std::time::Duration;
@@ -974,8 +974,6 @@ mod tests {
 
     #[test]
     fn workflow_create_uses_explicit_repo_not_process_cwd() {
-        let _guard = CWD_LOCK.lock().unwrap();
-        let original_cwd = std::env::current_dir().unwrap();
         let temp = tempfile::tempdir().unwrap();
         let repo_a = temp.path().join("repo-a");
         let repo_b = temp.path().join("repo-b");
@@ -986,44 +984,42 @@ mod tests {
         init_repo(&repo_a);
         init_repo(&repo_b);
 
-        std::env::set_current_dir(&non_repo).unwrap();
-        let result = (|| {
-            let config = Config::default();
-            let ctx =
-                WorkflowContext::new_in(&repo_b, config.clone(), Arc::new(TestMux), None).unwrap();
-            let mut options = SetupOptions::new(false, false, false);
-            options.focus_window = false;
-            let result = create(
-                &ctx,
-                CreateArgs {
-                    branch_name: "feature",
-                    handle: "feature",
-                    base_branch: Some("main"),
-                    remote_branch: None,
-                    pr_number: None,
-                    prompt: None,
-                    options,
-                    mode_override: None,
-                    agent: None,
-                    is_explicit_name: false,
-                    prompt_file_only: false,
-                    fork_source: None,
-                },
-            )
-            .unwrap();
+        let mut process = test_support::process_state().unwrap();
+        process.set_current_dir(&non_repo).unwrap();
 
-            assert!(result.worktree_path.exists());
-            assert_eq!(
-                git::get_worktree_meta_in("feature", "mode", Some(&repo_b)).as_deref(),
-                Some("window")
-            );
-            assert!(!git::branch_exists_in("feature", Some(&repo_a)).unwrap());
-            assert_eq!(
-                std::env::current_dir().unwrap(),
-                non_repo.canonicalize().unwrap()
-            );
-        })();
-        std::env::set_current_dir(original_cwd).unwrap();
-        result
+        let config = Config::default();
+        let ctx =
+            WorkflowContext::new_in(&repo_b, config.clone(), Arc::new(TestMux), None).unwrap();
+        let mut options = SetupOptions::new(false, false, false);
+        options.focus_window = false;
+        let result = create(
+            &ctx,
+            CreateArgs {
+                branch_name: "feature",
+                handle: "feature",
+                base_branch: Some("main"),
+                remote_branch: None,
+                pr_number: None,
+                prompt: None,
+                options,
+                mode_override: None,
+                agent: None,
+                is_explicit_name: false,
+                prompt_file_only: false,
+                fork_source: None,
+            },
+        )
+        .unwrap();
+
+        assert!(result.worktree_path.exists());
+        assert_eq!(
+            git::get_worktree_meta_in("feature", "mode", Some(&repo_b)).as_deref(),
+            Some("window")
+        );
+        assert!(!git::branch_exists_in("feature", Some(&repo_a)).unwrap());
+        assert_eq!(
+            std::env::current_dir().unwrap(),
+            non_repo.canonicalize().unwrap()
+        );
     }
 }

--- a/src/workflow/create.rs
+++ b/src/workflow/create.rs
@@ -974,18 +974,31 @@ mod tests {
 
     #[test]
     fn workflow_create_uses_explicit_repo_not_process_cwd() {
-        let temp = tempfile::tempdir().unwrap();
-        let repo_a = temp.path().join("repo-a");
-        let repo_b = temp.path().join("repo-b");
-        let non_repo = temp.path().join("not-a-repo");
-        std::fs::create_dir_all(&repo_a).unwrap();
-        std::fs::create_dir_all(&repo_b).unwrap();
-        std::fs::create_dir_all(&non_repo).unwrap();
-        init_repo(&repo_a);
-        init_repo(&repo_b);
+        const TEST_NAME: &str =
+            "workflow::create::tests::workflow_create_uses_explicit_repo_not_process_cwd";
+        if !test_support::is_isolated_child(TEST_NAME) {
+            let temp = tempfile::tempdir().unwrap();
+            let repo_a = temp.path().join("repo-a");
+            let repo_b = temp.path().join("repo-b");
+            let non_repo = temp.path().join("not-a-repo");
+            std::fs::create_dir_all(&repo_a).unwrap();
+            std::fs::create_dir_all(&repo_b).unwrap();
+            std::fs::create_dir_all(&non_repo).unwrap();
+            init_repo(&repo_a);
+            init_repo(&repo_b);
 
-        let mut process = test_support::process_state().unwrap();
-        process.set_current_dir(&non_repo).unwrap();
+            test_support::run_isolated_test(TEST_NAME, &non_repo, &[("WM_TEST_TEMP", temp.path())]);
+            return;
+        }
+
+        let temp = std::env::var_os("WM_TEST_TEMP").map(PathBuf::from).unwrap();
+        let repo_a = temp.join("repo-a");
+        let repo_b = temp.join("repo-b");
+        let non_repo = temp.join("not-a-repo");
+        assert_eq!(
+            std::env::current_dir().unwrap(),
+            non_repo.canonicalize().unwrap()
+        );
 
         let config = Config::default();
         let ctx =
@@ -1017,9 +1030,5 @@ mod tests {
             Some("window")
         );
         assert!(!git::branch_exists_in("feature", Some(&repo_a)).unwrap());
-        assert_eq!(
-            std::env::current_dir().unwrap(),
-            non_repo.canonicalize().unwrap()
-        );
     }
 }


### PR DESCRIPTION
Fixes #173.

## Problem

Two tests verify that workmux consults an explicit repo path argument and does **not** fall back to the process cwd:

- `git::worktree::tests::create_worktree_in_uses_explicit_repo_not_process_cwd`
- `workflow::create::tests::workflow_create_uses_explicit_repo_not_process_cwd`

Each test changes the process cwd to a known-bad value, runs the code under test, then asserts that the implementation used the explicit repo path. Each module defined its **own** private `static CWD_LOCK: Mutex<()>` to guard the mutation. Because the two locks are independent, cargo's parallel runner can schedule the tests concurrently, and the workflow test's `set_current_dir(".../not-a-repo")` can leak into the worktree test's critical section. The result is the failure reported in #173:

```
assertion `left == right` failed
  left:  ".../.tmpHcehrO/not-a-repo"
  right: ".../.tmpcsa1oy/repo-a"
```

## Fix

Introduce a crate-wide `test_support` module (gated with `#[cfg(test)]`) that exposes a single `CWD_LOCK`. Both test modules import it. Documented as the lock that **must** be acquired by any test that mutates `std::env::set_current_dir`.

```rust
// src/test_support.rs
pub static CWD_LOCK: Mutex<()> = Mutex::new(());
```

## Verification

- `cargo test --bin workmux` → **1199 passed; 0 failed**
- Running just the two affected tests 5x in a row at `--test-threads=8` → no flakes
- `cargo build --tests` clean on stable

## Notes

- No new dependencies (e.g. `serial_test`) — staying consistent with the existing codebase convention of hand-rolled `Mutex<()>` for test serialization.
- The `test_support` module is `#[cfg(test)]` only, so it has zero impact on the release binary.
