### PR TITLE
Notify when pi agents finish

### DIFF
--- a/.pi/extensions/workmux-status.ts
+++ b/.pi/extensions/workmux-status.ts
@@ -12,11 +12,45 @@ export default function (pi: ExtensionAPI) {
     pi.exec("workmux", ["set-window-status", status]).catch(() => {});
   }
 
+  function lastAssistantText(messages: any[]): string {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i];
+      if (m?.role === "assistant" && Array.isArray(m.content)) {
+        const text = m.content
+          .filter((b: any) => b?.type === "text")
+          .map((b: any) => b.text ?? "")
+          .join("")
+          .trim();
+        if (text) return text;
+      }
+    }
+    return "";
+  }
+
   pi.on("agent_start", async () => {
     setStatus("working");
   });
 
-  pi.on("agent_end", async () => {
+  pi.on("agent_end", async (event: any) => {
     setStatus("done");
+
+    const summary = lastAssistantText(event?.messages ?? []);
+    const args = summary
+      ? ["notify", "--body", summary.slice(0, 200)]
+      : ["notify"];
+    // `workmux notify` blocks until the notification is clicked/dismissed,
+    // so spawn it fully detached so it survives independent of pi's lifecycle.
+    // If we used pi.exec (which captures output), pi could tear down the child
+    // and close the D-Bus connection, dismissing the notification.
+    try {
+      const { spawn } = await import("node:child_process");
+      const child = spawn("workmux", args, {
+        detached: true,
+        stdio: "ignore",
+      });
+      child.unref();
+    } catch (e) {
+      console.error("[workmux] failed to spawn notify:", e);
+    }
   });
 }

--- a/.pi/extensions/workmux-status.ts
+++ b/.pi/extensions/workmux-status.ts
@@ -9,7 +9,9 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export default function (pi: ExtensionAPI) {
   function setStatus(status: string) {
-    pi.exec("workmux", ["set-window-status", status]).catch(() => {});
+    return pi
+      .exec("workmux", ["set-window-status", status])
+      .then(() => {}, () => {});
   }
 
   function lastAssistantText(messages: any[]): string {
@@ -28,11 +30,11 @@ export default function (pi: ExtensionAPI) {
   }
 
   pi.on("agent_start", async () => {
-    setStatus("working");
+    await setStatus("working");
   });
 
   pi.on("agent_end", async (event: any) => {
-    setStatus("done");
+    await setStatus("done");
 
     const summary = lastAssistantText(event?.messages ?? []);
     const args = summary

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -781,6 +781,14 @@ enum Commands {
     #[command(hide = true, name = "last-done")]
     LastDone,
 
+    /// Show a desktop notification; clicking it focuses the last-done agent
+    #[command(hide = true, name = "notify")]
+    Notify {
+        /// Notification body text (e.g. the agent's final answer)
+        #[arg(long)]
+        body: Option<String>,
+    },
+
     /// Switch to the last visited agent (toggle between two)
     #[command(hide = true, name = "last-agent")]
     LastAgent,
@@ -1126,6 +1134,7 @@ pub fn run() -> Result<()> {
         Commands::SetWindowStatus { command } => command::set_window_status::run(command),
         Commands::SetBase { base } => command::set_base::run(&base),
         Commands::LastDone => command::last_done::run(),
+        Commands::Notify { body } => command::notify::run(body.as_deref()),
         Commands::LastAgent => command::last_agent::run(),
         Commands::HostExec { args } => {
             let (command, cmd_args) = args

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -12,6 +12,7 @@ pub mod host_exec;
 pub mod last_agent;
 pub mod last_done;
 pub mod list;
+pub mod notify;
 pub mod merge;
 pub mod open;
 pub mod path;

--- a/src/command/notify.rs
+++ b/src/command/notify.rs
@@ -1,0 +1,60 @@
+//! Desktop notification that focuses the most recently completed agent on click.
+//!
+//! Shows a system notification and blocks until the user interacts with it.
+//! Clicking the notification switches to the most recently completed or waiting
+//! agent (same logic as `workmux last-done`).
+//!
+//! On Linux this uses notify-rust's action callback via D-Bus. On macOS, where
+//! notify-rust does not support click actions, it falls back to a plain
+//! non-clickable notification (matching the existing merge notification).
+//!
+//! Intended to be spawned in the background by the pi status extension when an
+//! agent finishes, so the user is alerted and can jump back with a click.
+
+use anyhow::Result;
+use tracing::debug;
+
+/// Show a desktop notification. Blocks until the notification is clicked or
+/// dismissed. On click, switches to the most recently completed agent.
+pub fn run(body: Option<&str>) -> Result<()> {
+    let message = body.unwrap_or("Agent finished");
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        use notify_rust::{Hint, Notification};
+
+        let handle = Notification::new()
+            .summary("workmux")
+            .body(message)
+            .timeout(notify_rust::Timeout::Never)
+            .action("default", "Focus")
+            .hint(Hint::Resident(true))
+            .show()?;
+
+        handle.wait_for_action(|action: &str| {
+            debug!(action, "notification action");
+            if action == "default" {
+                if let Err(e) = crate::command::last_done::run() {
+                    debug!(error = %e, "last-done after notification click failed");
+                }
+            }
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        use mac_notification_sys::{Notification, set_application};
+        if let Err(e) = set_application("com.apple.Terminal") {
+            debug!(error = ?e, "Failed to set notification application");
+        }
+        if let Err(e) = Notification::default()
+            .title("workmux")
+            .message(message)
+            .send()
+        {
+            debug!(error = ?e, "Failed to send notification");
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- add a hidden `workmux notify` command for desktop notifications
- include the pi agent's final assistant text as the notification body
- make notification clicks jump to the most recently done/waiting agent via the existing `last-done` logic
- await the pi status update before spawning the notification so sidebar state can persist reliably
- spawn the notification command detached from the pi extension so action-capable notifications survive until clicked/dismissed

## Notes

`notify-rust` action notifications need `Hint::Resident(true)` plus `Timeout::Never` with mako; otherwise action-bearing notifications can disappear before they are visible/clickable.

The click action intentionally reuses `last-done`, so it focuses the most recently completed/waiting agent rather than carrying an exact originating pane ID in the notification payload.

This branch is currently based on `main`; after #184 lands, it should be rebased so the notification extension layers on top of the scoped `--scope-id` Pi status extension.

## Tests

- `cargo build --quiet`
- `cargo test --bin workmux --quiet`
