### PR TITLE
Sidebar: no usar hostname ni [tmux] como título de la tarjeta

### DIFF
--- a/src/agent_display.rs
+++ b/src/agent_display.rs
@@ -107,13 +107,16 @@ enum LabelSource {
 ///
 /// `window_cmd` is the foreground command of the agent's pane; if `None` (non-tmux
 /// backends), the window name is never promoted because we have no way to detect
-/// auto-tracking vs a sticky user-set name.
+/// auto-tracking vs a sticky user-set name. `hostname` is the short host name;
+/// a window named like the host (or `user@host`, or a tmux `[mode]` indicator)
+/// is never promoted.
 pub fn resolve_labels(
     project: &str,
     session: &str,
     worktree: &str,
     window: &str,
     window_cmd: Option<&str>,
+    hostname: &str,
 ) -> (String, String) {
     let candidates: [(LabelSource, &str, bool); 4] = [
         (
@@ -124,7 +127,7 @@ pub fn resolve_labels(
         (
             LabelSource::Window,
             window,
-            is_window_meaningful(window, window_cmd),
+            is_window_meaningful(window, window_cmd, hostname),
         ),
         (
             LabelSource::Session,
@@ -142,10 +145,9 @@ pub fn resolve_labels(
         None => (LabelSource::Project, project.to_string()),
     };
 
-    // Worktree-primary contract: per the plan, the common feature-branch case
-    // keeps project as secondary regardless of other meaningful candidates.
-    // When worktree is demoted, fall through to the next candidate in the chain
-    // and append the worktree so it never disappears.
+    // Worktree-primary contract: the common feature-branch case keeps project as
+    // secondary. When worktree is demoted, fall through to the next candidate in
+    // the chain and append the worktree so it never disappears.
     let secondary = if primary_src == LabelSource::Worktree {
         if !project.is_empty() && project != worktree {
             project.to_string()
@@ -204,7 +206,7 @@ fn is_worktree_meaningful(w: &str) -> bool {
     !w.is_empty() && !matches!(w, "main" | "master")
 }
 
-fn is_window_meaningful(window: &str, cmd: Option<&str>) -> bool {
+fn is_window_meaningful(window: &str, cmd: Option<&str>, hostname: &str) -> bool {
     let Some(cmd) = cmd else {
         return false;
     };
@@ -216,6 +218,17 @@ fn is_window_meaningful(window: &str, cmd: Option<&str>) -> bool {
     // Block generic shell/default names even when they differ from pane_current_command.
     // E.g., a pane running `node` with window name `zsh` should not promote `zsh`.
     if is_generic_window_name(window) {
+        return false;
+    }
+    // tmux's automatic-rename can leak the active pane's title (often the host
+    // name, or `user@host`) into window_name. Never promote those.
+    let hostname = hostname.trim();
+    if window.contains('@') || (!hostname.is_empty() && window.eq_ignore_ascii_case(hostname)) {
+        return false;
+    }
+    // tmux mode/flag indicators from automatic-rename-format (e.g. `[tmux]`
+    // while a pane is in copy-mode, `[dead]`) are bracketed; never promote them.
+    if window.starts_with('[') && window.ends_with(']') {
         return false;
     }
     // tmux's #{automatic_rename} flag is unreliable; comparing window_name against
@@ -301,6 +314,17 @@ pub fn strip_oc_title_prefix(mut title: &str) -> &str {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    /// Shorthand for the common case: no host name.
+    fn rl(
+        project: &str,
+        session: &str,
+        worktree: &str,
+        window: &str,
+        cmd: Option<&str>,
+    ) -> (String, String) {
+        resolve_labels(project, session, worktree, window, cmd, "")
+    }
 
     #[test]
     fn test_extract_worktree_name_window_mode() {
@@ -408,7 +432,7 @@ mod tests {
     #[test]
     fn resolve_labels_feature_branch_keeps_worktree_primary() {
         // Common case: feature-branch worktree, project as secondary.
-        let (primary, secondary) = resolve_labels("api", "api", "fix-auth", "zsh", Some("zsh"));
+        let (primary, secondary) = rl("api", "api", "fix-auth", "zsh", Some("zsh"));
         assert_eq!(primary, "fix-auth");
         assert_eq!(secondary, "api");
     }
@@ -417,7 +441,7 @@ mod tests {
     fn resolve_labels_promotes_sticky_window_on_main_worktree() {
         // Multiple agents on `main` with sticky tmux window names.
         let (primary, secondary) =
-            resolve_labels("api", "api", "main", "db-migration", Some("sleep"));
+            rl("api", "api", "main", "db-migration", Some("sleep"));
         assert_eq!(primary, "db-migration");
         assert_eq!(secondary, "api · main");
     }
@@ -426,7 +450,7 @@ mod tests {
     fn resolve_labels_promotes_session_when_window_auto_tracks() {
         // Session-per-project: session name carries identity, window auto-tracks shell.
         let (primary, secondary) =
-            resolve_labels("monorepo", "frontend-refactor", "main", "zsh", Some("zsh"));
+            rl("monorepo", "frontend-refactor", "main", "zsh", Some("zsh"));
         assert_eq!(primary, "frontend-refactor");
         assert_eq!(secondary, "monorepo · main");
     }
@@ -434,7 +458,7 @@ mod tests {
     #[test]
     fn resolve_labels_falls_back_to_project_when_nothing_else_meaningful() {
         // Numeric session, auto-tracked window, main worktree → project wins.
-        let (primary, secondary) = resolve_labels("api", "0", "main", "zsh", Some("zsh"));
+        let (primary, secondary) = rl("api", "0", "main", "zsh", Some("zsh"));
         assert_eq!(primary, "api");
         assert_eq!(secondary, "main");
     }
@@ -442,21 +466,21 @@ mod tests {
     #[test]
     fn resolve_labels_window_never_promoted_without_cmd() {
         // Non-tmux backends pass None for window_cmd; window must not be promoted.
-        let (primary, secondary) = resolve_labels("api", "api", "main", "looks-meaningful", None);
+        let (primary, secondary) = rl("api", "api", "main", "looks-meaningful", None);
         assert_eq!(primary, "api");
         assert_eq!(secondary, "main");
     }
 
     #[test]
     fn resolve_labels_session_equal_to_project_not_meaningful() {
-        let (primary, secondary) = resolve_labels("api", "api", "main", "zsh", Some("zsh"));
+        let (primary, secondary) = rl("api", "api", "main", "zsh", Some("zsh"));
         assert_eq!(primary, "api");
         assert_eq!(secondary, "main");
     }
 
     #[test]
     fn resolve_labels_default_session_not_meaningful() {
-        let (primary, secondary) = resolve_labels("api", "default", "main", "zsh", Some("zsh"));
+        let (primary, secondary) = rl("api", "default", "main", "zsh", Some("zsh"));
         assert_eq!(primary, "api");
         assert_eq!(secondary, "main");
     }
@@ -464,7 +488,7 @@ mod tests {
     #[test]
     fn resolve_labels_master_treated_like_main() {
         let (primary, secondary) =
-            resolve_labels("api", "release-prep", "master", "zsh", Some("zsh"));
+            rl("api", "release-prep", "master", "zsh", Some("zsh"));
         assert_eq!(primary, "release-prep");
         assert_eq!(secondary, "api · master");
     }
@@ -472,7 +496,7 @@ mod tests {
     #[test]
     fn resolve_labels_worktree_primary_keeps_project_secondary_even_with_sticky_window() {
         let (primary, secondary) =
-            resolve_labels("api", "session-x", "fix-auth", "scratchpad", Some("zsh"));
+            rl("api", "session-x", "fix-auth", "scratchpad", Some("zsh"));
         assert_eq!(primary, "fix-auth");
         assert_eq!(secondary, "api");
     }
@@ -480,21 +504,21 @@ mod tests {
     #[test]
     fn resolve_labels_window_zsh_not_promoted_when_pane_runs_node() {
         // Generic window names are blocklisted even when they differ from cmd.
-        let (primary, secondary) = resolve_labels("api", "0", "main", "zsh", Some("node"));
+        let (primary, secondary) = rl("api", "0", "main", "zsh", Some("node"));
         assert_eq!(primary, "api");
         assert_eq!(secondary, "main");
     }
 
     #[test]
     fn resolve_labels_window_default_blocked() {
-        let (primary, secondary) = resolve_labels("api", "0", "main", "default", Some("node"));
+        let (primary, secondary) = rl("api", "0", "main", "default", Some("node"));
         assert_eq!(primary, "api");
         assert_eq!(secondary, "main");
     }
 
     #[test]
     fn resolve_labels_worktree_primary_no_project_yields_empty_secondary() {
-        let (primary, secondary) = resolve_labels("", "", "fix-auth", "", None);
+        let (primary, secondary) = rl("", "", "fix-auth", "", None);
         assert_eq!(primary, "fix-auth");
         assert_eq!(secondary, "");
     }
@@ -502,7 +526,7 @@ mod tests {
     #[test]
     fn resolve_labels_blocks_pwsh_powershell_nu() {
         for shell in ["pwsh", "powershell", "nu", "csh", "tcsh", "xonsh", "elvish"] {
-            let (primary, _) = resolve_labels("api", "0", "main", shell, Some("node"));
+            let (primary, _) = rl("api", "0", "main", shell, Some("node"));
             assert_eq!(primary, "api", "expected {shell} to be blocked");
         }
     }
@@ -510,10 +534,49 @@ mod tests {
     #[test]
     fn resolve_labels_trims_whitespace_in_predicates() {
         // Whitespace-padded generic values must not bypass meaningfulness checks.
-        let (primary, _) = resolve_labels("api", " default ", "main", " zsh ", Some("zsh"));
+        let (primary, _) = rl("api", " default ", "main", " zsh ", Some("zsh"));
         assert_eq!(primary, "api");
 
-        let (primary, _) = resolve_labels("api", " 0 ", " main ", " zsh ", Some("zsh"));
+        let (primary, _) = rl("api", " 0 ", " main ", " zsh ", Some("zsh"));
+        assert_eq!(primary, "api");
+    }
+
+    #[test]
+    fn resolve_labels_hostname_window_not_promoted() {
+        // tmux auto-rename leaked the host name into window_name; it must not be
+        // the title — falls through to session/project.
+        let (primary, secondary) = resolve_labels(
+            "conversations",
+            "conversations",
+            "main",
+            "Vicentes-MacBook-Pro",
+            Some("fish"),
+            "Vicentes-MacBook-Pro",
+        );
+        assert_eq!(primary, "conversations");
+        assert_eq!(secondary, "main");
+    }
+
+    #[test]
+    fn resolve_labels_bracketed_tmux_indicator_not_promoted() {
+        // `[tmux]` (copy-mode indicator from automatic-rename-format) must not
+        // be the title; falls through to session/project.
+        let (primary, _) = resolve_labels(
+            "conversations",
+            "conversations",
+            "main",
+            "[tmux]",
+            Some("fish"),
+            "somehost",
+        );
+        assert_eq!(primary, "conversations");
+    }
+
+    #[test]
+    fn resolve_labels_user_at_host_window_not_promoted() {
+        // `user@host` window names are never promoted.
+        let (primary, _) =
+            resolve_labels("api", "0", "main", "vicente@host", Some("node"), "otherhost");
         assert_eq!(primary, "api");
     }
 

--- a/src/command/sidebar/app.rs
+++ b/src/command/sidebar/app.rs
@@ -193,6 +193,9 @@ pub struct SidebarApp {
     /// Per-agent flag: true when the agent is the first of its tmux session
     /// group, so a session header is rendered above it. Indexed like `agents`.
     pub group_starts: Vec<bool>,
+    /// Whether agents are grouped by tmux session (headers shown). Toggled
+    /// with `s`; the daemon does the matching sort.
+    pub group_by_session: bool,
     /// Cached horizontal chip hitboxes for top bar mouse hit testing.
     pub horizontal_hitboxes: Vec<HitBox>,
     /// First agent index rendered in the horizontal top bar.
@@ -264,6 +267,7 @@ impl SidebarApp {
             agent_icons: ResolvedAgentIcons::default(),
             tile_heights: Vec::new(),
             group_starts: Vec::new(),
+            group_by_session: true,
             horizontal_hitboxes: Vec::new(),
             first_visible_agent_idx: 0,
             horizontal_item_width: 24,
@@ -339,6 +343,7 @@ impl SidebarApp {
             agent_icons,
             tile_heights: Vec::new(),
             group_starts: Vec::new(),
+            group_by_session: true,
             horizontal_hitboxes: Vec::new(),
             first_visible_agent_idx: 0,
             horizontal_item_width,
@@ -414,13 +419,18 @@ impl SidebarApp {
         self.agents = snapshot.agents;
 
         // Mark session-group boundaries (agents are already grouped by session
-        // in the snapshot sort, so a boundary is just a session change).
-        self.group_starts = self
-            .agents
-            .iter()
-            .enumerate()
-            .map(|(i, a)| i == 0 || self.agents[i - 1].session != a.session)
-            .collect();
+        // in the snapshot sort, so a boundary is just a session change). When
+        // grouping is off there are no headers.
+        self.group_by_session = snapshot.group_by_session;
+        self.group_starts = if self.group_by_session {
+            self.agents
+                .iter()
+                .enumerate()
+                .map(|(i, a)| i == 0 || self.agents[i - 1].session != a.session)
+                .collect()
+        } else {
+            vec![false; self.agents.len()]
+        };
 
         // Restore selection
         if let Some(ref pane_id) = selected_pane {
@@ -625,22 +635,34 @@ impl SidebarApp {
         }
     }
 
-    /// Total height in rows of the item at `idx` for the current layout mode.
-    /// Every item carries one divider row; group starts also carry the title
-    /// rows from `group_header_lines`.
+    /// Rows of chrome prepended above the agent at `idx`: the session title
+    /// plus its full-width divider when it starts a group, a single divider
+    /// between cards otherwise, and nothing above the very first card when
+    /// grouping is off.
+    pub(super) fn chrome_lines(&self, idx: usize) -> usize {
+        if self.is_group_start(idx) {
+            self.group_header_lines(idx) + 1
+        } else if idx > 0 {
+            1
+        } else {
+            0
+        }
+    }
+
+    /// Total height in rows of the item at `idx` for the current layout mode,
+    /// including its chrome (session title and/or divider).
     pub(super) fn item_height(&self, idx: usize) -> usize {
         match self.layout_mode {
-            SidebarLayoutMode::Compact => 1 + self.group_header_lines(idx) + 1,
+            SidebarLayoutMode::Compact => 1 + self.chrome_lines(idx),
             SidebarLayoutMode::Tiles => self.tile_item_height(idx),
         }
     }
 
     /// Height in rows of a tile-mode item at the given index.
-    /// Uses cached heights from the last render pass, plus the per-item divider
-    /// row and any session title rows.
+    /// Uses cached heights from the last render pass, plus its chrome rows.
     fn tile_item_height(&self, idx: usize) -> usize {
         let base = self.tile_heights.get(idx).copied().unwrap_or(3);
-        base + self.group_header_lines(idx) + 1
+        base + self.chrome_lines(idx)
     }
 
     pub fn jump_to_selected(&mut self) {
@@ -678,6 +700,32 @@ impl SidebarApp {
             settings.sidebar_layout = Some(self.layout_mode.as_str().to_string());
             let _ = store.save_settings(&settings);
         }
+    }
+
+    /// Toggle grouping agents by tmux session. The daemon does the matching
+    /// sort; we persist the choice and nudge it to re-snapshot immediately.
+    pub fn toggle_group_by_session(&mut self) {
+        self.group_by_session = !self.group_by_session;
+        let value = if self.group_by_session { "true" } else { "false" };
+        // Persist to tmux so all sidebar instances pick it up immediately
+        let _ = Cmd::new("tmux")
+            .args(&[
+                "set-option",
+                "-g",
+                "@workmux_sidebar_group_by_session",
+                value,
+            ])
+            .run();
+        // Persist to settings.json so it survives tmux restarts
+        if let Ok(store) = crate::state::StateStore::new()
+            && let Ok(mut settings) = store.load_settings()
+        {
+            settings.sidebar_group_by_session = Some(self.group_by_session);
+            let _ = store.save_settings(&settings);
+        }
+        // Nudge the daemon so the regrouped snapshot comes back without waiting
+        // for the next poll.
+        super::daemon_ctrl::signal_daemon();
     }
 
     /// Toggle the sleeping state of the selected agent.

--- a/src/command/sidebar/app.rs
+++ b/src/command/sidebar/app.rs
@@ -190,6 +190,9 @@ pub struct SidebarApp {
     pub agent_icons: ResolvedAgentIcons,
     /// Cached tile heights for hit testing (updated each render).
     pub tile_heights: Vec<usize>,
+    /// Per-agent flag: true when the agent is the first of its tmux session
+    /// group, so a session header is rendered above it. Indexed like `agents`.
+    pub group_starts: Vec<bool>,
     /// Cached horizontal chip hitboxes for top bar mouse hit testing.
     pub horizontal_hitboxes: Vec<HitBox>,
     /// First agent index rendered in the horizontal top bar.
@@ -260,6 +263,7 @@ impl SidebarApp {
             template_error: Some(template_error),
             agent_icons: ResolvedAgentIcons::default(),
             tile_heights: Vec::new(),
+            group_starts: Vec::new(),
             horizontal_hitboxes: Vec::new(),
             first_visible_agent_idx: 0,
             horizontal_item_width: 24,
@@ -334,6 +338,7 @@ impl SidebarApp {
             template_error,
             agent_icons,
             tile_heights: Vec::new(),
+            group_starts: Vec::new(),
             horizontal_hitboxes: Vec::new(),
             first_visible_agent_idx: 0,
             horizontal_item_width,
@@ -407,6 +412,15 @@ impl SidebarApp {
             .map(|a| a.pane_id.clone());
 
         self.agents = snapshot.agents;
+
+        // Mark session-group boundaries (agents are already grouped by session
+        // in the snapshot sort, so a boundary is just a session change).
+        self.group_starts = self
+            .agents
+            .iter()
+            .enumerate()
+            .map(|(i, a)| i == 0 || self.agents[i - 1].session != a.session)
+            .collect();
 
         // Restore selection
         if let Some(ref pane_id) = selected_pane {
@@ -570,23 +584,16 @@ impl SidebarApp {
         let relative_row = (row - area.y) as usize;
         let offset = self.list_state.offset();
 
-        match self.layout_mode {
-            SidebarLayoutMode::Compact => {
-                let idx = offset + relative_row;
-                (idx < self.agents.len()).then_some(idx)
+        // Walk variable item heights (both modes can carry session headers).
+        let mut y = 0;
+        for idx in offset..self.agents.len() {
+            let h = self.item_height(idx);
+            if relative_row < y + h {
+                return Some(idx);
             }
-            SidebarLayoutMode::Tiles => {
-                let mut y = 0;
-                for idx in offset..self.agents.len() {
-                    let h = self.tile_item_height(idx);
-                    if relative_row < y + h {
-                        return Some(idx);
-                    }
-                    y += h;
-                }
-                None
-            }
+            y += h;
         }
+        None
     }
 
     pub fn ensure_selected_visible(&mut self, visible_count: usize) {
@@ -600,18 +607,40 @@ impl SidebarApp {
         }
     }
 
+    /// Whether the agent at `idx` is the first of its tmux session group.
+    pub(super) fn is_group_start(&self, idx: usize) -> bool {
+        self.group_starts.get(idx).copied().unwrap_or(false)
+    }
+
+    /// Number of header rows rendered above the agent at `idx`. Zero unless it
+    /// starts a session group; then one row (the session name), plus a leading
+    /// blank line for every group after the first.
+    pub(super) fn group_header_lines(&self, idx: usize) -> usize {
+        if !self.is_group_start(idx) {
+            0
+        } else if idx == 0 {
+            1
+        } else {
+            2
+        }
+    }
+
+    /// Total height in rows of the item at `idx` for the current layout mode.
+    /// Every item carries one divider row; group starts also carry the title
+    /// rows from `group_header_lines`.
+    pub(super) fn item_height(&self, idx: usize) -> usize {
+        match self.layout_mode {
+            SidebarLayoutMode::Compact => 1 + self.group_header_lines(idx) + 1,
+            SidebarLayoutMode::Tiles => self.tile_item_height(idx),
+        }
+    }
+
     /// Height in rows of a tile-mode item at the given index.
-    /// Uses cached heights from the last render pass.
+    /// Uses cached heights from the last render pass, plus the per-item divider
+    /// row and any session title rows.
     fn tile_item_height(&self, idx: usize) -> usize {
         let base = self.tile_heights.get(idx).copied().unwrap_or(3);
-        let mut h = base;
-        if idx > 0 {
-            h += 1; // top separator
-        }
-        if idx == self.agents.len() - 1 {
-            h += 1; // bottom separator
-        }
-        h
+        base + self.group_header_lines(idx) + 1
     }
 
     pub fn jump_to_selected(&mut self) {

--- a/src/command/sidebar/app.rs
+++ b/src/command/sidebar/app.rs
@@ -196,6 +196,9 @@ pub struct SidebarApp {
     /// Whether agents are grouped by tmux session (headers shown). Toggled
     /// with `s`; the daemon does the matching sort.
     pub group_by_session: bool,
+    /// Short host name, used to avoid promoting a window named like the host
+    /// (tmux auto-rename can leak it into window_name).
+    hostname: String,
     /// Cached horizontal chip hitboxes for top bar mouse hit testing.
     pub horizontal_hitboxes: Vec<HitBox>,
     /// First agent index rendered in the horizontal top bar.
@@ -268,6 +271,7 @@ impl SidebarApp {
             tile_heights: Vec::new(),
             group_starts: Vec::new(),
             group_by_session: true,
+            hostname: String::new(),
             horizontal_hitboxes: Vec::new(),
             first_visible_agent_idx: 0,
             horizontal_item_width: 24,
@@ -344,6 +348,7 @@ impl SidebarApp {
             tile_heights: Vec::new(),
             group_starts: Vec::new(),
             group_by_session: true,
+            hostname: query_host_short(),
             horizontal_hitboxes: Vec::new(),
             first_visible_agent_idx: 0,
             horizontal_item_width,
@@ -924,6 +929,7 @@ impl SidebarApp {
             &worktree,
             window,
             agent.window_cmd.as_deref(),
+            &self.hostname,
         )
     }
 }
@@ -1371,6 +1377,16 @@ mod tests {
 
 /// Detect this sidebar's host window using TMUX_PANE (stable, one-time).
 /// Returns (session, window_id).
+/// Short host name (`#{host_short}`), used to drop window names that tmux's
+/// automatic-rename leaked from the host. Empty if tmux can't be queried.
+fn query_host_short() -> String {
+    Cmd::new("tmux")
+        .args(&["display-message", "-p", "#{host_short}"])
+        .run_and_capture_stdout()
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default()
+}
+
 fn detect_host_window() -> (Option<String>, Option<String>) {
     let pane_id = std::env::var("TMUX_PANE").ok().unwrap_or_default();
     let mut args = vec!["display-message", "-p"];

--- a/src/command/sidebar/daemon.rs
+++ b/src/command/sidebar/daemon.rs
@@ -231,6 +231,30 @@ fn read_sidebar_layout_mode(config: &Config) -> Option<SidebarLayoutMode> {
     None
 }
 
+/// Read whether agents are grouped by tmux session, from tmux global first,
+/// then settings.json, then config; defaults to true.
+fn read_sidebar_group_by_session(config: &Config) -> bool {
+    if let Ok(output) = Cmd::new("tmux")
+        .args(&["show-option", "-gqv", "@workmux_sidebar_group_by_session"])
+        .run_and_capture_stdout()
+    {
+        match output.trim() {
+            "true" => return true,
+            "false" => return false,
+            _ => {}
+        }
+    }
+
+    if let Ok(store) = StateStore::new()
+        && let Ok(settings) = store.load_settings()
+        && let Some(v) = settings.sidebar_group_by_session
+    {
+        return v;
+    }
+
+    config.sidebar.group_by_session.unwrap_or(true)
+}
+
 /// Read pane IDs manually marked as sleeping from the tmux global option.
 fn read_sleeping_panes() -> HashSet<String> {
     Cmd::new("tmux")
@@ -1434,11 +1458,12 @@ pub fn run() -> Result<()> {
                 .ok();
             let Some(agents) = agents else { continue };
 
-            let (position, layout_mode) = {
+            let (position, layout_mode, group_by_session) = {
                 let cfg = config.lock().unwrap();
                 (
                     super::read_sidebar_position(&cfg),
                     read_sidebar_layout_mode(&cfg).unwrap_or_default(),
+                    read_sidebar_group_by_session(&cfg),
                 )
             };
             let sleeping_pane_ids = read_sleeping_panes();
@@ -1462,6 +1487,7 @@ pub fn run() -> Result<()> {
                     now_ts,
                     position,
                     layout_mode,
+                    group_by_session,
                     git_statuses,
                     pr_statuses,
                     sleeping_pane_ids,
@@ -1634,6 +1660,7 @@ struct TickInput {
     now_ts: u64,
     position: SidebarPosition,
     layout_mode: SidebarLayoutMode,
+    group_by_session: bool,
     git_statuses: HashMap<PathBuf, GitStatus>,
     pr_statuses: HashMap<PathBuf, PrPathEntry>,
     sleeping_pane_ids: HashSet<String>,
@@ -1677,6 +1704,7 @@ fn compute_tick(
         now_ts,
         position,
         layout_mode,
+        group_by_session,
         git_statuses,
         pr_statuses,
         sleeping_pane_ids,
@@ -1714,6 +1742,7 @@ fn compute_tick(
         git_statuses,
         pr_statuses,
         &sleeping_pane_ids,
+        group_by_session,
     );
     snapshot.interrupted_pane_ids = interrupted.clone();
 
@@ -2207,6 +2236,7 @@ mod tests {
                     now_ts,
                     position: SidebarPosition::Left,
                     layout_mode: SidebarLayoutMode::default(),
+                    group_by_session: true,
                     git_statuses: HashMap::new(),
                     pr_statuses: HashMap::new(),
                     sleeping_pane_ids: HashSet::new(),

--- a/src/command/sidebar/runtime.rs
+++ b/src/command/sidebar/runtime.rs
@@ -220,6 +220,7 @@ fn process_event(
                 (KeyCode::Char('G'), _) => app.select_last(),
                 (KeyCode::Char('g'), _) => app.select_first(),
                 (KeyCode::Char('v'), _) => app.toggle_layout_mode(),
+                (KeyCode::Char('s'), _) => app.toggle_group_by_session(),
                 (KeyCode::Char('z'), _) => app.toggle_sleeping(),
                 _ => {}
             }

--- a/src/command/sidebar/snapshot.rs
+++ b/src/command/sidebar/snapshot.rs
@@ -88,7 +88,8 @@ pub fn build_snapshot(
         .unwrap_or_default()
         .as_secs();
 
-    agents.sort_by_cached_key(|a| {
+    // Per-agent recency key: sleeping last, then most recent, then pane number.
+    let own_key = |a: &AgentPane| -> (bool, u64, u64) {
         let is_sleeping = sleeping_pane_ids.contains(&a.pane_id);
         let elapsed = a
             .status_ts
@@ -101,6 +102,31 @@ pub fn build_snapshot(
             .parse()
             .unwrap_or(u64::MAX);
         (is_sleeping, elapsed, pane_num)
+    };
+
+    // Group by tmux session: order sessions by their most-relevant agent, and
+    // keep agents of the same session contiguous (recency order within group).
+    let mut session_best: HashMap<String, (bool, u64, u64)> = HashMap::new();
+    for a in &agents {
+        let key = own_key(a);
+        session_best
+            .entry(a.session.clone())
+            .and_modify(|best| {
+                if key < *best {
+                    *best = key;
+                }
+            })
+            .or_insert(key);
+    }
+
+    agents.sort_by_cached_key(|a| {
+        let best = session_best
+            .get(&a.session)
+            .copied()
+            .unwrap_or((true, u64::MAX, u64::MAX));
+        // session_best ranks the group; session name breaks ties so sessions
+        // never interleave; own_key orders within the group.
+        (best, a.session.clone(), own_key(a))
     });
 
     // Populate window_id from the tmux state lookup

--- a/src/command/sidebar/snapshot.rs
+++ b/src/command/sidebar/snapshot.rs
@@ -46,6 +46,14 @@ pub struct SidebarSnapshot {
     /// Clients use this to trigger their own per-project config reload.
     #[serde(default)]
     pub config_version: u64,
+    /// Whether agents are grouped by tmux session (sorted contiguously and
+    /// shown with session headers). Toggled with the `s` key.
+    #[serde(default = "default_true")]
+    pub group_by_session: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// Build a snapshot from reconciled agents and tmux state.
@@ -63,6 +71,7 @@ pub fn build_snapshot(
     git_statuses: HashMap<PathBuf, GitStatus>,
     pr_statuses: HashMap<PathBuf, PrPathEntry>,
     sleeping_pane_ids: &HashSet<String>,
+    group_by_session: bool,
 ) -> SidebarSnapshot {
     let done_icon = status_icons.done();
     let waiting_icon = status_icons.waiting();
@@ -104,30 +113,35 @@ pub fn build_snapshot(
         (is_sleeping, elapsed, pane_num)
     };
 
-    // Group by tmux session: order sessions by their most-relevant agent, and
-    // keep agents of the same session contiguous (recency order within group).
-    let mut session_best: HashMap<String, (bool, u64, u64)> = HashMap::new();
-    for a in &agents {
-        let key = own_key(a);
-        session_best
-            .entry(a.session.clone())
-            .and_modify(|best| {
-                if key < *best {
-                    *best = key;
-                }
-            })
-            .or_insert(key);
-    }
+    if group_by_session {
+        // Group by tmux session: order sessions by their most-relevant agent,
+        // and keep agents of the same session contiguous (recency within group).
+        let mut session_best: HashMap<String, (bool, u64, u64)> = HashMap::new();
+        for a in &agents {
+            let key = own_key(a);
+            session_best
+                .entry(a.session.clone())
+                .and_modify(|best| {
+                    if key < *best {
+                        *best = key;
+                    }
+                })
+                .or_insert(key);
+        }
 
-    agents.sort_by_cached_key(|a| {
-        let best = session_best
-            .get(&a.session)
-            .copied()
-            .unwrap_or((true, u64::MAX, u64::MAX));
-        // session_best ranks the group; session name breaks ties so sessions
-        // never interleave; own_key orders within the group.
-        (best, a.session.clone(), own_key(a))
-    });
+        agents.sort_by_cached_key(|a| {
+            let best = session_best
+                .get(&a.session)
+                .copied()
+                .unwrap_or((true, u64::MAX, u64::MAX));
+            // session_best ranks the group; session name breaks ties so sessions
+            // never interleave; own_key orders within the group.
+            (best, a.session.clone(), own_key(a))
+        });
+    } else {
+        // Flat list ordered purely by recency.
+        agents.sort_by_cached_key(own_key);
+    }
 
     // Populate window_id from the tmux state lookup
     for agent in &mut agents {
@@ -172,6 +186,7 @@ pub fn build_snapshot(
         sleeping_pane_ids: live_sleeping,
         agents,
         config_version: 0,
+        group_by_session,
     }
 }
 
@@ -233,6 +248,7 @@ mod tests {
             git_statuses,
             pr_statuses,
             &HashSet::new(),
+            true,
         )
     }
 

--- a/src/command/sidebar/ui.rs
+++ b/src/command/sidebar/ui.rs
@@ -670,6 +670,34 @@ fn status_icon_extra_width(ctx: &RowContext<'_>) -> usize {
     }
 }
 
+/// Session group title: the session name in bold, preceded by a blank line
+/// for groups after the first.
+fn session_header_lines(session: &str, is_first: bool, palette: &ThemePalette) -> Vec<Line<'static>> {
+    let name = Style::default()
+        .fg(palette.header)
+        .add_modifier(Modifier::BOLD);
+    let mut lines = Vec::new();
+    if !is_first {
+        lines.push(Line::from(""));
+    }
+    lines.push(Line::from(Span::styled(format!(" {session}"), name)));
+    lines
+}
+
+/// Full-width faint divider under a session title.
+fn flush_divider(width: usize, color: Color) -> Line<'static> {
+    Line::from(Span::styled("─".repeat(width), Style::default().fg(color)))
+}
+
+/// Faint divider between tiles in a group, aligned with the card stripe (`▌ `).
+fn stripe_divider(width: usize, color: Color) -> Line<'static> {
+    let style = Style::default().fg(color);
+    Line::from(vec![
+        Span::styled("▌ ", style),
+        Span::styled("─".repeat(width.saturating_sub(2)), style),
+    ])
+}
+
 /// Compact single-line-per-agent list (original layout).
 fn render_compact_list(f: &mut Frame, app: &mut SidebarApp, area: Rect) {
     if app.agents.is_empty() {
@@ -704,24 +732,50 @@ fn render_compact_list(f: &mut Frame, app: &mut SidebarApp, area: Rect) {
 
     let items: Vec<ListItem> = contexts
         .iter()
-        .map(|ctx| {
+        .enumerate()
+        .map(|(idx, ctx)| {
             let mut spans = render_line_with_options(ctx, &template, width, &render_options);
 
             // Post-pass: apply selection background where the template has
-            // not already supplied an explicit user `bg=`.
+            // not already supplied an explicit user `bg=`. Selection bg is
+            // baked into the row (not a List highlight_style) so the session
+            // header lines below stay unhighlighted.
             if ctx.is_selected {
                 for span in &mut spans {
                     if span.style.bg.is_none() {
                         span.style = span.style.bg(app.palette.highlight_row_bg);
                     }
                 }
+                // Fill the rest of the row so the highlight spans full width.
+                let used: usize = spans.iter().map(|s| display_width(s.content.as_ref())).sum();
+                if used < width {
+                    spans.push(Span::styled(
+                        " ".repeat(width - used),
+                        Style::default().bg(app.palette.highlight_row_bg),
+                    ));
+                }
             }
 
-            ListItem::new(Line::from(spans))
+            // Prepend the session title (group start) plus a faint divider
+            // before each row. Compact has no stripe, so dividers are flush.
+            let mut lines = Vec::new();
+            if app.is_group_start(idx) {
+                lines.extend(session_header_lines(
+                    &app.agents[idx].session,
+                    idx == 0,
+                    &app.palette,
+                ));
+            }
+            lines.push(flush_divider(width, app.palette.border));
+            lines.push(Line::from(spans));
+
+            ListItem::new(lines)
         })
         .collect();
 
-    let list = List::new(items).highlight_style(Style::default().bg(app.palette.highlight_row_bg));
+    // No highlight_style: selection bg is baked into the row content above so
+    // it never bleeds onto session header lines.
+    let list = List::new(items);
 
     f.render_stateful_widget(list, area, &mut app.list_state);
 }
@@ -740,7 +794,6 @@ fn render_tile_list(f: &mut Frame, app: &mut SidebarApp, area: Rect) {
 
     let sep_width = area.width as usize;
     let selected_idx = app.list_state.selected();
-    let agent_count = app.agents.len();
     let pane_suffixes = compute_pane_suffixes(&app.agents);
     let tile_templates: Vec<_> = app.templates.tiles.clone();
     let body_width = (area.width as usize).saturating_sub(6); // stripe(2) + icon(2) + gap(1) + right margin(1)
@@ -785,13 +838,15 @@ fn render_tile_list(f: &mut Frame, app: &mut SidebarApp, area: Rect) {
                 String::new()
             };
 
-            // Separator at the top (between tiles, not on first item)
+            // Top of the item: a session title + full-width divider when this
+            // agent starts a group; otherwise a stripe-aligned divider between
+            // tiles of the same group.
             let mut lines = Vec::new();
-            if idx > 0 {
-                lines.push(Line::from(Span::styled(
-                    "─".repeat(sep_width),
-                    Style::default().fg(app.palette.border),
-                )));
+            if app.is_group_start(idx) {
+                lines.extend(session_header_lines(&agent.session, idx == 0, &app.palette));
+                lines.push(flush_divider(sep_width, app.palette.border));
+            } else {
+                lines.push(stripe_divider(sep_width, app.palette.border));
             }
 
             let mut visible_lines = 0;
@@ -850,14 +905,6 @@ fn render_tile_list(f: &mut Frame, app: &mut SidebarApp, area: Rect) {
             }
 
             tile_heights.push(visible_lines);
-
-            // Bottom separator after the last item
-            if idx == agent_count - 1 {
-                lines.push(Line::from(Span::styled(
-                    "─".repeat(sep_width),
-                    Style::default().fg(app.palette.border),
-                )));
-            }
 
             ListItem::new(lines)
         })

--- a/src/command/sidebar/ui.rs
+++ b/src/command/sidebar/ui.rs
@@ -756,8 +756,9 @@ fn render_compact_list(f: &mut Frame, app: &mut SidebarApp, area: Rect) {
                 }
             }
 
-            // Prepend the session title (group start) plus a faint divider
-            // before each row. Compact has no stripe, so dividers are flush.
+            // Chrome: session title + divider at group starts, a divider
+            // between rows otherwise, nothing above the very first row when
+            // grouping is off. Compact has no stripe, so dividers are flush.
             let mut lines = Vec::new();
             if app.is_group_start(idx) {
                 lines.extend(session_header_lines(
@@ -765,8 +766,10 @@ fn render_compact_list(f: &mut Frame, app: &mut SidebarApp, area: Rect) {
                     idx == 0,
                     &app.palette,
                 ));
+                lines.push(flush_divider(width, app.palette.border));
+            } else if idx > 0 {
+                lines.push(flush_divider(width, app.palette.border));
             }
-            lines.push(flush_divider(width, app.palette.border));
             lines.push(Line::from(spans));
 
             ListItem::new(lines)
@@ -845,7 +848,7 @@ fn render_tile_list(f: &mut Frame, app: &mut SidebarApp, area: Rect) {
             if app.is_group_start(idx) {
                 lines.extend(session_header_lines(&agent.session, idx == 0, &app.palette));
                 lines.push(flush_divider(sep_width, app.palette.border));
-            } else {
+            } else if idx > 0 {
                 lines.push(stripe_divider(sep_width, app.palette.border));
             }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -212,6 +212,10 @@ pub struct SidebarConfig {
     /// Layout mode: "compact" or "tiles". Default: "tiles"
     pub layout: Option<String>,
 
+    /// Group agents by tmux session (session headers). Default: true.
+    /// Toggle live with the `s` key in the sidebar.
+    pub group_by_session: Option<bool>,
+
     /// Horizontal bar configuration.
     #[serde(default)]
     pub horizontal: HorizontalSidebarConfig,
@@ -2355,6 +2359,10 @@ impl Config {
             width: project.sidebar.width.or(self.sidebar.width),
             height: project.sidebar.height.or(self.sidebar.height),
             layout: project.sidebar.layout.or(self.sidebar.layout),
+            group_by_session: project
+                .sidebar
+                .group_by_session
+                .or(self.sidebar.group_by_session),
             horizontal: HorizontalSidebarConfig {
                 item_width: project
                     .sidebar

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -712,6 +712,7 @@ mod tests {
             worktree_sort_mode: Some("age".to_string()),
             last_done_cycle: None,
             sidebar_layout: None,
+            sidebar_group_by_session: None,
             sidebar_width: None,
             sidebar_height: None,
         };

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -182,6 +182,10 @@ pub struct GlobalSettings {
     #[serde(default)]
     pub sidebar_layout: Option<String>,
 
+    /// Whether the sidebar groups agents by tmux session
+    #[serde(default)]
+    pub sidebar_group_by_session: Option<bool>,
+
     /// Sidebar width in columns (manual override synced across windows)
     #[serde(default)]
     pub sidebar_width: Option<u16>,


### PR DESCRIPTION
Bloquea window_name basura (hostname, user@host, [tmux]/[dead]) para que no sea el título de la tarjeta; cae a sesión/proyecto y la tarea queda en la 3ª línea. Tests en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)