### PR TITLE
Use unique temp filenames for atomic state writes

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -8,6 +8,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tracing::debug;
 
+use crate::util::write_atomic;
+
 #[derive(Debug, Deserialize)]
 pub struct PrDetails {
     #[serde(rename = "headRefName")]
@@ -923,10 +925,7 @@ pub fn save_pr_cache(statuses: &HashMap<PathBuf, HashMap<String, PrSummary>>) {
     let Ok(content) = serde_json::to_string(&merged) else {
         return;
     };
-    let tmp = path.with_extension(format!("json.{}.tmp", std::process::id()));
-    if std::fs::write(&tmp, content).is_ok() {
-        let _ = std::fs::rename(tmp, path);
-    }
+    let _ = write_atomic(&path, content.as_bytes());
 }
 
 #[cfg(test)]

--- a/src/state/codex_status.rs
+++ b/src/state/codex_status.rs
@@ -230,7 +230,14 @@ fn delete_status(dir: &Path, pane_key: &PaneKey) -> Result<()> {
 }
 
 fn write_atomic(path: &Path, content: &[u8]) -> Result<()> {
-    let tmp = path.with_extension("json.tmp");
+    // Use a unique temp filename per writer so concurrent writes to the same
+    // target don't clobber each other's temp file. rename() is atomic on the
+    // same filesystem.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tmp = path.with_extension(format!("json.tmp.{}.{}", std::process::id(), nanos));
     fs::write(&tmp, content).context("Failed to write Codex status temp file")?;
     fs::rename(&tmp, path).context("Failed to rename Codex status temp file")?;
     Ok(())

--- a/src/state/codex_status.rs
+++ b/src/state/codex_status.rs
@@ -24,6 +24,7 @@ use tracing::warn;
 
 use crate::multiplexer::AgentStatus;
 use crate::state::{PaneKey, StateStore};
+use crate::util::write_atomic;
 
 #[derive(Debug, Deserialize)]
 struct CodexHookProbe {
@@ -227,20 +228,6 @@ fn delete_status(dir: &Path, pane_key: &PaneKey) -> Result<()> {
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error).context("Failed to delete Codex status file"),
     }
-}
-
-fn write_atomic(path: &Path, content: &[u8]) -> Result<()> {
-    // Use a unique temp filename per writer so concurrent writes to the same
-    // target don't clobber each other's temp file. rename() is atomic on the
-    // same filesystem.
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let tmp = path.with_extension(format!("json.tmp.{}.{}", std::process::id(), nanos));
-    fs::write(&tmp, content).context("Failed to write Codex status temp file")?;
-    fs::rename(&tmp, path).context("Failed to rename Codex status temp file")?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/state/run.rs
+++ b/src/state/run.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::store::get_state_dir;
+use crate::util::write_atomic;
 
 /// Specification for a command to execute.
 #[derive(Debug, Serialize, Deserialize)]
@@ -87,12 +88,10 @@ pub fn read_result(run_dir: &Path) -> Result<Option<RunResult>> {
 
 /// Write the result atomically to a run directory.
 pub fn write_result(run_dir: &Path, result: &RunResult) -> Result<()> {
-    let tmp_path = run_dir.join("result.json.tmp");
     let final_path = run_dir.join("result.json");
 
     let content = serde_json::to_string_pretty(result)?;
-    fs::write(&tmp_path, content)?;
-    fs::rename(&tmp_path, &final_path)?;
+    write_atomic(&final_path, content.as_bytes())?;
     Ok(())
 }
 

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -508,7 +508,14 @@ fn tmux_auto_renamed_windows(
 ///
 /// This ensures the target file is never partially written.
 fn write_atomic(path: &Path, content: &[u8]) -> Result<()> {
-    let tmp = path.with_extension("json.tmp");
+    // Use a unique temp filename per writer so concurrent writes to the same
+    // target don't clobber each other's temp file. rename() is atomic on the
+    // same filesystem.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tmp = path.with_extension(format!("json.tmp.{}.{}", std::process::id(), nanos));
     fs::write(&tmp, content).context("Failed to write temp file")?;
     fs::rename(&tmp, path).context("Failed to rename temp file")?;
     Ok(())
@@ -678,7 +685,10 @@ mod tests {
         for entry in fs::read_dir(&agents_dir).unwrap() {
             let entry = entry.unwrap();
             let name = entry.file_name().to_string_lossy().to_string();
-            assert!(!name.ends_with(".tmp"), "temp file should be cleaned up");
+            assert!(
+                !name.contains(".tmp"),
+                "temp file should be cleaned up: {name}"
+            );
         }
     }
 

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -9,6 +9,7 @@ use tracing::{info, trace, warn};
 
 use super::types::{AgentState, GlobalSettings, PaneKey};
 use crate::config::SandboxRuntime;
+use crate::util::write_atomic;
 
 /// Manages filesystem-based state persistence for workmux agents.
 ///
@@ -502,23 +503,6 @@ fn tmux_auto_renamed_windows(
             _ => None,
         })
         .collect()
-}
-
-/// Write content atomically using temp file + rename.
-///
-/// This ensures the target file is never partially written.
-fn write_atomic(path: &Path, content: &[u8]) -> Result<()> {
-    // Use a unique temp filename per writer so concurrent writes to the same
-    // target don't clobber each other's temp file. rename() is atomic on the
-    // same filesystem.
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let tmp = path.with_extension(format!("json.tmp.{}.{}", std::process::id(), nanos));
-    fs::write(&tmp, content).context("Failed to write temp file")?;
-    fs::rename(&tmp, path).context("Failed to rename temp file")?;
-    Ok(())
 }
 
 /// Get the workmux state directory (`$XDG_STATE_HOME/workmux`).

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,77 @@
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
+use std::fs;
+use std::io::Write;
 use std::path::{Component, Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
+
+const STALE_ATOMIC_TEMP_AGE: Duration = Duration::from_secs(60);
+
+/// Write content through a same-directory temporary file and atomically replace the target.
+pub fn write_atomic(path: &Path, content: &[u8]) -> Result<()> {
+    cleanup_stale_atomic_temps(path)?;
+
+    let parent = path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let prefix = atomic_temp_prefix(path);
+    let mut tmp = tempfile::Builder::new()
+        .prefix(&prefix)
+        .tempfile_in(parent)
+        .with_context(|| format!("Failed to create temp file for {}", path.display()))?;
+
+    tmp.write_all(content)
+        .with_context(|| format!("Failed to write temp file for {}", path.display()))?;
+    tmp.flush()
+        .with_context(|| format!("Failed to flush temp file for {}", path.display()))?;
+    tmp.persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("Failed to rename temp file for {}", path.display()))?;
+    Ok(())
+}
+
+fn cleanup_stale_atomic_temps(path: &Path) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let Ok(entries) = fs::read_dir(parent) else {
+        return Ok(());
+    };
+    let prefix = atomic_temp_prefix(path);
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with(&prefix) {
+            continue;
+        }
+        if !is_stale_atomic_temp(&entry) {
+            continue;
+        }
+        let _ = fs::remove_file(entry.path());
+    }
+
+    Ok(())
+}
+
+fn is_stale_atomic_temp(entry: &fs::DirEntry) -> bool {
+    entry
+        .metadata()
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .is_some_and(|age| age >= STALE_ATOMIC_TEMP_AGE)
+}
+
+fn atomic_temp_prefix(path: &Path) -> String {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("atomic");
+    format!(".{file_name}.tmp.")
+}
 
 /// Canonicalize a path, falling back to the original if canonicalization fails.
 pub fn canon_or_self(p: &Path) -> PathBuf {
@@ -173,6 +244,36 @@ pub fn format_elapsed_duration(d: Duration) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn write_atomic_replaces_target_and_removes_temp() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+
+        write_atomic(&path, b"first").unwrap();
+        write_atomic(&path, b"second").unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "second");
+        let leftovers = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp."))
+            .count();
+        assert_eq!(leftovers, 0);
+    }
+
+    #[test]
+    fn write_atomic_does_not_remove_fresh_temp() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let temp = dir.path().join(".state.json.tmp.keep");
+        fs::write(&temp, "pending").unwrap();
+
+        write_atomic(&path, b"stored").unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "stored");
+        assert_eq!(fs::read_to_string(&temp).unwrap(), "pending");
+    }
 
     #[test]
     fn expand_worktree_dir_tilde_and_project() {


### PR DESCRIPTION
## Summary

- Use a unique temp filename per writer for atomic state writes (`pid + nanos`) instead of a shared `.json.tmp`
- Applies to both `StateStore::write_atomic` and the Codex status `write_atomic`
- Relax the leftover-temp-file test assertion to catch any `.tmp` suffix

## Why

Concurrent status writes for the same pane (e.g. duplicate status extensions firing at once) shared one `.json.tmp` path, so one writer could clobber another's temp file before the atomic rename. The rename itself is atomic on the same filesystem; only the temp path needs to be unique per writer.

## Tests

- `cargo test --quiet -- --test-threads=1`

Split out of #184 where it was bundled with unrelated Pi status changes.
