### PR TITLE
fix: wait for interactive shell before sending pane commands

### DIFF
--- a/src/multiplexer/handshake.rs
+++ b/src/multiplexer/handshake.rs
@@ -34,10 +34,80 @@ pub trait PaneHandshake: Send {
 
     /// Waits for the handshake signal, consuming the handshake object.
     fn wait(self: Box<Self>) -> Result<()>;
+
+    /// Waits for the handshake and any backend-specific shell readiness check.
+    ///
+    /// Backends without a post-exec readiness mechanism retain the original
+    /// handshake behavior.
+    fn wait_for_shell(self: Box<Self>, _pane_id: &str) -> Result<()> {
+        self.wait()
+    }
 }
 
 /// Timeout for waiting for pane readiness (seconds)
 const HANDSHAKE_TIMEOUT_SECS: u64 = 5;
+const PANE_READY_POLL_INTERVAL_MS: u64 = 50;
+
+#[derive(Default)]
+struct PaneContentStability {
+    previous: Option<String>,
+}
+
+impl PaneContentStability {
+    fn reset(&mut self) {
+        self.previous = None;
+    }
+
+    fn observe(&mut self, content: String) -> bool {
+        if content.is_empty() {
+            self.reset();
+            return false;
+        }
+
+        if self.previous.as_ref() == Some(&content) {
+            return true;
+        }
+
+        self.previous = Some(content);
+        false
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum PaneReadiness {
+    Ready(Duration),
+    TimedOut { last_error: Option<String> },
+}
+
+fn poll_until_stable_pane(
+    timeout: Duration,
+    poll_interval: Duration,
+    mut capture: impl FnMut() -> Result<String>,
+) -> PaneReadiness {
+    let start = Instant::now();
+    let mut stability = PaneContentStability::default();
+
+    loop {
+        let last_error = match capture() {
+            Ok(content) => {
+                if stability.observe(content) {
+                    return PaneReadiness::Ready(start.elapsed());
+                }
+                None
+            }
+            Err(error) => {
+                stability.reset();
+                Some(error.to_string())
+            }
+        };
+
+        if start.elapsed() >= timeout {
+            return PaneReadiness::TimedOut { last_error };
+        }
+
+        thread::sleep(poll_interval);
+    }
+}
 
 /// Manages the tmux wait-for handshake protocol for pane synchronization.
 ///
@@ -75,6 +145,42 @@ impl TmuxHandshake {
             .context("Failed to initialize wait channel")?;
 
         Ok(Self { channel })
+    }
+
+    /// Wait until the pane has rendered non-empty, stable content.
+    ///
+    /// The initial wait-for signal is emitted before the shell is exec'd. Polling
+    /// the pane afterwards keeps input out of the PTY while interactive shell
+    /// initialization (including async prompt setup) is still in progress.
+    fn wait_for_stable_pane(pane_id: &str) {
+        let timeout = Duration::from_secs(HANDSHAKE_TIMEOUT_SECS);
+        let poll_interval = Duration::from_millis(PANE_READY_POLL_INTERVAL_MS);
+        let readiness = poll_until_stable_pane(timeout, poll_interval, || {
+            Cmd::new("tmux")
+                .args(&["capture-pane", "-p", "-t", pane_id])
+                .run_and_capture_stdout()
+                .inspect_err(|error| {
+                    trace!(pane_id, error = %error, "tmux:handshake pane capture failed");
+                })
+        });
+
+        match readiness {
+            PaneReadiness::Ready(elapsed) => {
+                debug!(
+                    pane_id,
+                    elapsed_ms = elapsed.as_millis(),
+                    "tmux:handshake pane ready"
+                );
+            }
+            PaneReadiness::TimedOut { last_error } => {
+                warn!(
+                    pane_id,
+                    timeout_secs = HANDSHAKE_TIMEOUT_SECS,
+                    last_error = ?last_error,
+                    "tmux:handshake pane readiness timeout; sending command anyway"
+                );
+            }
+        }
     }
 }
 
@@ -181,6 +287,12 @@ impl PaneHandshake for TmuxHandshake {
                 }
             }
         }
+    }
+
+    fn wait_for_shell(self: Box<Self>, pane_id: &str) -> Result<()> {
+        self.wait()?;
+        Self::wait_for_stable_pane(pane_id);
+        Ok(())
     }
 }
 
@@ -295,5 +407,66 @@ impl Drop for UnixPipeHandshake {
     fn drop(&mut self) {
         // Clean up the pipe file if it still exists
         let _ = std::fs::remove_file(&self.pipe_path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PaneContentStability, PaneReadiness, poll_until_stable_pane};
+    use anyhow::anyhow;
+    use std::collections::VecDeque;
+    use std::time::Duration;
+
+    #[test]
+    fn pane_content_must_be_non_empty_and_stable() {
+        let mut stability = PaneContentStability::default();
+
+        assert!(!stability.observe(String::new()));
+        assert!(!stability.observe("loading".to_string()));
+        assert!(!stability.observe("prompt".to_string()));
+        assert!(stability.observe("prompt".to_string()));
+    }
+
+    #[test]
+    fn empty_pane_content_resets_stability() {
+        let mut stability = PaneContentStability::default();
+
+        assert!(!stability.observe("prompt".to_string()));
+        assert!(!stability.observe(String::new()));
+        assert!(!stability.observe("prompt".to_string()));
+        assert!(stability.observe("prompt".to_string()));
+    }
+
+    #[test]
+    fn stable_pane_poll_requires_consecutive_matching_captures() {
+        let mut captures = VecDeque::from([
+            Ok(String::new()),
+            Ok("loading".to_string()),
+            Err(anyhow!("capture failed")),
+            Ok("loading".to_string()),
+            Ok("prompt".to_string()),
+            Ok("prompt".to_string()),
+        ]);
+
+        let readiness = poll_until_stable_pane(Duration::from_secs(1), Duration::ZERO, || {
+            captures.pop_front().expect("capture sequence exhausted")
+        });
+
+        assert!(matches!(readiness, PaneReadiness::Ready(_)));
+        assert!(captures.is_empty());
+    }
+
+    #[test]
+    fn stable_pane_poll_times_out_after_capture_error() {
+        let readiness = poll_until_stable_pane(Duration::ZERO, Duration::ZERO, || {
+            Err(anyhow!("pane exited"))
+        });
+
+        assert_eq!(
+            readiness,
+            PaneReadiness::TimedOut {
+                last_error: Some("pane exited".to_string()),
+            }
+        );
     }
 }

--- a/src/multiplexer/mod.rs
+++ b/src/multiplexer/mod.rs
@@ -498,7 +498,7 @@ pub trait Multiplexer: Send + Sync {
                     )?
                 };
 
-                handshake.wait()?;
+                handshake.wait_for_shell(&spawned_id)?;
 
                 // Inject resume/continue arguments for agent panes when requested
                 if let Some(selected_agent) = resolved.selected_agent.as_mut() {

--- a/tests/test_workmux_add/test_shell_init.py
+++ b/tests/test_workmux_add/test_shell_init.py
@@ -1,5 +1,9 @@
 """Tests for shell initialization and login shell behavior."""
 
+import shlex
+import shutil
+import sys
+
 import pytest
 
 from ..conftest import (
@@ -98,3 +102,46 @@ class TestLoginShell:
             f"Expected 2 login shells, log content:\n"
             f"{log_file.read_text() if log_file.exists() else 'File not found'}"
         )
+
+
+@pytest.mark.tmux_only
+def test_pane_command_survives_input_flush_during_zsh_initialization(
+    mux_server: MuxEnvironment,
+    workmux_exe_path,
+    repo_path,
+):
+    """Pane commands are sent after async-style zsh initialization settles."""
+    zsh = shutil.which("zsh")
+    if zsh is None:
+        pytest.skip("zsh is not installed")
+
+    env = mux_server
+    branch_name = "feature-async-shell-init"
+    marker_file = env.home_path / "pane_command_ran"
+    zdotdir = env.home_path / "async-zsh"
+    zdotdir.mkdir()
+
+    flush_input = (
+        "import sys, termios; termios.tcflush(sys.stdin.fileno(), termios.TCIFLUSH)"
+    )
+    (zdotdir / ".zshrc").write_text(
+        "sleep 0.2\n"
+        f"{shlex.quote(sys.executable)} -c {shlex.quote(flush_input)}\n"
+        "PS1='workmux-ready% '\n"
+    )
+
+    env.configure_default_shell(zsh)
+    env.set_session_env("ZDOTDIR", str(zdotdir))
+    write_workmux_config(
+        repo_path,
+        panes=[{"command": f"touch {shlex.quote(str(marker_file))}"}],
+    )
+
+    add_branch_and_get_worktree(
+        env,
+        workmux_exe_path,
+        repo_path,
+        branch_name,
+    )
+
+    wait_for_file(env, marker_file, timeout=5.0)


### PR DESCRIPTION
## Summary

When `workmux add` opens a new workbox, pane commands (e.g. `nvim` or a long-running CLI) flash briefly and never execute for users running an async prompt theme like Pure. The handshake wrapper (`TmuxHandshake` in `src/multiplexer/handshake.rs`) signals readiness via `tmux wait-for -U <channel>` *before* `exec <shell> -l`, so `setup_panes` writes the command into the PTY while the shell is still initializing. Plain zsh eventually reads the buffered characters, but Pure's zpty-based async workers reset ZLE state during init and flush the terminal input buffer, silently discarding the keystrokes.

This moves readiness detection to *after* the shell is interactive. After the existing `wait()` unblocks, a bounded post-exec wait (~5s, matching `HANDSHAKE_TIMEOUT_SECS`) polls `tmux capture-pane -p` until the pane content is non-empty and stable across two consecutive polls (prompt rendered and init settled), then falls back to the current behavior on timeout so minimal-rc shells are neither slowed nor broken. It is wired into the shared `setup_panes` between `handshake.wait()` and `send_keys(...)`, so all pane commands benefit.

## Why this matters

The issue includes a self-contained repro that loses the keystrokes with Pure and succeeds without it. The root cause is a race between shell init flushing the input buffer and workmux writing the command; the pre-exec `wait-for` only proves the wrapper reached the exec, not that the shell is ready to read. The fix keeps the change tmux-focused per the issue - the wrapper script is unchanged (echo suppression is still needed) and other multiplexer backends keep their existing handshake semantics through the trait default.

## Testing

Added `tests/test_workmux_add/test_shell_init.py`, which uses a ZDOTDIR with a Pure-style async init that flushes PTY input during startup and asserts the configured pane command still executes. The timeout fallback path preserves current behavior for minimal shells.

Fixes #155
