### PR TITLE
fix(status): keep pi subagent panes working

### DIFF
--- a/.omp/extensions/workmux-status.ts
+++ b/.omp/extensions/workmux-status.ts
@@ -8,11 +8,13 @@
 import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
 
 export default function (pi: ExtensionAPI) {
+  const pid = (globalThis as any).process?.pid;
+  const fromPidArgs = typeof pid === "number" ? ["--from-pid", String(pid)] : [];
   let lastStatus: string | undefined;
   let statusQueue = Promise.resolve();
 
   function writeStatus(status: string) {
-    return pi.exec("workmux", ["set-window-status", status]).then(() => {}, () => {});
+    return pi.exec("workmux", ["set-window-status", status, ...fromPidArgs]).then(() => {}, () => {});
   }
 
   function setStatus(status: string) {

--- a/.pi/extensions/workmux-status.ts
+++ b/.pi/extensions/workmux-status.ts
@@ -8,8 +8,11 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export default function (pi: ExtensionAPI) {
+  const pid = (globalThis as any).process?.pid;
+  const fromPidArgs = typeof pid === "number" ? ["--from-pid", String(pid)] : [];
+
   function setStatus(status: string) {
-    pi.exec("workmux", ["set-window-status", status]).catch(() => {});
+    pi.exec("workmux", ["set-window-status", status, ...fromPidArgs]).catch(() => {});
   }
 
   pi.on("agent_start", async () => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -759,6 +759,10 @@ enum Commands {
     SetWindowStatus {
         #[arg(value_enum)]
         command: command::set_window_status::SetWindowStatusCommand,
+
+        /// PID of the Pi process emitting this status update; child Pi done events keep parent panes working
+        #[arg(long = "from-pid")]
+        from_pid: Option<u32>,
     },
 
     /// Set the base branch for the current worktree (used after rebasing)
@@ -1123,7 +1127,9 @@ pub fn run() -> Result<()> {
             ClaudeCommands::Prune => prune_claude_config(),
         },
         Commands::Sandbox(args) => command::sandbox::run(args),
-        Commands::SetWindowStatus { command } => command::set_window_status::run(command),
+        Commands::SetWindowStatus { command, from_pid } => {
+            command::set_window_status::run(command, from_pid)
+        }
         Commands::SetBase { base } => command::set_base::run(&base),
         Commands::LastDone => command::last_done::run(),
         Commands::LastAgent => command::last_agent::run(),

--- a/src/command/set_window_status.rs
+++ b/src/command/set_window_status.rs
@@ -17,7 +17,7 @@ pub enum SetWindowStatusCommand {
     Clear,
 }
 
-pub fn run(cmd: SetWindowStatusCommand) -> Result<()> {
+pub fn run(cmd: SetWindowStatusCommand, from_pid: Option<u32>) -> Result<()> {
     if std::env::var_os("WORKMUX_DISABLE_SET_WINDOW_STATUS").is_some() {
         return Ok(());
     }
@@ -75,6 +75,7 @@ pub fn run(cmd: SetWindowStatusCommand) -> Result<()> {
             } else {
                 requested_status
             };
+            let status = resolve_pi_process_status(status, from_pid);
 
             let (icon, auto_clear) = match status {
                 AgentStatus::Working => (config.status_icons.working(), false),
@@ -96,6 +97,32 @@ pub fn run(cmd: SetWindowStatusCommand) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// If a `done` status comes from a child Pi process that still has a live
+/// parent Pi ancestor, keep the pane `working` so a subagent finishing
+/// doesn't mark the parent's pane done.
+fn resolve_pi_process_status(status: AgentStatus, from_pid: Option<u32>) -> AgentStatus {
+    resolve_pi_process_status_with(
+        status,
+        from_pid,
+        crate::state::process_tree::has_pi_ancestor,
+    )
+}
+
+fn resolve_pi_process_status_with<F>(
+    status: AgentStatus,
+    from_pid: Option<u32>,
+    mut has_pi_ancestor: F,
+) -> AgentStatus
+where
+    F: FnMut(u32) -> bool,
+{
+    if matches!(status, AgentStatus::Done) && from_pid.is_some_and(|pid| has_pi_ancestor(pid)) {
+        AgentStatus::Working
+    } else {
+        status
+    }
 }
 
 /// Send a status update via RPC when running inside a sandbox guest.
@@ -121,5 +148,42 @@ fn run_via_rpc(cmd: SetWindowStatusCommand) -> Result<()> {
             Ok(()) // Fail silently like the host path does
         }
         _ => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn done_without_from_pid_stays_done() {
+        assert_eq!(
+            resolve_pi_process_status_with(AgentStatus::Done, None, |_| true),
+            AgentStatus::Done
+        );
+    }
+
+    #[test]
+    fn done_with_pi_ancestor_renders_working() {
+        assert_eq!(
+            resolve_pi_process_status_with(AgentStatus::Done, Some(42), |_| true),
+            AgentStatus::Working
+        );
+    }
+
+    #[test]
+    fn done_without_pi_ancestor_stays_done() {
+        assert_eq!(
+            resolve_pi_process_status_with(AgentStatus::Done, Some(42), |_| false),
+            AgentStatus::Done
+        );
+    }
+
+    #[test]
+    fn working_is_not_changed_by_pi_ancestor() {
+        assert_eq!(
+            resolve_pi_process_status_with(AgentStatus::Working, Some(42), |_| true),
+            AgentStatus::Working
+        );
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -4,6 +4,7 @@
 //! terminal multiplexer backends (tmux, WezTerm, Zellij).
 
 pub mod codex_status;
+pub mod process_tree;
 pub mod run;
 pub mod store;
 mod types;

--- a/src/state/process_tree.rs
+++ b/src/state/process_tree.rs
@@ -1,0 +1,220 @@
+//! Process-tree helper for Pi nested-agent status.
+//!
+//! Pi subagents run as child `pi` processes under the parent `pi` process in
+//! the same terminal pane. We use that relationship to avoid letting a child
+//! agent's `done` event mark the pane done while its parent is still alive,
+//! without keeping any Workmux-owned persistent scope state.
+//!
+//! Linux-only by design: this reads `/proc`, matching the existing
+//! `multiplexer::tmux::process_ancestors` helper. On other platforms
+//! `has_pi_ancestor` returns `false`, so child `done` events are not
+//! suppressed there.
+
+use std::collections::HashSet;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ProcessInfo {
+    pub pid: u32,
+    pub ppid: u32,
+    pub command: String,
+}
+
+const MAX_ANCESTOR_DEPTH: usize = 32;
+
+/// Return true when `pid` has a live ancestor that looks like a Pi process.
+///
+/// The starting process itself is not considered an ancestor. A normal Pi pane
+/// usually looks like `tmux -> zsh -> pi`, so this returns false for the pane's
+/// top-level Pi process. A subagent looks like `tmux -> zsh -> pi -> pi`, so it
+/// returns true for the child Pi process while the parent is still alive.
+pub fn has_pi_ancestor(pid: u32) -> bool {
+    has_pi_ancestor_with(pid, read_process_info)
+}
+
+pub(crate) fn has_pi_ancestor_with<F>(pid: u32, mut read_info: F) -> bool
+where
+    F: FnMut(u32) -> Option<ProcessInfo>,
+{
+    let Some(current) = read_info(pid) else {
+        return false;
+    };
+
+    let mut next = current.ppid;
+    let mut seen = HashSet::from([pid]);
+
+    for _ in 0..MAX_ANCESTOR_DEPTH {
+        if next == 0 || !seen.insert(next) {
+            return false;
+        }
+
+        let Some(info) = read_info(next) else {
+            return false;
+        };
+
+        if is_pi_command(&info.command) {
+            return true;
+        }
+
+        next = info.ppid;
+    }
+
+    false
+}
+
+fn is_pi_command(command: &str) -> bool {
+    if command.contains("pi-coding-agent") {
+        return true;
+    }
+
+    let mut parts = command.split_whitespace();
+    let Some(first) = parts.next() else {
+        return false;
+    };
+
+    let first_name = basename(first);
+    if matches!(first_name, "pi" | "omp" | "oh-my-pi") {
+        return true;
+    }
+
+    // Pi installed through npm may run as `node /path/to/.bin/pi`, and procfs
+    // can report the short comm as `node-MainThread`. Inspecting cmdline lets
+    // us recognize that parent as Pi without depending on the short comm.
+    if first_name.starts_with("node") {
+        if let Some(second) = parts.next() {
+            let second_name = basename(second);
+            return matches!(second_name, "pi" | "omp" | "oh-my-pi");
+        }
+    }
+
+    false
+}
+
+fn basename(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}
+
+#[cfg(target_os = "linux")]
+fn read_process_info(pid: u32) -> Option<ProcessInfo> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let mut info = parse_linux_stat(&stat)?;
+    if let Some(cmdline) = read_linux_cmdline(pid) {
+        info.command = cmdline;
+    }
+    Some(info)
+}
+
+#[cfg(target_os = "linux")]
+fn read_linux_cmdline(pid: u32) -> Option<String> {
+    let bytes = std::fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+    let command = bytes
+        .split(|byte| *byte == 0)
+        .filter_map(|part| std::str::from_utf8(part).ok())
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    if command.trim().is_empty() {
+        None
+    } else {
+        Some(command)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn parse_linux_stat(stat: &str) -> Option<ProcessInfo> {
+    let open = stat.find('(')?;
+    let close = stat.rfind(')')?;
+    let pid = stat[..open].trim().parse().ok()?;
+    let command = stat[open + 1..close].to_string();
+    let rest = stat[close + 1..].trim();
+    let mut fields = rest.split_whitespace();
+    let _state = fields.next()?;
+    let ppid = fields.next()?.parse().ok()?;
+
+    Some(ProcessInfo { pid, ppid, command })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_process_info(_pid: u32) -> Option<ProcessInfo> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn info(pid: u32, ppid: u32, command: &str) -> ProcessInfo {
+        ProcessInfo {
+            pid,
+            ppid,
+            command: command.to_string(),
+        }
+    }
+
+    fn lookup(map: HashMap<u32, ProcessInfo>) -> impl FnMut(u32) -> Option<ProcessInfo> {
+        move |pid| map.get(&pid).cloned()
+    }
+
+    #[test]
+    fn recognizes_node_backed_pi_command_line() {
+        assert!(is_pi_command(
+            "node /home/amit/.npm/_npx/hash/node_modules/.bin/pi --offline"
+        ));
+        assert!(is_pi_command("/usr/local/bin/pi"));
+        assert!(!is_pi_command("node /usr/bin/not-pi"));
+        assert!(!is_pi_command("bash -c pi --help"));
+    }
+
+    #[test]
+    fn normal_pi_without_pi_ancestor_returns_false() {
+        let map = HashMap::from([
+            (10, info(10, 9, "pi")),
+            (9, info(9, 8, "zsh")),
+            (8, info(8, 1, "tmux: server")),
+            (1, info(1, 0, "systemd")),
+        ]);
+
+        assert!(!has_pi_ancestor_with(10, lookup(map)));
+    }
+
+    #[test]
+    fn child_pi_with_pi_parent_returns_true() {
+        let map = HashMap::from([
+            (20, info(20, 10, "pi")),
+            (10, info(10, 9, "pi")),
+            (9, info(9, 8, "zsh")),
+            (8, info(8, 1, "tmux: server")),
+            (1, info(1, 0, "systemd")),
+        ]);
+
+        assert!(has_pi_ancestor_with(20, lookup(map)));
+    }
+
+    #[test]
+    fn missing_parent_returns_false() {
+        let map = HashMap::from([(20, info(20, 10, "pi"))]);
+
+        assert!(!has_pi_ancestor_with(20, lookup(map)));
+    }
+
+    #[test]
+    fn cycles_return_false() {
+        let map = HashMap::from([(20, info(20, 10, "pi")), (10, info(10, 20, "zsh"))]);
+
+        assert!(!has_pi_ancestor_with(20, lookup(map)));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parses_linux_stat() {
+        let stat = "1234 (pi) S 1000 1234 1234 0 -1 4194304 1 2 3 4 5 6 7 8 20 0 1 0 123456 0";
+        assert_eq!(
+            parse_linux_stat(stat),
+            Some(ProcessInfo {
+                pid: 1234,
+                ppid: 1000,
+                command: "pi".to_string(),
+            })
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Pi status extensions pass the emitting process id via `--from-pid`
- a child Pi `done` event is kept as `working` while a parent Pi ancestor is still alive; a top-level Pi `done` stays `done`
- the guard is stateless and Linux-only (reads `/proc`), matching the existing `multiplexer::tmux::process_ancestors` helper

## Bug

Pi runs subagents as separate `pi` processes in the same tmux pane and loads the same status extension in parent and child. Both fire identical `agent_start` / `agent_end` hooks, and the events carry no run or parent id, so a child subagent finishing was indistinguishable from the parent finishing and marked the pane done early.

With no id in the event, the process tree is the only signal available to tell them apart: a top-level Pi has no Pi ancestor, a subagent Pi does.

## Tests

- `cargo test --bin workmux process_tree --quiet`
- `cargo test --bin workmux set_window_status --quiet`
- `cargo test --quiet`

Two related fixes that were previously bundled here have been split into their own PRs:
- #188 — unique temp filenames for atomic state writes
- #189 — preserve live Pi panes on tmux command drift (builds on this PR)
