### PR TITLE
Add Oh My Pi agent support

### DIFF
--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -146,6 +146,7 @@ jobs:
           - gemini
           - opencode
           - pi
+          - omp
         platform:
           - linux/amd64
           - linux/arm64
@@ -215,6 +216,7 @@ jobs:
           - gemini
           - opencode
           - pi
+          - omp
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4

--- a/.omp/extensions/workmux-status.ts
+++ b/.omp/extensions/workmux-status.ts
@@ -8,37 +8,52 @@
 import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
 
 export default function (pi: ExtensionAPI) {
+  let lastStatus: string | undefined;
+  let statusQueue = Promise.resolve();
+
+  function writeStatus(status: string) {
+    return pi.exec("workmux", ["set-window-status", status]).then(() => {}, () => {});
+  }
+
   function setStatus(status: string) {
-    pi.exec("workmux", ["set-window-status", status]).catch(() => {});
+    if (status === lastStatus) {
+      return statusQueue;
+    }
+    lastStatus = status;
+    statusQueue = statusQueue.then(
+      () => writeStatus(status),
+      () => writeStatus(status),
+    );
+    return statusQueue;
   }
 
   pi.on("agent_start", async () => {
-    setStatus("working");
-  });
-
-  pi.on("message_update", async () => {
-    setStatus("working");
+    await setStatus("working");
   });
 
   pi.on("message_end", async (event) => {
     if ("role" in event.message && event.message.role === "assistant") {
-      setStatus("waiting");
+      await setStatus("waiting");
     }
   });
 
   pi.on("tool_call", async (event) => {
     if (event.toolName === "ask") {
-      setStatus("waiting");
+      await setStatus("waiting");
     } else {
-      setStatus("working");
+      await setStatus("working");
     }
   });
 
   pi.on("tool_execution_start", async () => {
-    setStatus("working");
+    await setStatus("working");
   });
 
   pi.on("agent_end", async () => {
-    setStatus("done");
+    if (lastStatus === "done") {
+      return;
+    }
+    lastStatus = "done";
+    await writeStatus("done");
   });
 }

--- a/.omp/extensions/workmux-status.ts
+++ b/.omp/extensions/workmux-status.ts
@@ -1,0 +1,44 @@
+/**
+ * Workmux status tracking extension for oh-my-pi.
+ *
+ * Reports agent status to workmux for tmux window status display.
+ * See: https://workmux.raine.dev/guide/status-tracking
+ */
+
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+  function setStatus(status: string) {
+    pi.exec("workmux", ["set-window-status", status]).catch(() => {});
+  }
+
+  pi.on("agent_start", async () => {
+    setStatus("working");
+  });
+
+  pi.on("message_update", async () => {
+    setStatus("working");
+  });
+
+  pi.on("message_end", async (event) => {
+    if ("role" in event.message && event.message.role === "assistant") {
+      setStatus("waiting");
+    }
+  });
+
+  pi.on("tool_call", async (event) => {
+    if (event.toolName === "ask") {
+      setStatus("waiting");
+    } else {
+      setStatus("working");
+    }
+  });
+
+  pi.on("tool_execution_start", async () => {
+    setStatus("working");
+  });
+
+  pi.on("agent_end", async () => {
+    setStatus("done");
+  });
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ description: Release notes and version history for workmux
 
 # Changelog
 
+## Unreleased
+
+- Add first-party Oh My Pi (`omp`) support for prompt injection, status setup with waiting detection, skills, and sandbox credential mounts.
+
 ## v0.1.212 (2026-06-06)
 
 - Add an uninstall script that removes workmux hooks, bundled skills, cache, and state data while preserving unrelated agent configuration.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ include = [
     "/resources/opencode/**/*",
     "/resources/gemini/**/*",
     "/.pi/extensions/**/*",
+    "/.omp/extensions/**/*",
     "/Cargo.toml",
     "/Cargo.lock",
     "/CHANGELOG.md",

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Each pane supports:
   flag)
 
 Built-in agents (`claude`, `gemini`, `codex`, `opencode`, `kiro-cli`, `vibe`,
-`pi`) are auto-detected when used as literal commands and receive prompt
+`pi`, `omp`) are auto-detected when used as literal commands and receive prompt
 injection automatically, without needing the `<agent>` placeholder or a matching
 `agent` config:
 
@@ -735,7 +735,7 @@ done
 When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`,
 workmux automatically injects the prompt into panes running the configured agent
 command (e.g., `claude`, `codex`, `opencode`, `gemini`, `kiro-cli`, `vibe`,
-`pi`, or whatever you've set via the `agent` config or `--agent` flag) without
+`pi`, `omp`, or whatever you've set via the `agent` config or `--agent` flag) without
 requiring any `.workmux.yaml` changes:
 
 - Panes with a command matching the configured agent are automatically started
@@ -760,7 +760,7 @@ LLM. The tool used depends on your configuration:
 
 1. `auto_name.command` is set: uses that command as-is
 2. `config.agent` is a known agent (`claude`, `gemini`, `codex`, `opencode`,
-   `kiro-cli`, `vibe`, `pi`): uses the agent's CLI with a fast/cheap model
+   `kiro-cli`, `vibe`, `pi`, `omp`): uses the agent's CLI with a fast/cheap model
 3. Neither: falls back to the [`llm`](https://llm.datasette.io/) CLI tool
 
 ##### Usage
@@ -811,6 +811,7 @@ When an agent is configured, these commands are used automatically:
 | `opencode` | `opencode run`                                                           |
 | `kiro-cli` | `kiro-cli chat --no-interactive`                                         |
 | `pi`       | `pi -p`                                                                  |
+| `omp`      | `omp -p`                                                                 |
 
 To override back to `llm` when an agent is configured, set
 `auto_name.command: "llm"`.
@@ -1888,6 +1889,7 @@ at-a-glance visibility into what the agent in each window doing.
 | Codex        | ✅ Supported\*                                                              |
 | Copilot CLI  | ✅ Supported\*                                                              |
 | Pi           | ✅ Supported\*                                                              |
+| Oh My Pi    | ✅ Supported                                                                |
 | Gemini CLI   | ✅ Supported                                                                |
 | Kiro         | [Tracking issue](https://github.com/kirodotdev/Kiro/issues/5440)            |
 | Mistral Vibe | [Tracking issue](https://github.com/mistralai/mistral-vibe/discussions/334) |
@@ -1902,8 +1904,8 @@ at-a-glance visibility into what the agent in each window doing.
 
 ### Setup
 
-Run `workmux setup` to automatically detect your agent CLIs, install status
-tracking hooks, and install skills:
+Run `workmux setup` to automatically detect Claude Code, Copilot CLI, OpenCode,
+Pi, Oh My Pi, and other supported agent CLIs, install status tracking hooks, and install skills:
 
 ```bash
 workmux setup
@@ -1957,6 +1959,16 @@ curl -o ~/.config/opencode/plugins/workmux-status.ts \
 ```
 
 Restart OpenCode for the plugin to take effect.
+
+**Oh My Pi**: copy the workmux status extension to your global OMP extensions directory:
+
+```bash
+mkdir -p ~/.omp/agent/extensions
+curl -o ~/.omp/agent/extensions/workmux-status.ts \
+  https://raw.githubusercontent.com/raine/workmux/main/.omp/extensions/workmux-status.ts
+```
+
+Restart omp for the extension to take effect.
 
 ### Customization
 

--- a/docker/Dockerfile.omp
+++ b/docker/Dockerfile.omp
@@ -1,0 +1,21 @@
+ARG BASE=ghcr.io/raine/workmux-sandbox:base
+FROM ${BASE}
+
+ARG BUN_VERSION=1.3.14
+ENV BUN_INSTALL=/opt/bun PATH=/opt/bun/bin:/usr/local/bin:$PATH
+
+# Install runtime dependencies required by oh-my-pi.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 python3-pip python3-venv unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG CACHE_BUST=1
+
+# Install Bun and oh-my-pi globally.
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" && \
+    bun --version && \
+    bun install -g @oh-my-pi/pi-coding-agent && \
+    ln -sfn /opt/bun/bin/bun /usr/local/bin/bun && \
+    ln -sfn /opt/bun/bin/omp /usr/local/bin/omp
+
+RUN command -v bun && command -v python3 && command -v omp

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -8,7 +8,7 @@ workmux is designed with AI agent workflows in mind. Run multiple agents in para
 
 ## Agent integration
 
-When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`, workmux automatically injects the prompt into panes running the configured agent command (e.g., `claude`, `codex`, `opencode`, `gemini`, `kiro-cli`, `vibe`, `pi`, or whatever you've set via the `agent` config or `--agent` flag) without requiring any `.workmux.yaml` changes:
+When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`, workmux automatically injects the prompt into panes running the configured agent command (e.g., `claude`, `codex`, `opencode`, `gemini`, `kiro-cli`, `vibe`, `pi`, `omp`, or whatever you've set via the `agent` config or `--agent` flag) without requiring any `.workmux.yaml` changes:
 
 - Panes with a command matching the configured agent are automatically started with the given prompt.
 - You can keep your `.workmux.yaml` pane configuration simple (e.g., `panes: [{ command: "<agent>" }]`) and let workmux handle prompt injection at runtime.
@@ -92,7 +92,7 @@ Named agents are global-only for security. Define them in `~/.config/workmux/con
 
 ## Per-pane agents
 
-workmux automatically recognizes built-in agent commands (`claude`, `gemini`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`) in pane commands. This means prompt injection works without the `<agent>` placeholder or a matching `agent` config:
+workmux automatically recognizes built-in agent commands (`claude`, `gemini`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`, `omp`) in pane commands. This means prompt injection works without the `<agent>` placeholder or a matching `agent` config:
 
 ```yaml
 panes:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -177,7 +177,7 @@ Each pane supports:
 
 - `<agent>`: resolves to the configured agent (from `agent` config or `--agent` flag)
 
-Built-in agents (`claude`, `gemini`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`) are auto-detected when used as literal commands and receive prompt injection automatically, without needing the `<agent>` placeholder or a matching `agent` config:
+Built-in agents (`claude`, `gemini`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`, `omp`) are auto-detected when used as literal commands and receive prompt injection automatically, without needing the `<agent>` placeholder or a matching `agent` config:
 
 ```yaml
 panes:
@@ -305,7 +305,7 @@ auto_name:
 The command used for branch name generation is resolved in this order:
 
 1. `auto_name.command` is set: uses that command as-is
-2. `agent` is a known agent (`claude`, `gemini`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`): uses the agent's CLI with a fast/cheap model automatically
+2. `agent` is a known agent (`claude`, `gemini`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`, `omp`): uses the agent's CLI with a fast/cheap model automatically
 3. Neither: falls back to the `llm` CLI (requires installation)
 
 To override back to `llm` when an agent is configured, set `auto_name.command: "llm"`.

--- a/docs/guide/sandbox/features.md
+++ b/docs/guide/sandbox/features.md
@@ -46,7 +46,7 @@ Any allowed command can execute code from project files. For example, an agent c
 ```yaml
 # ~/.config/workmux/config.yaml
 sandbox:
-  host_commands: ['just', 'cargo', 'npm']
+  host_commands: ["just", "cargo", "npm"]
 ```
 
 `host_commands` is only read from your global config. If set in a project's `.workmux.yaml`, it is ignored and a warning is logged. This ensures that only you control which commands get host access, not the projects you clone.
@@ -108,16 +108,18 @@ Both sandbox backends mount agent-specific credential directories from the host.
 | `codex`    | `~/.codex/`                | `/home/user/.codex/`          | `$HOME/.codex/`                |
 | `opencode` | `~/.local/share/opencode/` | `/tmp/.local/share/opencode/` | `$HOME/.local/share/opencode/` |
 | `pi`       | `~/.pi/agent/`             | `/tmp/.pi/agent/`             | `$HOME/.pi/agent/`             |
+| `omp`      | `~/.omp/agent/`            | `/tmp/.omp/agent/`            | `$HOME/.omp/agent/`            |
 
 OpenCode's global config directory (`~/.config/opencode/`) is also mounted read-only, providing access to `opencode.json`, plugins, and global MCP definitions.
 
 Key behaviors:
 
-- Gemini, Codex, and OpenCode store credentials in files. If you've authenticated on the host, the sandbox automatically has access.
+- Gemini, Codex, OpenCode, and OMP store credentials in files. If you've authenticated on the host, the sandbox automatically has access.
 - Claude stores auth in macOS Keychain, which isn't accessible from containers or Linux VMs. You need to authenticate Claude separately inside the sandbox.
 - Authentication done inside the sandbox writes back to the host directory. Credentials persist across sandbox recreations.
 - The credential mount is determined by the `agent` setting. Switching agents requires recreating the sandbox (Lima) or starting a new container.
 - For `pi`, the entire `~/.pi/agent/` is shared except `bin/`. Pi auto-downloads platform-specific `fd` and `rg` binaries into `bin/`, so a Linux sandbox would otherwise overwrite a macOS host's Mach-O binaries through the bind mount. Workmux overlays a per-sandbox, arch-keyed directory on `bin/` to keep host and guest binaries separate.
+- OMP uses file-backed state and credentials mounted from `~/.omp/agent/`.
 
 The container backend also uses a separate config file for Claude, mounted to `/tmp/.claude.json` inside the container. Docker/Podman use `~/.claude-sandbox.json` (file mount); Apple Container uses `~/.claude-sandbox-config/claude.json` (directory mount, since Apple Container only supports directory mounts).
 
@@ -165,7 +167,7 @@ Requests are authenticated with a per-session token passed via the `WM_RPC_TOKEN
 
 ### Agent can't find credentials
 
-Claude stores auth in macOS Keychain, so it must authenticate separately inside containers and VMs. Other agents (Gemini, Codex, OpenCode) use file-based credentials that are shared with the host automatically.
+Claude stores auth in macOS Keychain, so it must authenticate separately inside containers and VMs. Other agents (Gemini, Codex, OpenCode, OMP) use file-based credentials that are shared with the host automatically.
 
 If credentials are missing, start a shell in the sandbox with `workmux sandbox shell` and run the agent to trigger authentication. Credentials written inside the sandbox persist to the host.
 

--- a/docs/guide/sandbox/lima.md
+++ b/docs/guide/sandbox/lima.md
@@ -110,6 +110,7 @@ The agent CLI installed depends on your `agent` configuration:
 | `gemini`           | Node.js + Gemini CLI via npm               |
 | `opencode`         | OpenCode binary via `opencode.ai/install`  |
 | `pi`               | Pi CLI via npm                             |
+| `omp`              | Oh My Pi CLI via Bun + Python              |
 
 Changing the `agent` setting after VM creation has no effect on existing VMs. Recreate the VM with `workmux sandbox prune` to provision with a different agent.
 

--- a/docs/guide/sidebar/customization.md
+++ b/docs/guide/sidebar/customization.md
@@ -172,6 +172,7 @@ Default icons:
 - `opencode` → `OC`
 - `gemini` → `G`
 - `pi` → `π`
+- `omp` → `⌥`
 - `kiro-cli` → `K`
 - `vibe` → `V`
 - `copilot` → `CP`
@@ -179,7 +180,7 @@ Default icons:
 Unknown agents render an empty icon.
 
 Default colors are brand accents: Claude orange, Codex teal, Gemini blue,
-Copilot purple, Vibe orange, Pi sage, OpenCode blue. Stale rows still dim
+Copilot purple, Vibe orange, Pi sage, OMP red/orange, OpenCode blue. Stale rows still dim
 and selected rows still take the highlight background; the icon color sits
 on top of those.
 

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -36,11 +36,17 @@ Run `workmux setup` to install all skills automatically:
 workmux setup --skills
 ```
 
-This detects your installed agents and copies skills to the right location. The setup wizard also offers skill installation on first run.
+This detects installed Claude Code, OpenCode, Pi, and Oh My Pi agents and copies skills to the right location. The setup wizard also offers skill installation on first run.
 
 You can also copy skills manually from [`skills/`](https://github.com/raine/workmux/tree/main/skills) to your skills directory:
 
 **Claude Code**: `~/.claude/skills/` (or project `.claude/skills/`). If `CLAUDE_CONFIG_DIR` is set, `workmux setup --skills` installs to `$CLAUDE_CONFIG_DIR/skills/` instead.
+
+**OpenCode**: `~/.config/opencode/skills/`.
+
+**Pi**: `~/.pi/agent/skills/`.
+
+**Oh My Pi**: `~/.omp/agent/skills/`.
 
 ## `/workmux`
 

--- a/docs/guide/status-tracking.md
+++ b/docs/guide/status-tracking.md
@@ -19,6 +19,7 @@ Workmux can display the status of the agent in your tmux window list, giving you
 | Codex        | ✅ Supported\*                                                              |
 | Copilot CLI  | ✅ Supported\*                                                              |
 | Pi           | ✅ Supported\*                                                              |
+| Oh My Pi     | ✅ Supported                                                                |
 | Gemini CLI   | ✅ Supported                                                                |
 | Kiro         | [Tracking issue](https://github.com/kirodotdev/Kiro/issues/5440)            |
 | Mistral Vibe | [Tracking issue](https://github.com/mistralai/mistral-vibe/discussions/334) |
@@ -44,7 +45,7 @@ Run `workmux setup` to automatically detect your agent CLIs and install status t
 workmux setup
 ```
 
-This detects Claude Code, Copilot CLI, OpenCode, and Pi by checking for their configuration directories, then offers to install the appropriate hooks. For Claude Code, `CLAUDE_CONFIG_DIR` is respected when locating `settings.json`. Workmux will also prompt you on first run if it detects an agent without status tracking configured.
+This detects Claude Code, Copilot CLI, OpenCode, Pi, and Oh My Pi by checking for their configuration directories, then offers to install the appropriate hooks. For Claude Code, `CLAUDE_CONFIG_DIR` is respected when locating `settings.json`. Workmux will also prompt you on first run if it detects an agent without status tracking configured.
 
 Workmux automatically modifies your tmux `window-status-format` to display the status icons. This happens once per session and only affects the current tmux session (not your global config).
 
@@ -70,6 +71,18 @@ curl -o ~/.pi/agent/extensions/workmux-status.ts \
 ```
 
 Restart pi for the extension to take effect.
+
+## Oh My Pi setup
+
+If you prefer manual setup, copy the workmux status extension to your global OMP extensions directory:
+
+```bash
+mkdir -p ~/.omp/agent/extensions
+curl -o ~/.omp/agent/extensions/workmux-status.ts \
+  https://raw.githubusercontent.com/raine/workmux/main/.omp/extensions/workmux-status.ts
+```
+
+Restart omp for the extension to take effect.
 
 ## OpenCode setup
 

--- a/docs/reference/commands/add.md
+++ b/docs/reference/commands/add.md
@@ -177,7 +177,7 @@ workmux add feature/ai-session --mode session -p "Implement the new API"
 
 ## AI agent integration
 
-When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`, workmux automatically injects the prompt into panes running the configured agent command (e.g., `claude`, `codex`, `opencode`, `gemini`, `kiro-cli`, `vibe`, `pi`, or whatever you've set via the `agent` config or `--agent` flag) without requiring any `.workmux.yaml` changes:
+When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`, workmux automatically injects the prompt into panes running the configured agent command (e.g., `claude`, `codex`, `opencode`, `gemini`, `kiro-cli`, `vibe`, `pi`, `omp`, or whatever you've set via the `agent` config or `--agent` flag) without requiring any `.workmux.yaml` changes:
 
 - Panes with a command matching the configured agent are automatically started with the given prompt.
 - You can keep your `.workmux.yaml` pane configuration simple (e.g., `panes: [{ command: "<agent>" }]`) and let workmux handle prompt injection at runtime.
@@ -191,7 +191,7 @@ If your editor has an embedded agent (e.g., neovim with an agent plugin), use `-
 The `--auto-name` (`-A`) flag generates a branch name from your prompt using an LLM. The tool used depends on your configuration:
 
 1. `auto_name.command` is set: uses that command as-is
-2. `config.agent` is a known agent (`claude`, `gemini`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`): uses the agent's CLI with a fast/cheap model
+2. `config.agent` is a known agent (`claude`, `gemini`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`, `omp`): uses the agent's CLI with a fast/cheap model
 3. Neither: falls back to the [`llm`](https://llm.datasette.io/) CLI tool
 
 ### Usage
@@ -239,6 +239,7 @@ When an agent is configured, these commands are used automatically:
 | `opencode` | `opencode run`                                                           |
 | `kiro-cli` | `kiro-cli chat --no-interactive`                                         |
 | `pi`       | `pi -p`                                                                  |
+| `omp`      | `omp -p`                                                                 |
 
 To override back to `llm` when an agent is configured, set `auto_name.command: "llm"`.
 

--- a/src/agent_identity.rs
+++ b/src/agent_identity.rs
@@ -27,6 +27,7 @@ pub enum AgentKind {
     OpenCode,
     Gemini,
     Pi,
+    Omp,
     KiroCli,
     Vibe,
     Copilot,
@@ -42,6 +43,7 @@ impl AgentKind {
             AgentKind::OpenCode => "opencode",
             AgentKind::Gemini => "gemini",
             AgentKind::Pi => "pi",
+            AgentKind::Omp => "omp",
             AgentKind::KiroCli => "kiro-cli",
             AgentKind::Vibe => "vibe",
             AgentKind::Copilot => "copilot",
@@ -56,6 +58,7 @@ impl AgentKind {
             "opencode" => Some(AgentKind::OpenCode),
             "gemini" => Some(AgentKind::Gemini),
             "pi" => Some(AgentKind::Pi),
+            "omp" => Some(AgentKind::Omp),
             "kiro-cli" => Some(AgentKind::KiroCli),
             "vibe" => Some(AgentKind::Vibe),
             "copilot" => Some(AgentKind::Copilot),
@@ -72,6 +75,7 @@ impl AgentKind {
             AgentKind::OpenCode => "OC",
             AgentKind::Gemini => "G",
             AgentKind::Pi => "π",
+            AgentKind::Omp => "⌥",
             AgentKind::KiroCli => "K",
             AgentKind::Vibe => "V",
             AgentKind::Copilot => "CP",
@@ -87,6 +91,7 @@ impl AgentKind {
             AgentKind::OpenCode => "OpenCode",
             AgentKind::Gemini => "Gemini",
             AgentKind::Pi => "Pi",
+            AgentKind::Omp => "Oh My Pi",
             AgentKind::KiroCli => "Kiro",
             AgentKind::Vibe => "Vibe",
             AgentKind::Copilot => "Copilot",
@@ -107,6 +112,7 @@ impl AgentKind {
             AgentKind::Copilot => Color::Rgb(0x89, 0x57, 0xe5),
             AgentKind::Vibe => Color::Rgb(0xff, 0x82, 0x05),
             AgentKind::Pi => Color::Rgb(0x96, 0xbb, 0xb5),
+            AgentKind::Omp => Color::Rgb(0xe0, 0x57, 0x35),
             AgentKind::OpenCode => Color::Blue,
             AgentKind::KiroCli => return None,
         })
@@ -168,10 +174,20 @@ fn classify_by_title(title: &str) -> Option<AgentKind> {
     if title.contains('\u{03C0}') {
         return Some(AgentKind::Pi);
     }
+    if title.contains("Oh My Pi") || contains_omp_ascii_case_insensitive(title) {
+        return Some(AgentKind::Omp);
+    }
     if title.contains("Vibe") {
         return Some(AgentKind::Vibe);
     }
     None
+}
+
+fn contains_omp_ascii_case_insensitive(title: &str) -> bool {
+    title
+        .as_bytes()
+        .windows(3)
+        .any(|w| w.eq_ignore_ascii_case(b"omp"))
 }
 
 fn is_generic_interpreter(stem: &str) -> bool {
@@ -247,6 +263,7 @@ mod tests {
         assert_eq!(classify("claude", ""), Some("claude".into()));
         assert_eq!(classify("gemini", ""), Some("gemini".into()));
         assert_eq!(classify("pi", ""), Some("pi".into()));
+        assert_eq!(classify("omp", ""), Some("omp".into()));
         assert_eq!(classify("vibe", ""), Some("vibe".into()));
     }
 
@@ -279,6 +296,12 @@ mod tests {
             classify("node", "\u{03C0} - sidebar-templates"),
             Some("pi".into())
         );
+    }
+
+    #[test]
+    fn generic_interpreter_with_omp_title() {
+        assert_eq!(classify("bun", "omp"), Some("omp".into()));
+        assert_eq!(classify("python3", "Oh My Pi"), Some("omp".into()));
     }
 
     #[test]
@@ -340,6 +363,7 @@ mod tests {
             AgentKind::OpenCode,
             AgentKind::Gemini,
             AgentKind::Pi,
+            AgentKind::Omp,
             AgentKind::KiroCli,
             AgentKind::Vibe,
             AgentKind::Copilot,

--- a/src/agent_identity.rs
+++ b/src/agent_identity.rs
@@ -185,9 +185,8 @@ fn classify_by_title(title: &str) -> Option<AgentKind> {
 
 fn contains_omp_ascii_case_insensitive(title: &str) -> bool {
     title
-        .as_bytes()
-        .windows(3)
-        .any(|w| w.eq_ignore_ascii_case(b"omp"))
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .any(|token| token.eq_ignore_ascii_case("omp"))
 }
 
 fn is_generic_interpreter(stem: &str) -> bool {
@@ -301,7 +300,17 @@ mod tests {
     #[test]
     fn generic_interpreter_with_omp_title() {
         assert_eq!(classify("bun", "omp"), Some("omp".into()));
+        assert_eq!(classify("bun", "OMP"), Some("omp".into()));
+        assert_eq!(classify("bun", "agent: omp"), Some("omp".into()));
         assert_eq!(classify("python3", "Oh My Pi"), Some("omp".into()));
+    }
+
+    #[test]
+    fn generic_interpreter_with_omp_substring_title_does_not_match() {
+        assert_eq!(classify("bun", "component-tests"), None);
+        assert_eq!(classify("node", "compile server"), None);
+        assert_eq!(classify("python3", "company dashboard"), None);
+        assert_eq!(classify("python3", "completion worker"), None);
     }
 
     #[test]

--- a/src/agent_setup/mod.rs
+++ b/src/agent_setup/mod.rs
@@ -9,6 +9,7 @@ pub mod codex;
 pub mod copilot;
 pub mod gemini;
 pub mod hooks;
+pub mod omp;
 pub mod opencode;
 pub mod pi;
 
@@ -30,6 +31,8 @@ pub enum Agent {
     Gemini,
     OpenCode,
     Pi,
+    #[serde(rename = "omp")]
+    Omp,
 }
 
 impl Agent {
@@ -41,6 +44,7 @@ impl Agent {
             Agent::Gemini => "Gemini CLI",
             Agent::OpenCode => "OpenCode",
             Agent::Pi => "pi",
+            Agent::Omp => "Oh My Pi",
         }
     }
 
@@ -54,6 +58,7 @@ impl Agent {
             Agent::Gemini,
             Agent::OpenCode,
             Agent::Pi,
+            Agent::Omp,
         ]
     }
 }
@@ -143,6 +148,18 @@ pub fn check_all() -> Vec<AgentCheck> {
         });
     }
 
+    if let Some(reason) = omp::detect() {
+        let status = match omp::check() {
+            Ok(s) => s,
+            Err(e) => StatusCheck::Error(e.to_string()),
+        };
+        results.push(AgentCheck {
+            agent: Agent::Omp,
+            reason,
+            status,
+        });
+    }
+
     if let Some(reason) = opencode::detect() {
         let status = match opencode::check() {
             Ok(s) => s,
@@ -167,6 +184,7 @@ pub fn install(agent: Agent) -> Result<String> {
         Agent::Gemini => gemini::install(),
         Agent::OpenCode => opencode::install(),
         Agent::Pi => pi::install(),
+        Agent::Omp => omp::install(),
     }
 }
 
@@ -179,6 +197,7 @@ pub fn uninstall_one(agent: Agent) -> Result<String> {
         Agent::Gemini => gemini::uninstall(),
         Agent::OpenCode => opencode::uninstall(),
         Agent::Pi => pi::uninstall(),
+        Agent::Omp => omp::uninstall(),
     }
 }
 
@@ -438,6 +457,7 @@ mod tests {
         assert_eq!(Agent::Gemini.name(), "Gemini CLI");
         assert_eq!(Agent::OpenCode.name(), "OpenCode");
         assert_eq!(Agent::Pi.name(), "pi");
+        assert_eq!(Agent::Omp.name(), "Oh My Pi");
     }
 
     #[test]
@@ -454,6 +474,7 @@ mod tests {
             "\"opencode\""
         );
         assert_eq!(serde_json::to_string(&Agent::Pi).unwrap(), "\"pi\"");
+        assert_eq!(serde_json::to_string(&Agent::Omp).unwrap(), "\"omp\"");
     }
 
     #[test]
@@ -470,6 +491,8 @@ mod tests {
         assert_eq!(agent, Agent::OpenCode);
         let agent: Agent = serde_json::from_str("\"pi\"").unwrap();
         assert_eq!(agent, Agent::Pi);
+        let agent: Agent = serde_json::from_str("\"omp\"").unwrap();
+        assert_eq!(agent, Agent::Omp);
     }
 
     #[test]
@@ -496,13 +519,15 @@ mod tests {
         state.declined.insert(Agent::Codex);
         state.declined.insert(Agent::OpenCode);
         state.declined.insert(Agent::Pi);
+        state.declined.insert(Agent::Omp);
 
         let json = serde_json::to_string_pretty(&state).unwrap();
         let deserialized: SetupState = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.declined.len(), 4);
+        assert_eq!(deserialized.declined.len(), 5);
         assert!(deserialized.declined.contains(&Agent::Claude));
         assert!(deserialized.declined.contains(&Agent::Codex));
         assert!(deserialized.declined.contains(&Agent::OpenCode));
+        assert!(deserialized.declined.contains(&Agent::Omp));
     }
 
     #[test]

--- a/src/agent_setup/omp.rs
+++ b/src/agent_setup/omp.rs
@@ -113,7 +113,9 @@ mod tests {
 
     #[test]
     fn test_extension_tracks_waiting_status() {
-        assert!(EXTENSION_SOURCE.contains("pi.on(\"message_update\""));
+        assert!(EXTENSION_SOURCE.contains("lastStatus"));
+        assert!(EXTENSION_SOURCE.contains("statusQueue"));
+        assert!(EXTENSION_SOURCE.contains("status === lastStatus"));
         assert!(EXTENSION_SOURCE.contains("pi.on(\"message_end\""));
         assert!(EXTENSION_SOURCE.contains("\"role\" in event.message"));
         assert!(EXTENSION_SOURCE.contains("event.message.role === \"assistant\""));

--- a/src/agent_setup/omp.rs
+++ b/src/agent_setup/omp.rs
@@ -6,8 +6,9 @@
 //! Installs extension by writing `workmux-status.ts` to the extensions directory.
 
 use anyhow::{Context, Result};
+use std::ffi::OsString;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::StatusCheck;
 
@@ -15,7 +16,27 @@ use super::StatusCheck;
 const EXTENSION_SOURCE: &str = include_str!("../../.omp/extensions/workmux-status.ts");
 
 fn omp_agent_dir() -> Option<PathBuf> {
-    home::home_dir().map(|h| h.join(".omp/agent"))
+    let home = home::home_dir()?;
+    Some(omp_agent_dir_with_env(&home, |key| std::env::var_os(key)))
+}
+
+pub(crate) fn omp_agent_dir_with_env(
+    home: &Path,
+    get_env: impl Fn(&str) -> Option<OsString>,
+) -> PathBuf {
+    if let Some(dir) = get_env("PI_CODING_AGENT_DIR") {
+        return PathBuf::from(dir);
+    }
+
+    let config_dir = get_env("PI_CONFIG_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(".omp"));
+
+    if config_dir.is_absolute() {
+        config_dir.join("agent")
+    } else {
+        home.join(config_dir).join("agent")
+    }
 }
 
 fn extension_path() -> Option<PathBuf> {
@@ -99,6 +120,31 @@ mod tests {
         assert!(EXTENSION_SOURCE.contains("pi.on(\"tool_call\""));
         assert!(EXTENSION_SOURCE.contains("event.toolName === \"ask\""));
         assert!(EXTENSION_SOURCE.contains("setStatus(\"waiting\")"));
+    }
+
+    #[test]
+    fn test_omp_agent_dir_default() {
+        let dir = omp_agent_dir_with_env(Path::new("/home/test"), |_| None);
+
+        assert_eq!(dir, PathBuf::from("/home/test/.omp/agent"));
+    }
+
+    #[test]
+    fn test_omp_agent_dir_respects_pi_config_dir() {
+        let dir = omp_agent_dir_with_env(Path::new("/home/test"), |key| {
+            (key == "PI_CONFIG_DIR").then(|| OsString::from("custom-omp"))
+        });
+
+        assert_eq!(dir, PathBuf::from("/home/test/custom-omp/agent"));
+    }
+
+    #[test]
+    fn test_omp_agent_dir_respects_pi_coding_agent_dir() {
+        let dir = omp_agent_dir_with_env(Path::new("/home/test"), |key| {
+            (key == "PI_CODING_AGENT_DIR").then(|| OsString::from("/tmp/omp-agent"))
+        });
+
+        assert_eq!(dir, PathBuf::from("/tmp/omp-agent"));
     }
 
     #[test]

--- a/src/agent_setup/omp.rs
+++ b/src/agent_setup/omp.rs
@@ -1,0 +1,134 @@
+//! OMP agent status tracking setup.
+//!
+//! Detects OMP via its agent directory at `~/.omp/agent/` and writes
+//! `workmux-status.ts` to that agent directory.
+//!
+//! Installs extension by writing `workmux-status.ts` to the extensions directory.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::PathBuf;
+
+use super::StatusCheck;
+
+/// The OMP extension source, embedded at compile time.
+const EXTENSION_SOURCE: &str = include_str!("../../.omp/extensions/workmux-status.ts");
+
+fn omp_agent_dir() -> Option<PathBuf> {
+    home::home_dir().map(|h| h.join(".omp/agent"))
+}
+
+fn extension_path() -> Option<PathBuf> {
+    omp_agent_dir().map(|d| d.join("extensions/workmux-status.ts"))
+}
+
+/// Detect if OMP is present via filesystem.
+/// Returns the reason string if detected, None otherwise.
+pub fn detect() -> Option<&'static str> {
+    if omp_agent_dir().is_some_and(|d| d.is_dir()) {
+        return Some("found ~/.omp/agent/");
+    }
+    None
+}
+
+/// Check if workmux extension is installed for OMP.
+pub fn check() -> Result<StatusCheck> {
+    let Some(path) = extension_path() else {
+        return Ok(StatusCheck::NotInstalled);
+    };
+
+    if path.exists() {
+        Ok(StatusCheck::Installed)
+    } else {
+        Ok(StatusCheck::NotInstalled)
+    }
+}
+
+/// Install workmux extension for OMP.
+/// Returns a description of what was done.
+pub fn install() -> Result<String> {
+    let path =
+        extension_path().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).context("Failed to create omp extensions directory")?;
+    }
+
+    fs::write(&path, EXTENSION_SOURCE).context("Failed to write omp extension")?;
+
+    Ok(format!(
+        "Installed extension to {}. Restart omp for it to take effect.",
+        path.display()
+    ))
+}
+
+/// Remove workmux extension for OMP agent.
+///
+/// Deletes the extension file and cleans up empty parent directories.
+pub fn uninstall() -> Result<String> {
+    let Some(path) = extension_path() else {
+        return Ok("omp config dir not found, nothing to uninstall".to_string());
+    };
+    uninstall_at(path)
+}
+
+fn uninstall_at(path: PathBuf) -> Result<String> {
+    if !path.exists() {
+        return Ok("No omp extension found".to_string());
+    }
+    fs::remove_file(&path)?;
+    // Clean up empty extensions directory
+    if let Some(parent) = path.parent()
+        && parent.read_dir().is_ok_and(|mut it| it.next().is_none())
+    {
+        let _ = fs::remove_dir(parent);
+    }
+    Ok(format!("Removed omp extension at {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extension_tracks_waiting_status() {
+        assert!(EXTENSION_SOURCE.contains("pi.on(\"message_update\""));
+        assert!(EXTENSION_SOURCE.contains("pi.on(\"message_end\""));
+        assert!(EXTENSION_SOURCE.contains("\"role\" in event.message"));
+        assert!(EXTENSION_SOURCE.contains("event.message.role === \"assistant\""));
+        assert!(EXTENSION_SOURCE.contains("pi.on(\"tool_call\""));
+        assert!(EXTENSION_SOURCE.contains("event.toolName === \"ask\""));
+        assert!(EXTENSION_SOURCE.contains("setStatus(\"waiting\")"));
+    }
+
+    #[test]
+    fn test_uninstall_no_omp_extension_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ext_path = tmp.path().join("extensions/workmux-status.ts");
+        let result = uninstall_at(ext_path).unwrap();
+        assert!(result.contains("No omp extension found"));
+    }
+
+    #[test]
+    fn test_uninstall_removes_omp_extension_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ext_dir = tmp.path().join("extensions");
+        std::fs::create_dir_all(&ext_dir).unwrap();
+        let ext_path = ext_dir.join("workmux-status.ts");
+        std::fs::write(&ext_path, "// extension").unwrap();
+
+        let result = uninstall_at(ext_path.clone()).unwrap();
+        assert!(result.contains("Removed omp extension"));
+        assert!(!ext_path.exists());
+    }
+
+    #[test]
+    fn test_uninstall_omp_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ext_path = tmp.path().join("extensions/workmux-status.ts");
+        let result1 = uninstall_at(ext_path.clone()).unwrap();
+        assert!(result1.contains("No omp extension found"));
+        let result2 = uninstall_at(ext_path).unwrap();
+        assert!(result2.contains("No omp extension found"));
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1749,6 +1749,7 @@ impl SandboxConfig {
                 "codex" => Some(home.join(".codex")),
                 "opencode" => Some(home.join(".local/share/opencode")),
                 "pi" => Some(home.join(".pi/agent")),
+                "omp" => Some(home.join(".omp/agent")),
                 _ => None,
             }
         }
@@ -4182,6 +4183,8 @@ extra_mounts:
         let dir = config.resolved_agent_config_dir("claude").unwrap();
         let home = home::home_dir().unwrap();
         assert_eq!(dir, home.join(".claude"));
+        let dir = config.resolved_agent_config_dir("omp").unwrap();
+        assert_eq!(dir, home.join(".omp/agent"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1749,7 +1749,10 @@ impl SandboxConfig {
                 "codex" => Some(home.join(".codex")),
                 "opencode" => Some(home.join(".local/share/opencode")),
                 "pi" => Some(home.join(".pi/agent")),
-                "omp" => Some(home.join(".omp/agent")),
+                "omp" => Some(crate::agent_setup::omp::omp_agent_dir_with_env(
+                    &home,
+                    |key| std::env::var_os(key),
+                )),
                 _ => None,
             }
         }
@@ -4185,6 +4188,29 @@ extra_mounts:
         assert_eq!(dir, home.join(".claude"));
         let dir = config.resolved_agent_config_dir("omp").unwrap();
         assert_eq!(dir, home.join(".omp/agent"));
+    }
+
+    #[test]
+    fn test_resolved_agent_config_dir_omp_with_pi_config_dir() {
+        // SAFETY: this test restores the original value before returning.
+        let prev = std::env::var_os("PI_CONFIG_DIR");
+        unsafe {
+            std::env::set_var("PI_CONFIG_DIR", "custom-omp");
+        }
+
+        let config = SandboxConfig::default();
+        let dir = config.resolved_agent_config_dir("omp").unwrap();
+        let home = home::home_dir().unwrap();
+        assert_eq!(dir, home.join("custom-omp/agent"));
+
+        match prev {
+            Some(v) => unsafe {
+                std::env::set_var("PI_CONFIG_DIR", v);
+            },
+            None => unsafe {
+                std::env::remove_var("PI_CONFIG_DIR");
+            },
+        }
     }
 
     #[test]

--- a/src/multiplexer/agent.rs
+++ b/src/multiplexer/agent.rs
@@ -239,6 +239,30 @@ impl AgentProfile for PiProfile {
     }
 }
 
+pub struct OmpProfile;
+
+impl AgentProfile for OmpProfile {
+    fn name(&self) -> &'static str {
+        "omp"
+    }
+
+    fn needs_auto_status(&self) -> bool {
+        true
+    }
+
+    fn prompt_argument(&self, prompt_path: &str) -> String {
+        format!("\"$(cat {})\"", prompt_path)
+    }
+
+    fn auto_name_command(&self) -> Option<&'static str> {
+        Some("omp -p")
+    }
+
+    fn continue_flag(&self) -> Option<&'static str> {
+        Some("--continue")
+    }
+}
+
 pub struct DefaultProfile;
 
 impl AgentProfile for DefaultProfile {
@@ -255,6 +279,7 @@ static PROFILES: &[&dyn AgentProfile] = &[
     &OpenCodeProfile,
     &CodexProfile,
     &PiProfile,
+    &OmpProfile,
     &KiroProfile,
     &VibeProfile,
 ];
@@ -540,6 +565,18 @@ mod tests {
     }
 
     #[test]
+    fn test_omp_profile() {
+        let profile = OmpProfile;
+        assert_eq!(profile.name(), "omp");
+        assert!(!profile.needs_bang_delay());
+        assert!(profile.needs_auto_status());
+        assert_eq!(profile.prompt_argument("PROMPT.md"), "\"$(cat PROMPT.md)\"");
+        assert_eq!(profile.skip_permissions_flag(), None);
+        assert_eq!(profile.auto_name_command(), Some("omp -p"));
+        assert_eq!(profile.continue_flag(), Some("--continue"));
+    }
+
+    #[test]
     fn test_default_profile() {
         let profile = DefaultProfile;
         assert_eq!(profile.name(), "default");
@@ -592,6 +629,12 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_profile_omp() {
+        let profile = resolve_profile(Some("omp"));
+        assert_eq!(profile.name(), "omp");
+    }
+
+    #[test]
     fn test_resolve_profile_codex() {
         let profile = resolve_profile(Some("codex"));
         assert_eq!(profile.name(), "codex");
@@ -630,6 +673,7 @@ mod tests {
         assert!(is_known_agent("codex"));
         assert!(is_known_agent("opencode"));
         assert!(is_known_agent("pi"));
+        assert!(is_known_agent("omp"));
         assert!(is_known_agent("kiro-cli"));
         assert!(is_known_agent("vibe"));
     }
@@ -722,6 +766,7 @@ mod tests {
         assert!(is_known_agent("env -u FOO claude"));
         assert!(is_known_agent("env FOO=bar codex --yolo"));
         assert!(is_known_agent("FOO=bar gemini -i foo"));
+        assert!(is_known_agent("env FOO=bar omp --continue"));
     }
 
     #[test]

--- a/src/sandbox/clipboard.rs
+++ b/src/sandbox/clipboard.rs
@@ -128,20 +128,21 @@ fn parse_osascript_hex(output: &str) -> Result<Option<Vec<u8>>> {
 #[cfg(target_os = "linux")]
 fn read_png_linux() -> Result<Option<Vec<u8>>> {
     // Try wl-paste first (Wayland)
-    if let Ok(output) = Command::new("wl-paste").args(["-t", "image/png"]).output() {
-        if output.status.success() && !output.stdout.is_empty() {
-            return Ok(Some(output.stdout));
-        }
+    if let Ok(output) = Command::new("wl-paste").args(["-t", "image/png"]).output()
+        && output.status.success()
+        && !output.stdout.is_empty()
+    {
+        return Ok(Some(output.stdout));
     }
 
     // Fall back to xclip (X11)
     if let Ok(output) = Command::new("xclip")
         .args(["-selection", "clipboard", "-t", "image/png", "-o"])
         .output()
+        && output.status.success()
+        && !output.stdout.is_empty()
     {
-        if output.status.success() && !output.stdout.is_empty() {
-            return Ok(Some(output.stdout));
-        }
+        return Ok(Some(output.stdout));
     }
 
     Ok(None)

--- a/src/sandbox/container.rs
+++ b/src/sandbox/container.rs
@@ -18,9 +18,10 @@ pub const DOCKERFILE_CODEX: &str = include_str!("../../docker/Dockerfile.codex")
 pub const DOCKERFILE_GEMINI: &str = include_str!("../../docker/Dockerfile.gemini");
 pub const DOCKERFILE_OPENCODE: &str = include_str!("../../docker/Dockerfile.opencode");
 pub const DOCKERFILE_PI: &str = include_str!("../../docker/Dockerfile.pi");
+pub const DOCKERFILE_OMP: &str = include_str!("../../docker/Dockerfile.omp");
 
 /// Known agents that have pre-built images.
-pub const KNOWN_AGENTS: &[&str] = &["claude", "codex", "gemini", "opencode", "pi"];
+pub const KNOWN_AGENTS: &[&str] = &["claude", "codex", "gemini", "opencode", "pi", "omp"];
 
 /// Get the agent-specific Dockerfile content, or None for unknown agents.
 pub fn dockerfile_for_agent(agent: &str) -> Option<&'static str> {
@@ -30,6 +31,7 @@ pub fn dockerfile_for_agent(agent: &str) -> Option<&'static str> {
         "gemini" => Some(DOCKERFILE_GEMINI),
         "opencode" => Some(DOCKERFILE_OPENCODE),
         "pi" => Some(DOCKERFILE_PI),
+        "omp" => Some(DOCKERFILE_OMP),
         _ => None,
     }
 }
@@ -538,6 +540,7 @@ pub fn build_docker_run_args(
             "codex" => "/home/user/.codex",
             "opencode" => "/tmp/.local/share/opencode",
             "pi" => "/tmp/.pi/agent",
+            "omp" => "/tmp/.omp/agent",
             _ => unreachable!(), // resolved_agent_config_dir returns None for unknown agents
         };
         let _ = std::fs::create_dir_all(&config_dir);
@@ -1387,6 +1390,7 @@ mod tests {
         assert!(dockerfile_for_agent("gemini").is_some());
         assert!(dockerfile_for_agent("opencode").is_some());
         assert!(dockerfile_for_agent("pi").is_some());
+        assert!(dockerfile_for_agent("omp").is_some());
     }
 
     #[test]
@@ -2210,6 +2214,42 @@ mod tests {
     }
 
     #[test]
+    fn test_build_args_omp_agent_mounts_config_dir() {
+        use crate::config::{ContainerConfig, SandboxConfig, SandboxRuntime};
+        let config = SandboxConfig {
+            enabled: Some(true),
+            container: ContainerConfig {
+                runtime: Some(SandboxRuntime::AppleContainer),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let args = build_docker_run_args(
+            "omp",
+            &config,
+            "omp",
+            Path::new("/tmp/project"),
+            Path::new("/tmp/project"),
+            &[],
+            None,
+            false,
+        )
+        .unwrap();
+
+        let args_str = args.join(" ");
+        assert!(
+            args_str.contains("/tmp/.omp/agent"),
+            "omp agent config mount missing: {}",
+            args_str
+        );
+        assert!(
+            !args_str.contains("/tmp/.claude.json"),
+            "no claude mount expected for omp"
+        );
+        assert!(!args_str.contains("/tmp/.claude,"));
+    }
+
+    #[test]
     fn test_build_args_pi_agent_overlays_bin_after_parent() {
         use crate::config::SandboxConfig;
         let config = SandboxConfig {
@@ -2271,9 +2311,9 @@ mod tests {
             ..Default::default()
         };
         let args = build_docker_run_args(
-            "claude",
+            "omp",
             &config,
-            "claude",
+            "omp",
             Path::new("/tmp/myproject"),
             Path::new("/tmp/myproject"),
             &[],
@@ -2285,7 +2325,7 @@ mod tests {
         let args_str = args.join(" ");
         assert!(
             !args_str.contains("pi-agent-bin"),
-            "claude agent should not have pi bin overlay"
+            "omp agent should not have pi bin overlay"
         );
     }
 }

--- a/src/sandbox/host_exec_sandbox.rs
+++ b/src/sandbox/host_exec_sandbox.rs
@@ -364,27 +364,27 @@ fn spawn_bwrap(
     // Hide secret directories behind tmpfs
     for dir in DENY_READ_DIRS {
         let path = home_path.join(dir);
-        if path.exists() {
-            if let Some(s) = path.to_str() {
-                cmd.args(["--tmpfs", s]);
-            }
+        if path.exists()
+            && let Some(s) = path.to_str()
+        {
+            cmd.args(["--tmpfs", s]);
         }
     }
     for path in &extra_deny {
-        if path.exists() {
-            if let Some(s) = path.to_str() {
-                cmd.args(["--tmpfs", s]);
-            }
+        if path.exists()
+            && let Some(s) = path.to_str()
+        {
+            cmd.args(["--tmpfs", s]);
         }
     }
 
     // Hide secret files by binding /dev/null over them
     for file in DENY_READ_FILES {
         let path = home_path.join(file);
-        if path.is_file() {
-            if let Some(s) = path.to_str() {
-                cmd.args(["--ro-bind", "/dev/null", s]);
-            }
+        if path.is_file()
+            && let Some(s) = path.to_str()
+        {
+            cmd.args(["--ro-bind", "/dev/null", s]);
         }
     }
 
@@ -392,22 +392,22 @@ fn spawn_bwrap(
     // (the root is read-only, so the process can't create them itself)
     for dir in ALLOW_WRITE_DIRS {
         let path = home_path.join(dir);
-        if !path.exists() {
-            if let Err(e) = std::fs::create_dir_all(&path) {
-                debug!(?path, error = %e, "failed to create cache dir for bwrap binding");
-                continue;
-            }
+        if !path.exists()
+            && let Err(e) = std::fs::create_dir_all(&path)
+        {
+            debug!(?path, error = %e, "failed to create cache dir for bwrap binding");
+            continue;
         }
         if let Some(s) = path.to_str() {
             cmd.args(["--bind", s, s]);
         }
     }
     for path in &extra_write {
-        if !path.exists() {
-            if let Err(e) = std::fs::create_dir_all(path) {
-                debug!(?path, error = %e, "failed to create XDG dir for bwrap binding");
-                continue;
-            }
+        if !path.exists()
+            && let Err(e) = std::fs::create_dir_all(path)
+        {
+            debug!(?path, error = %e, "failed to create XDG dir for bwrap binding");
+            continue;
         }
         if let Some(s) = path.to_str() {
             cmd.args(["--bind", s, s]);

--- a/src/sandbox/lima/config.rs
+++ b/src/sandbox/lima/config.rs
@@ -58,6 +58,19 @@ npm install -g @mariozechner/pi-coding-agent
 "#
         .to_string(),
 
+        "omp" => r#"# Install Python and Bun (required for oh-my-pi)
+sudo apt-get install -y --no-install-recommends python3 python3-pip python3-venv unzip
+export BUN_INSTALL="$HOME/.bun"
+curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
+export PATH="$BUN_INSTALL/bin:$PATH"
+sudo ln -sfn "$BUN_INSTALL/bin/bun" /usr/local/bin/bun
+
+# Install oh-my-pi CLI
+bun install -g @oh-my-pi/pi-coding-agent
+sudo ln -sfn "$BUN_INSTALL/bin/omp" /usr/local/bin/omp
+"#
+        .to_string(),
+
         other => format!("# No built-in install script for agent: {other}\n\
                           # Use sandbox.lima.provision to install it manually.\n"),
     }
@@ -535,6 +548,22 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_lima_config_omp_agent() {
+        let mounts = vec![Mount::rw(PathBuf::from("/tmp/test"))];
+        let sandbox_config = SandboxConfig::default();
+        let yaml = generate_lima_config("test-vm", &mounts, &sandbox_config, "omp", true).unwrap();
+
+        assert!(yaml.contains("@oh-my-pi/pi-coding-agent"));
+        assert!(yaml.contains("bun install -g"));
+        assert!(yaml.contains("python3"));
+        assert!(!yaml.contains("nodesource.com"));
+        assert!(!yaml.contains("npm install -g"));
+        assert!(!yaml.contains("@mariozechner/pi-coding-agent"));
+        assert!(!yaml.contains("claude.ai/install.sh"));
+        assert!(!yaml.contains(".claude.json"));
+    }
+
+    #[test]
     fn test_generate_lima_config_unknown_agent() {
         let mounts = vec![Mount::rw(PathBuf::from("/tmp/test"))];
         let sandbox_config = SandboxConfig::default();
@@ -610,6 +639,19 @@ mod tests {
         let script = lima_install_script_for_agent("pi");
         assert!(script.contains("@mariozechner/pi-coding-agent"));
         assert!(script.contains("npm install -g"));
+    }
+
+    #[test]
+    fn test_lima_install_script_for_agent_omp() {
+        let script = lima_install_script_for_agent("omp");
+        assert!(script.contains("@oh-my-pi/pi-coding-agent"));
+        assert!(script.contains("bun install -g"));
+        assert!(script.contains("python3"));
+        assert!(!script.contains("nodesource.com"));
+        assert!(!script.contains("npm install -g"));
+        assert!(!script.contains("@mariozechner/pi-coding-agent"));
+        assert!(!script.contains("claude.ai/install.sh"));
+        assert!(!script.contains(".claude.json"));
     }
 
     #[test]

--- a/src/sandbox/lima/mounts.rs
+++ b/src/sandbox/lima/mounts.rs
@@ -263,6 +263,7 @@ pub fn generate_mounts(
             "codex" => ".codex",
             "opencode" => ".local/share/opencode",
             "pi" => ".pi/agent",
+            "omp" => ".omp/agent",
             _ => unreachable!(),
         };
         let guest_path = lima_guest_home()
@@ -469,6 +470,42 @@ mod tests {
             src.contains("test-vm"),
             "host path should be per-VM: {}",
             src
+        );
+    }
+
+    #[test]
+    fn test_omp_agent_mounts_agent_dir_without_bin_overlay() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_root = init_git_project(tmp.path());
+
+        let mut config = Config::default();
+        config.sandbox.agent_config_dir =
+            Some(format!("{}/agent-cfg/{{agent}}", tmp.path().display()));
+
+        let mounts = generate_mounts(
+            &project_root,
+            IsolationLevel::Project,
+            &config,
+            "test-vm",
+            "omp",
+        )
+        .unwrap();
+
+        assert!(
+            mounts.iter().any(|m| m.guest_path.ends_with(".omp/agent")),
+            "parent .omp/agent mount missing"
+        );
+        assert!(
+            !mounts
+                .iter()
+                .any(|m| m.guest_path.ends_with(".omp/agent/bin")),
+            "omp agent should not get a bin overlay"
+        );
+        assert!(
+            !mounts
+                .iter()
+                .any(|m| m.host_path.to_string_lossy().contains("pi-agent-bin")),
+            "omp agent should not get pi bin overlay"
         );
     }
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -71,7 +71,9 @@ fn skills_dir_with_env(
                 .unwrap_or_else(|| home.join(".pi/agent"));
             Some(pi_dir.join("skills"))
         }
-        Agent::Omp => Some(home.join(".omp/agent/skills")),
+        Agent::Omp => {
+            Some(crate::agent_setup::omp::omp_agent_dir_with_env(home, get_env).join("skills"))
+        }
         Agent::Codex | Agent::Copilot | Agent::Gemini => None,
     }
 }
@@ -363,6 +365,26 @@ mod tests {
         let dir = skills_dir_with_env(Agent::Omp, Path::new("/home/test"), |_| None).unwrap();
 
         assert_eq!(dir, PathBuf::from("/home/test/.omp/agent/skills"));
+    }
+
+    #[test]
+    fn test_skills_dir_omp_respects_pi_config_dir() {
+        let dir = skills_dir_with_env(Agent::Omp, Path::new("/home/test"), |key| {
+            (key == "PI_CONFIG_DIR").then(|| OsString::from("custom-omp"))
+        })
+        .unwrap();
+
+        assert_eq!(dir, PathBuf::from("/home/test/custom-omp/agent/skills"));
+    }
+
+    #[test]
+    fn test_skills_dir_omp_respects_pi_coding_agent_dir() {
+        let dir = skills_dir_with_env(Agent::Omp, Path::new("/home/test"), |key| {
+            (key == "PI_CODING_AGENT_DIR").then(|| OsString::from("/tmp/omp-agent"))
+        })
+        .unwrap();
+
+        assert_eq!(dir, PathBuf::from("/tmp/omp-agent/skills"));
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -71,6 +71,7 @@ fn skills_dir_with_env(
                 .unwrap_or_else(|| home.join(".pi/agent"));
             Some(pi_dir.join("skills"))
         }
+        Agent::Omp => Some(home.join(".omp/agent/skills")),
         Agent::Codex | Agent::Copilot | Agent::Gemini => None,
     }
 }
@@ -355,6 +356,13 @@ mod tests {
         let dir = skills_dir_with_env(Agent::Pi, Path::new("/home/test"), |_| None).unwrap();
 
         assert_eq!(dir, PathBuf::from("/home/test/.pi/agent/skills"));
+    }
+
+    #[test]
+    fn test_skills_dir_omp() {
+        let dir = skills_dir_with_env(Agent::Omp, Path::new("/home/test"), |_| None).unwrap();
+
+        assert_eq!(dir, PathBuf::from("/home/test/.omp/agent/skills"));
     }
 
     #[test]

--- a/src/workflow/file_ops.rs
+++ b/src/workflow/file_ops.rs
@@ -92,12 +92,12 @@ pub fn handle_file_operations(
                 if let Ok(metadata) = dest_path.symlink_metadata() {
                     if metadata.is_dir() {
                         fs::remove_dir_all(&dest_path).with_context(|| {
-                            format!("Failed to remove existing directory at {:?}", &dest_path)
+                            format!("Failed to remove existing directory at {:?}", dest_path)
                         })?;
                     } else {
                         // Handles both files and symlinks
                         fs::remove_file(&dest_path).with_context(|| {
-                            format!("Failed to remove existing file/symlink at {:?}", &dest_path)
+                            format!("Failed to remove existing file/symlink at {:?}", dest_path)
                         })?;
                     }
                 }

--- a/src/workflow/merge.rs
+++ b/src/workflow/merge.rs
@@ -254,10 +254,7 @@ pub fn merge(
     if rebase {
         // Rebase the feature branch on top of target inside its own worktree.
         // This is where conflicts will be detected.
-        println!(
-            "Rebasing '{}' onto '{}'...",
-            &branch_to_merge, target_branch
-        );
+        println!("Rebasing '{}' onto '{}'...", branch_to_merge, target_branch);
         info!(
             branch = %branch_to_merge,
             base = target_branch,

--- a/tests/test_workmux_add/test_agents.py
+++ b/tests/test_workmux_add/test_agents.py
@@ -238,9 +238,7 @@ printf '%s' "$1" > omp_prompt.txt
 """,
         )
 
-        write_workmux_config(
-            mux_repo_path, agent="omp", panes=[{"command": "<agent>"}]
-        )
+        write_workmux_config(mux_repo_path, agent="omp", panes=[{"command": "<agent>"}])
 
         worktree_path = add_branch_and_get_worktree(
             env,

--- a/tests/test_workmux_add/test_agents.py
+++ b/tests/test_workmux_add/test_agents.py
@@ -210,6 +210,56 @@ printf '%s' "$2" > "{output_filename}"
         )
         assert agent_output.read_text() == prompt_text
 
+    def test_add_uses_omp_agent_from_config(
+        self,
+        mux_server: MuxEnvironment,
+        workmux_exe_path: Path,
+        mux_repo_path: Path,
+        fake_agent_installer: FakeAgentInstaller,
+        shell_cmd: ShellCommands,
+    ):
+        """OMP receives the prompt as a positional argument."""
+        env = mux_server
+        branch_name = "feature-config-omp-agent"
+        window_name = get_window_name(branch_name)
+        prompt_text = "Using configured OMP agent"
+
+        env.configure_default_shell(shell_cmd.path)
+
+        fake_agent_installer.install(
+            "omp",
+            """#!/bin/sh
+set -e
+if [ "$1" = "--" ] || [ "$1" = "-i" ]; then
+    echo "unexpected prompt flag: $1" > omp_error.txt
+    exit 1
+fi
+printf '%s' "$1" > omp_prompt.txt
+""",
+        )
+
+        write_workmux_config(
+            mux_repo_path, agent="omp", panes=[{"command": "<agent>"}]
+        )
+
+        worktree_path = add_branch_and_get_worktree(
+            env,
+            workmux_exe_path,
+            mux_repo_path,
+            branch_name,
+            extra_args=f"--prompt {shlex.quote(prompt_text)}",
+        )
+
+        agent_output = worktree_path / "omp_prompt.txt"
+        wait_for_file(
+            env,
+            agent_output,
+            timeout=5.0,
+            window_name=window_name,
+            worktree_path=worktree_path,
+        )
+        assert agent_output.read_text() == prompt_text
+
     def test_add_with_agent_flag_overrides_default(
         self,
         mux_server: MuxEnvironment,

--- a/tests/test_workmux_add/test_named_agents.py
+++ b/tests/test_workmux_add/test_named_agents.py
@@ -74,6 +74,52 @@ printf '%s' "$2" > claude_received.txt
         )
         assert agent_output.read_text() == prompt_text
 
+    def test_literal_omp_known_agent_gets_prompt_injection(
+        self,
+        mux_server: MuxEnvironment,
+        workmux_exe_path: Path,
+        mux_repo_path: Path,
+        fake_agent_installer: FakeAgentInstaller,
+    ):
+        """A literal 'omp' command should auto-detect and inject the prompt."""
+        env = mux_server
+        branch_name = "feature-auto-detect-omp"
+        window_name = get_window_name(branch_name)
+        prompt_text = "auto detected omp prompt"
+
+        fake_agent_installer.install(
+            "omp",
+            """#!/bin/sh
+set -e
+printf '%s' "$1" > omp_received.txt
+""",
+        )
+
+        _write_rc_with_fake_path(env, fake_agent_installer.bin_dir)
+
+        write_workmux_config(
+            mux_repo_path,
+            panes=[{"command": "omp"}],
+        )
+
+        worktree_path = add_branch_and_get_worktree(
+            env,
+            workmux_exe_path,
+            mux_repo_path,
+            branch_name,
+            extra_args=f"--prompt {shlex.quote(prompt_text)}",
+        )
+
+        agent_output = worktree_path / "omp_received.txt"
+        wait_for_file(
+            env,
+            agent_output,
+            timeout=5.0,
+            window_name=window_name,
+            worktree_path=worktree_path,
+        )
+        assert agent_output.read_text() == prompt_text
+
     def test_two_known_agents_each_get_prompt(
         self,
         mux_server: MuxEnvironment,

--- a/tests/test_workmux_setup.py
+++ b/tests/test_workmux_setup.py
@@ -142,6 +142,22 @@ class TestSetupNoPrompt:
         )
         assert "All agents have status tracking configured" in result.stdout
 
+    def test_omp_extension_configured(
+        self,
+        mux_server: MuxEnvironment,
+        workmux_exe_path: Path,
+        repo_path: Path,
+    ):
+        """OMP with extension file shows all-configured message."""
+        extension_dir = mux_server.home_path / ".omp" / "agent" / "extensions"
+        extension_dir.mkdir(parents=True)
+        (extension_dir / "workmux-status.ts").write_text("// extension")
+
+        result = run_workmux_command(
+            mux_server, workmux_exe_path, repo_path, "setup --hooks"
+        )
+        assert "All agents have status tracking configured" in result.stdout
+
     def test_both_agents_configured(
         self,
         mux_server: MuxEnvironment,
@@ -310,6 +326,38 @@ class TestSetupInstall:
         assert len(package_json_path.read_text()) > 0
         assert plugin_path.exists()
         assert len(plugin_path.read_text()) > 0
+
+    def test_omp_install_accept(
+        self,
+        mux_server: MuxEnvironment,
+        workmux_exe_path: Path,
+        repo_path: Path,
+    ):
+        """Accepting installs OMP extension file."""
+        omp_dir = mux_server.home_path / ".omp" / "agent"
+        omp_dir.mkdir(parents=True)
+
+        exit_code_file = run_setup_interactive(mux_server, workmux_exe_path)
+        wait_for_pane_output(
+            mux_server, "test", "Install status tracking hooks?", timeout=5.0
+        )
+        mux_server.send_keys("test:", "y")
+        wait_for_pane_output(mux_server, "test", "Install bundled skills?", timeout=5.0)
+        mux_server.send_keys("test:", "n")
+
+        assert poll_until_file_has_content(exit_code_file, timeout=5.0)
+        assert exit_code_file.read_text().strip() == "0"
+
+        extension_path = omp_dir / "extensions" / "workmux-status.ts"
+        assert extension_path.exists()
+        extension_text = extension_path.read_text()
+        assert "@oh-my-pi/pi-coding-agent" in extension_text
+        assert "workmux\", [\"set-window-status" in extension_text
+        assert 'pi.on("message_end"' in extension_text
+        assert '"role" in event.message' in extension_text
+        assert 'event.message.role === "assistant"' in extension_text
+        assert 'event.toolName === "ask"' in extension_text
+        assert 'setStatus("waiting")' in extension_text
 
     def test_both_agents_install_accept(
         self,

--- a/tests/test_workmux_setup.py
+++ b/tests/test_workmux_setup.py
@@ -352,7 +352,7 @@ class TestSetupInstall:
         assert extension_path.exists()
         extension_text = extension_path.read_text()
         assert "@oh-my-pi/pi-coding-agent" in extension_text
-        assert "workmux\", [\"set-window-status" in extension_text
+        assert 'workmux", ["set-window-status' in extension_text
         assert 'pi.on("message_end"' in extension_text
         assert '"role" in event.message' in extension_text
         assert 'event.message.role === "assistant"' in extension_text


### PR DESCRIPTION
## Summary

Adds first-party Oh My Pi support using the canonical `omp` agent key so prompt injection, setup, skills, sandboxing, sidebar identity, and docs all recognize the upstream OMP CLI.

## Changes

- Add an `omp` agent profile with Pi-style positional prompt injection, `omp -p` auto-name, and `--continue` resume behavior.
- Add Oh My Pi status setup, bundled skills installation path, sidebar identity metadata, and status extension packaging.
- Track OMP waiting status when assistant streaming ends or the `ask` tool is invoked.
- Add OMP sandbox support across Docker, container mounts, Lima provisioning, Lima credential mounts, and sandbox image publishing matrices.
- Add integration coverage for `workmux setup --hooks`, `<agent>` with `agent: omp`, and literal `omp` pane command auto-detection.
- Update user-facing docs and changelog for OMP support.

## Testing

- `cargo test --bin workmux omp --quiet`
- `cargo test --bin workmux pi --quiet`
- `WORKMUX_TEST=1 pytest tests/test_workmux_setup.py -k omp -q`
- `WORKMUX_TEST=1 pytest tests/test_workmux_add/test_agents.py -k omp -q`
- `WORKMUX_TEST=1 pytest tests/test_workmux_add/test_named_agents.py -k omp -q`
- `docker build -f docker/Dockerfile.omp --build-arg BASE=ghcr.io/raine/workmux-sandbox:base -t workmux-sandbox:omp-smoke .`
- `docker run --rm workmux-sandbox:omp-smoke sh -lc 'command -v bun && command -v python3 && command -v omp && omp --version'`
- `npm --prefix docs run build`

Full regression notes:
- `cargo test --bin workmux --quiet` failed on `sandbox::rpc::tests::test_exec_sandbox_blocks_ssh_read`; single-test rerun failed the same way.
- `WORKMUX_TEST=1 pytest tests/test_workmux_setup.py tests/test_workmux_add/test_agents.py tests/test_workmux_add/test_named_agents.py -q` passed 50 tests and failed `TestShellAliases.test_agent_placeholder_respects_shell_aliases[zsh-tmux]`; single-test rerun failed the same way.