### PR TITLE
Kata containers backend

### DIFF
--- a/docs/guide/sandbox/container.md
+++ b/docs/guide/sandbox/container.md
@@ -49,7 +49,9 @@ workmux sandbox pull
 | `container.cpus`          | none                                    | CPU count for the container. Only passed when explicitly set. Apple Container defaults to 4 CPUs which is sufficient for most workloads.                                                                                                                                                                                                                                  |
 | `container.devices`       | `[]`                                    | Host device nodes exposed to the sandbox (e.g. `/dev/kvm`, `/dev/ttyUSB0`). Passed to the runtime as `--device`. Docker and Podman only; Apple Container rejects. **Global config only.**                                                                                                                                                                                 |
 | `container.group_add`     | `[]`                                    | Supplementary groups added to the sandboxed process (e.g. `dialout`, `video`, or numeric GIDs). Passed to the runtime as `--group-add`. Docker and Podman only; Apple Container rejects. **Global config only.**                                                                                                                                                          |
-| `container.oci_runtime`   | none (engine default)                   | OCI runtime to run the container under, passed as `docker`/`podman` `--runtime`. Unset omits `--runtime`, deferring to the engine's configured default (`runc` on Docker, typically `crun` on Podman). Set to e.g. `kata` to run under a VM-based runtime for stronger isolation. Docker only in practice (see note); Apple Container ignores it. **Global config only.** |
+| `container.cap_add`       | `[]`                                    | Extra Linux capabilities granted to the container, passed verbatim as `--cap-add` (e.g. `ALL` or `SYS_ADMIN`). Docker and Podman only; Apple Container ignores it. Permissive values weaken host-kernel container isolation. **Global config only.**                                                                                                                     |
+| `container.security_opt`  | `[]`                                    | Security options passed verbatim as `--security-opt` (e.g. `seccomp=unconfined` or `no-new-privileges`). Docker and Podman only; Apple Container ignores it. Options can strengthen or weaken confinement. **Global config only.**                                                                                                                                      |
+| `container.oci_runtime`   | none (engine default)                   | OCI runtime to run the container under, passed as Docker or local Podman `--runtime`. Unset omits `--runtime`, deferring to the engine's configured default. Set to e.g. `kata` for stronger VM-based isolation. Remote Podman rejects this flag; Apple Container ignores it. **Global config only.**                                                                   |
 | `target`                  | `agent`                                 | Which panes to sandbox: `agent` or `all`                                                                                                                                                                                                                                                                                                                                  |
 | `image`                   | `ghcr.io/raine/workmux-sandbox:{agent}` | Container image name (auto-resolved from configured agent).                                                                                                                                                                                                                                                                                                               |
 | `rpc_host`                | auto                                    | Override hostname for guest-to-host RPC. Defaults to `host.docker.internal` (Docker), `host.containers.internal` (Podman), or `192.168.64.1` (Apple Container). **Global config only.**                                                                                                                                                                                   |
@@ -159,17 +161,17 @@ sandbox:
     oci_runtime: kata
 ```
 
-`oci_runtime` is passed straight through to `docker`/`podman` as `--runtime`, so
-the container runs under whatever OCI runtime you name instead of the engine
-default (`runc` on Docker, typically `crun` on Podman). Pointing it at a VM-based
-runtime such as [Kata Containers](https://katacontainers.io/) gives each sandbox
-a hardware-VM boundary while reusing the exact same container image, mounts, user
-mapping, and RPC path as the normal container backend. Leaving it unset keeps the
-engine's default behavior.
+`oci_runtime` is passed straight through to Docker or local Podman as `--runtime`,
+so the container runs under whatever OCI runtime you name instead of the engine's
+configured default. Pointing it at a VM-based runtime such as
+[Kata Containers](https://katacontainers.io/) gives each sandbox a hardware-VM
+boundary while reusing the exact same container image, mounts, user mapping, and
+RPC path as the normal container backend. Leaving it unset keeps the engine's
+default behavior.
 
 The named runtime must already be installed on the host and registered with your
 container engine (for Docker, listed under `docker info`'s runtimes). Setting it
-up is out of scope here — see the runtime's own documentation.
+up is out of scope here. See the runtime's own documentation.
 
 Notes:
 
@@ -178,8 +180,13 @@ Notes:
   a repository must not be able to select (or downgrade) it via its own config.
 - **Kata needs Docker.** Kata Containers does not officially support Podman as a
   container manager ([Kata limitations](https://github.com/kata-containers/kata-containers/blob/main/docs/Limitations.md)),
-  so use `runtime: docker` for the `kata` example above. Other OCI runtimes may
-  work under Podman via `--runtime`; check the specific runtime's support matrix.
+  so use `runtime: docker` for the `kata` example above.
+- **Podman support is local-only.** Other OCI runtimes may work with local Podman
+  on Linux. Remote Podman clients, including all macOS and Windows builds, do
+  not expose `podman run --runtime`. Workmux rejects `oci_runtime` on non-Linux
+  hosts and when `CONTAINER_HOST` or `CONTAINER_CONNECTION` selects a remote
+  service. Other remote Podman configurations are unsupported and may return
+  `unknown flag: --runtime` directly from Podman.
 - **Apple Container ignores it.** Apple Container manages its own VM and has no
   `--runtime` concept, so a configured `oci_runtime` is silently omitted there
   (as are `cap_add`/`security_opt`). This lets one global config target Kata on a
@@ -188,6 +195,32 @@ Notes:
   inside the container, which needs a real in-guest kernel. It works under a
   VM-based runtime like Kata, but may not under a userspace-kernel runtime such
   as gVisor.
+
+**Docker-in-Docker under Kata:**
+
+```yaml
+sandbox:
+  enabled: true
+  container:
+    runtime: docker
+    oci_runtime: kata
+    cap_add: [ALL]
+    security_opt:
+      - seccomp=unconfined
+      - apparmor=unconfined
+      - systempaths=unconfined
+```
+
+`cap_add` and `security_opt` are global-only passthroughs for Docker and Podman.
+They support an inner Docker daemon under Kata without `--privileged`, which
+injects host device nodes that conflict with devices in the guest. The values
+above grant every Linux capability and disable several container-level security
+controls, while Kata's guest VM remains the host isolation boundary.
+
+These fields are independent of `oci_runtime`. Without a VM-based OCI runtime,
+permissive values apply to a host-kernel container and weaken the sandbox's
+isolation from the host. `security_opt` values such as `no-new-privileges` can
+instead strengthen confinement. Apple Container silently omits both fields.
 
 **Sandbox all panes (not just agent):**
 

--- a/docs/guide/sandbox/container.md
+++ b/docs/guide/sandbox/container.md
@@ -41,24 +41,24 @@ workmux sandbox pull
 
 ## Configuration
 
-| Option                    | Default                                 | Description                                                                                                                                                                                                                                          |
-| ------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `enabled`                 | `false`                                 | Enable container sandboxing                                                                                                                                                                                                                          |
-| `container.runtime`       | auto-detect                             | Container runtime: `docker`, `podman`, or `apple-container`. Auto-detected from PATH when not set. On macOS, prefers Apple Container (`container`) over Docker/Podman.                                                                               |
-| `container.memory`        | `16G` (Apple Container) / none (others) | Memory limit for the container. Apple Container VMs default to 1 GB which is too low, so workmux sets `16G` by default. This is a ceiling, not an upfront allocation. Works with any runtime when explicitly set.                                    |
-| `container.cpus`          | none                                    | CPU count for the container. Only passed when explicitly set. Apple Container defaults to 4 CPUs which is sufficient for most workloads.                                                                                                             |
-| `container.devices`       | `[]`                                    | Host device nodes exposed to the sandbox (e.g. `/dev/kvm`, `/dev/ttyUSB0`). Passed to the runtime as `--device`. Docker and Podman only; Apple Container rejects. **Global config only.**                                                            |
-| `container.group_add`     | `[]`                                    | Supplementary groups added to the sandboxed process (e.g. `dialout`, `video`, or numeric GIDs). Passed to the runtime as `--group-add`. Docker and Podman only; Apple Container rejects. **Global config only.**                                     |
-| `container.oci_runtime`   | none (runc)                             | OCI runtime to run the container under, passed as `docker`/`podman` `--runtime`. Unset uses the runtime default (`runc`). Set to e.g. `kata` to run under a VM-based runtime for stronger isolation. Docker and Podman only. **Global config only.** |
-| `target`                  | `agent`                                 | Which panes to sandbox: `agent` or `all`                                                                                                                                                                                                             |
-| `image`                   | `ghcr.io/raine/workmux-sandbox:{agent}` | Container image name (auto-resolved from configured agent).                                                                                                                                                                                          |
-| `rpc_host`                | auto                                    | Override hostname for guest-to-host RPC. Defaults to `host.docker.internal` (Docker), `host.containers.internal` (Podman), or `192.168.64.1` (Apple Container). **Global config only.**                                                              |
-| `env_passthrough`         | `[]`                                    | Environment variables to pass through. **Global config only.**                                                                                                                                                                                       |
-| `env`                     | `{}`                                    | Environment variables to set with explicit values (unlike `env_passthrough` which reads from host). **Global config only.**                                                                                                                          |
-| `extra_mounts`            | `[]`                                    | Additional host paths to mount (see [shared features](./features#extra-mounts)). **Global config only.**                                                                                                                                             |
-| `agent_config_dir`        | per-agent default                       | Custom host directory for agent config. Supports `{agent}` placeholder. Overrides default mounts (e.g. `~/.claude/`). Auto-created if missing. **Global config only.**                                                                               |
-| `network.policy`          | `allow`                                 | Network restriction policy: `allow` (no restrictions) or `deny` (block all except allowed domains). See [network restrictions](#network-restrictions). **Global config only.**                                                                       |
-| `network.allowed_domains` | `[]`                                    | Allowed outbound HTTPS domains when policy is `deny`. Supports exact matches, `*.` wildcard prefixes, and exact-host private destination opt-in. **Global config only.**                                                                             |
+| Option                    | Default                                 | Description                                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`                 | `false`                                 | Enable container sandboxing                                                                                                                                                                                                                                                                                                                                               |
+| `container.runtime`       | auto-detect                             | Container runtime: `docker`, `podman`, or `apple-container`. Auto-detected from PATH when not set. On macOS, prefers Apple Container (`container`) over Docker/Podman.                                                                                                                                                                                                    |
+| `container.memory`        | `16G` (Apple Container) / none (others) | Memory limit for the container. Apple Container VMs default to 1 GB which is too low, so workmux sets `16G` by default. This is a ceiling, not an upfront allocation. Works with any runtime when explicitly set.                                                                                                                                                         |
+| `container.cpus`          | none                                    | CPU count for the container. Only passed when explicitly set. Apple Container defaults to 4 CPUs which is sufficient for most workloads.                                                                                                                                                                                                                                  |
+| `container.devices`       | `[]`                                    | Host device nodes exposed to the sandbox (e.g. `/dev/kvm`, `/dev/ttyUSB0`). Passed to the runtime as `--device`. Docker and Podman only; Apple Container rejects. **Global config only.**                                                                                                                                                                                 |
+| `container.group_add`     | `[]`                                    | Supplementary groups added to the sandboxed process (e.g. `dialout`, `video`, or numeric GIDs). Passed to the runtime as `--group-add`. Docker and Podman only; Apple Container rejects. **Global config only.**                                                                                                                                                          |
+| `container.oci_runtime`   | none (engine default)                   | OCI runtime to run the container under, passed as `docker`/`podman` `--runtime`. Unset omits `--runtime`, deferring to the engine's configured default (`runc` on Docker, typically `crun` on Podman). Set to e.g. `kata` to run under a VM-based runtime for stronger isolation. Docker only in practice (see note); Apple Container ignores it. **Global config only.** |
+| `target`                  | `agent`                                 | Which panes to sandbox: `agent` or `all`                                                                                                                                                                                                                                                                                                                                  |
+| `image`                   | `ghcr.io/raine/workmux-sandbox:{agent}` | Container image name (auto-resolved from configured agent).                                                                                                                                                                                                                                                                                                               |
+| `rpc_host`                | auto                                    | Override hostname for guest-to-host RPC. Defaults to `host.docker.internal` (Docker), `host.containers.internal` (Podman), or `192.168.64.1` (Apple Container). **Global config only.**                                                                                                                                                                                   |
+| `env_passthrough`         | `[]`                                    | Environment variables to pass through. **Global config only.**                                                                                                                                                                                                                                                                                                            |
+| `env`                     | `{}`                                    | Environment variables to set with explicit values (unlike `env_passthrough` which reads from host). **Global config only.**                                                                                                                                                                                                                                               |
+| `extra_mounts`            | `[]`                                    | Additional host paths to mount (see [shared features](./features#extra-mounts)). **Global config only.**                                                                                                                                                                                                                                                                  |
+| `agent_config_dir`        | per-agent default                       | Custom host directory for agent config. Supports `{agent}` placeholder. Overrides default mounts (e.g. `~/.claude/`). Auto-created if missing. **Global config only.**                                                                                                                                                                                                    |
+| `network.policy`          | `allow`                                 | Network restriction policy: `allow` (no restrictions) or `deny` (block all except allowed domains). See [network restrictions](#network-restrictions). **Global config only.**                                                                                                                                                                                            |
+| `network.allowed_domains` | `[]`                                    | Allowed outbound HTTPS domains when policy is `deny`. Supports exact matches, `*.` wildcard prefixes, and exact-host private destination opt-in. **Global config only.**                                                                                                                                                                                                  |
 
 ### Example configurations
 
@@ -155,29 +155,35 @@ Listed paths are relative to the worktree root. Each one is shadowed by a read-o
 sandbox:
   enabled: true
   container:
+    runtime: docker
     oci_runtime: kata
 ```
 
 `oci_runtime` is passed straight through to `docker`/`podman` as `--runtime`, so
-the container runs under whatever OCI runtime you name instead of the default
-`runc`. Pointing it at a VM-based runtime such as
-[Kata Containers](https://katacontainers.io/) gives each sandbox a hardware-VM
-boundary while reusing the exact same container image, mounts, user mapping, and
-RPC path as the normal container backend. Leaving it unset keeps the default
-`runc` behavior.
+the container runs under whatever OCI runtime you name instead of the engine
+default (`runc` on Docker, typically `crun` on Podman). Pointing it at a VM-based
+runtime such as [Kata Containers](https://katacontainers.io/) gives each sandbox
+a hardware-VM boundary while reusing the exact same container image, mounts, user
+mapping, and RPC path as the normal container backend. Leaving it unset keeps the
+engine's default behavior.
 
 The named runtime must already be installed on the host and registered with your
-container runtime (for Docker, listed under `docker info`'s runtimes; for Podman,
-a configured `--runtime`). Setting it up is out of scope here — see the
-runtime's own documentation.
+container engine (for Docker, listed under `docker info`'s runtimes). Setting it
+up is out of scope here — see the runtime's own documentation.
 
 Notes:
 
 - **Global config only.** Like `devices`/`group_add`, `oci_runtime` is ignored
   when set in a project's `.workmux.yaml`. It changes the isolation boundary, so
   a repository must not be able to select (or downgrade) it via its own config.
-- **Docker and Podman only.** Apple Container manages its own VM and ignores this
-  setting.
+- **Kata needs Docker.** Kata Containers does not officially support Podman as a
+  container manager ([Kata limitations](https://github.com/kata-containers/kata-containers/blob/main/docs/Limitations.md)),
+  so use `runtime: docker` for the `kata` example above. Other OCI runtimes may
+  work under Podman via `--runtime`; check the specific runtime's support matrix.
+- **Apple Container ignores it.** Apple Container manages its own VM and has no
+  `--runtime` concept, so a configured `oci_runtime` is silently omitted there
+  (as are `cap_add`/`security_opt`). This lets one global config target Kata on a
+  Docker host and still run on macOS without erroring.
 - **Network-deny mode** ([below](#network-restrictions)) configures `iptables`
   inside the container, which needs a real in-guest kernel. It works under a
   VM-based runtime like Kata, but may not under a userspace-kernel runtime such

--- a/docs/guide/sandbox/container.md
+++ b/docs/guide/sandbox/container.md
@@ -41,23 +41,24 @@ workmux sandbox pull
 
 ## Configuration
 
-| Option                    | Default                                 | Description                                                                                                                                                                                                       |
-| ------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `enabled`                 | `false`                                 | Enable container sandboxing                                                                                                                                                                                       |
-| `container.runtime`       | auto-detect                             | Container runtime: `docker`, `podman`, or `apple-container`. Auto-detected from PATH when not set. On macOS, prefers Apple Container (`container`) over Docker/Podman.                                            |
-| `container.memory`        | `16G` (Apple Container) / none (others) | Memory limit for the container. Apple Container VMs default to 1 GB which is too low, so workmux sets `16G` by default. This is a ceiling, not an upfront allocation. Works with any runtime when explicitly set. |
-| `container.cpus`          | none                                    | CPU count for the container. Only passed when explicitly set. Apple Container defaults to 4 CPUs which is sufficient for most workloads.                                                                          |
-| `container.devices`       | `[]`                                    | Host device nodes exposed to the sandbox (e.g. `/dev/kvm`, `/dev/ttyUSB0`). Passed to the runtime as `--device`. Docker and Podman only; Apple Container rejects. **Global config only.**                         |
-| `container.group_add`     | `[]`                                    | Supplementary groups added to the sandboxed process (e.g. `dialout`, `video`, or numeric GIDs). Passed to the runtime as `--group-add`. Docker and Podman only; Apple Container rejects. **Global config only.**  |
-| `target`                  | `agent`                                 | Which panes to sandbox: `agent` or `all`                                                                                                                                                                          |
-| `image`                   | `ghcr.io/raine/workmux-sandbox:{agent}` | Container image name (auto-resolved from configured agent).                                                                                                                                                       |
-| `rpc_host`                | auto                                    | Override hostname for guest-to-host RPC. Defaults to `host.docker.internal` (Docker), `host.containers.internal` (Podman), or `192.168.64.1` (Apple Container). **Global config only.**                           |
-| `env_passthrough`         | `[]`                                    | Environment variables to pass through. **Global config only.**                                                                                                                                                    |
-| `env`                     | `{}`                                    | Environment variables to set with explicit values (unlike `env_passthrough` which reads from host). **Global config only.**                                                                                       |
-| `extra_mounts`            | `[]`                                    | Additional host paths to mount (see [shared features](./features#extra-mounts)). **Global config only.**                                                                                                          |
-| `agent_config_dir`        | per-agent default                       | Custom host directory for agent config. Supports `{agent}` placeholder. Overrides default mounts (e.g. `~/.claude/`). Auto-created if missing. **Global config only.**                                            |
-| `network.policy`          | `allow`                                 | Network restriction policy: `allow` (no restrictions) or `deny` (block all except allowed domains). See [network restrictions](#network-restrictions). **Global config only.**                                    |
-| `network.allowed_domains` | `[]`                                    | Allowed outbound HTTPS domains when policy is `deny`. Supports exact matches, `*.` wildcard prefixes, and exact-host private destination opt-in. **Global config only.**                                          |
+| Option                    | Default                                 | Description                                                                                                                                                                                                                                          |
+| ------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`                 | `false`                                 | Enable container sandboxing                                                                                                                                                                                                                          |
+| `container.runtime`       | auto-detect                             | Container runtime: `docker`, `podman`, or `apple-container`. Auto-detected from PATH when not set. On macOS, prefers Apple Container (`container`) over Docker/Podman.                                                                               |
+| `container.memory`        | `16G` (Apple Container) / none (others) | Memory limit for the container. Apple Container VMs default to 1 GB which is too low, so workmux sets `16G` by default. This is a ceiling, not an upfront allocation. Works with any runtime when explicitly set.                                    |
+| `container.cpus`          | none                                    | CPU count for the container. Only passed when explicitly set. Apple Container defaults to 4 CPUs which is sufficient for most workloads.                                                                                                             |
+| `container.devices`       | `[]`                                    | Host device nodes exposed to the sandbox (e.g. `/dev/kvm`, `/dev/ttyUSB0`). Passed to the runtime as `--device`. Docker and Podman only; Apple Container rejects. **Global config only.**                                                            |
+| `container.group_add`     | `[]`                                    | Supplementary groups added to the sandboxed process (e.g. `dialout`, `video`, or numeric GIDs). Passed to the runtime as `--group-add`. Docker and Podman only; Apple Container rejects. **Global config only.**                                     |
+| `container.oci_runtime`   | none (runc)                             | OCI runtime to run the container under, passed as `docker`/`podman` `--runtime`. Unset uses the runtime default (`runc`). Set to e.g. `kata` to run under a VM-based runtime for stronger isolation. Docker and Podman only. **Global config only.** |
+| `target`                  | `agent`                                 | Which panes to sandbox: `agent` or `all`                                                                                                                                                                                                             |
+| `image`                   | `ghcr.io/raine/workmux-sandbox:{agent}` | Container image name (auto-resolved from configured agent).                                                                                                                                                                                          |
+| `rpc_host`                | auto                                    | Override hostname for guest-to-host RPC. Defaults to `host.docker.internal` (Docker), `host.containers.internal` (Podman), or `192.168.64.1` (Apple Container). **Global config only.**                                                              |
+| `env_passthrough`         | `[]`                                    | Environment variables to pass through. **Global config only.**                                                                                                                                                                                       |
+| `env`                     | `{}`                                    | Environment variables to set with explicit values (unlike `env_passthrough` which reads from host). **Global config only.**                                                                                                                          |
+| `extra_mounts`            | `[]`                                    | Additional host paths to mount (see [shared features](./features#extra-mounts)). **Global config only.**                                                                                                                                             |
+| `agent_config_dir`        | per-agent default                       | Custom host directory for agent config. Supports `{agent}` placeholder. Overrides default mounts (e.g. `~/.claude/`). Auto-created if missing. **Global config only.**                                                                               |
+| `network.policy`          | `allow`                                 | Network restriction policy: `allow` (no restrictions) or `deny` (block all except allowed domains). See [network restrictions](#network-restrictions). **Global config only.**                                                                       |
+| `network.allowed_domains` | `[]`                                    | Allowed outbound HTTPS domains when policy is `deny`. Supports exact matches, `*.` wildcard prefixes, and exact-host private destination opt-in. **Global config only.**                                                                             |
 
 ### Example configurations
 
@@ -147,6 +148,40 @@ Listed paths are relative to the worktree root. Each one is shadowed by a read-o
 **Security: global-only.** `excluded_files` is ignored when set in a project's `.workmux.yaml`; it must be configured in your global config (`~/.config/workmux/config.yaml`). This prevents a malicious repo from deleting protections via its own config.
 
 **Note:** `excluded_files` relies on file-level bind mounts, which Apple Container does not support (it only accepts directory mounts). When the runtime is Apple Container and `excluded_files` is set, workmux fails fast rather than silently leaving secrets readable. Use Docker or Podman if you need this feature.
+
+**Run under a VM-based OCI runtime (stronger isolation):**
+
+```yaml
+sandbox:
+  enabled: true
+  container:
+    oci_runtime: kata
+```
+
+`oci_runtime` is passed straight through to `docker`/`podman` as `--runtime`, so
+the container runs under whatever OCI runtime you name instead of the default
+`runc`. Pointing it at a VM-based runtime such as
+[Kata Containers](https://katacontainers.io/) gives each sandbox a hardware-VM
+boundary while reusing the exact same container image, mounts, user mapping, and
+RPC path as the normal container backend. Leaving it unset keeps the default
+`runc` behavior.
+
+The named runtime must already be installed on the host and registered with your
+container runtime (for Docker, listed under `docker info`'s runtimes; for Podman,
+a configured `--runtime`). Setting it up is out of scope here — see the
+runtime's own documentation.
+
+Notes:
+
+- **Global config only.** Like `devices`/`group_add`, `oci_runtime` is ignored
+  when set in a project's `.workmux.yaml`. It changes the isolation boundary, so
+  a repository must not be able to select (or downgrade) it via its own config.
+- **Docker and Podman only.** Apple Container manages its own VM and ignores this
+  setting.
+- **Network-deny mode** ([below](#network-restrictions)) configures `iptables`
+  inside the container, which needs a real in-guest kernel. It works under a
+  VM-based runtime like Kata, but may not under a userspace-kernel runtime such
+  as gVisor.
 
 **Sandbox all panes (not just agent):**
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1454,11 +1454,25 @@ pub struct ContainerConfig {
     /// (Apple Container).
     #[serde(default)]
     pub excluded_files: Option<Vec<String>>,
+
+    /// OCI runtime to run the container under (docker/podman `--runtime`).
+    /// Unset = the runtime's default (runc). Set to e.g. "kata" to run the
+    /// container under a VM-based OCI runtime for stronger isolation. The named
+    /// runtime must be installed and registered with the container runtime.
+    /// Global-only: ignored in project config, since it changes the isolation
+    /// boundary.
+    #[serde(default)]
+    pub oci_runtime: Option<String>,
 }
 
 impl ContainerConfig {
     pub fn runtime(&self) -> SandboxRuntime {
         self.runtime.unwrap_or_else(SandboxRuntime::detect)
+    }
+
+    /// OCI runtime name to pass to `docker/podman run --runtime`, if configured.
+    pub fn oci_runtime(&self) -> Option<&str> {
+        self.oci_runtime.as_deref()
     }
 
     pub fn devices(&self) -> &[ContainerDevice] {
@@ -1486,10 +1500,10 @@ impl ContainerConfig {
         Ok(())
     }
 
-    /// Merge: project overrides global, per-field, EXCEPT for `devices` and
-    /// `group_add` which are security-sensitive and global-only. Warnings for
-    /// project-level attempts are emitted in `Config::merge` where both values
-    /// are visible.
+    /// Merge: project overrides global, per-field, EXCEPT for `devices`,
+    /// `group_add` and `oci_runtime` which are security-sensitive and
+    /// global-only. Warnings for project-level attempts are emitted in
+    /// `Config::merge` where both values are visible.
     fn merge(global: Self, project: Self) -> Self {
         // Security: excluded_files is global-only. Project config cannot set it --
         // otherwise a repo's .workmux.yaml could delete user-level secret
@@ -1507,6 +1521,7 @@ impl ContainerConfig {
             devices: global.devices,
             group_add: global.group_add,
             excluded_files: global.excluded_files,
+            oci_runtime: global.oci_runtime,
         }
     }
 }
@@ -2550,10 +2565,11 @@ impl Config {
                 self.sandbox.agent_config_dir.clone()
             },
             lima: LimaConfig::merge(self.sandbox.lima, project.sandbox.lima),
-            // Security: sandbox.container.devices and sandbox.container.group_add
-            // are global-only. They expose host hardware and can expand
-            // filesystem access via supplementary groups, so a malicious repo
-            // must not be able to enable them via .workmux.yaml.
+            // Security: sandbox.container.devices, group_add and oci_runtime
+            // are global-only. devices/group_add expose host hardware and can
+            // expand filesystem access via supplementary groups; oci_runtime
+            // changes the isolation boundary (e.g. a VM runtime vs runc). A
+            // malicious repo must not be able to set them via .workmux.yaml.
             container: {
                 if project.sandbox.container.devices.is_some() {
                     tracing::warn!(
@@ -2564,6 +2580,12 @@ impl Config {
                 if project.sandbox.container.group_add.is_some() {
                     tracing::warn!(
                         "sandbox.container.group_add in project config (.workmux.yaml) is ignored -- \
+                        move it to your global config (~/.config/workmux/config.yaml)"
+                    );
+                }
+                if project.sandbox.container.oci_runtime.is_some() {
+                    tracing::warn!(
+                        "sandbox.container.oci_runtime in project config (.workmux.yaml) is ignored -- \
                         move it to your global config (~/.config/workmux/config.yaml)"
                     );
                 }
@@ -2918,6 +2940,10 @@ pub const EXAMPLE_PROJECT_CONFIG: &str = r#"# workmux project configuration
 #   #   runtime: docker          # docker | podman | apple-container
 #   #   # memory: 16G            # VM memory limit (apple-container default: 16G)
 #   #   # cpus: 4                # VM CPU count (only passed when set)
+#   #   # OCI runtime to run under (docker/podman --runtime). Unset = runc.
+#   #   # Set to e.g. "kata" for VM-based isolation (runtime must be installed
+#   #   # and registered). GLOBAL-ONLY: ignored in a project .workmux.yaml.
+#   #   # oci_runtime: kata
 #   #   # Mask files out of the worktree bind mounts (paths relative to the
 #   #   # worktree root). Each listed file is shadowed by /dev/null so the
 #   #   # sandboxed agent cannot read it. Missing files are skipped.
@@ -3727,6 +3753,32 @@ agents:
         let project = Config::default();
         let merged = global.merge(project);
         assert_eq!(merged.sandbox.host_commands(), &["just".to_string()]);
+    }
+
+    #[test]
+    fn container_oci_runtime_is_global_only() {
+        // oci_runtime changes the isolation boundary, so a project .workmux.yaml
+        // must not be able to override the global value.
+        let global = container_cfg(|c| c.oci_runtime = Some("kata".into()));
+        let project = container_cfg(|c| c.oci_runtime = Some("runc".into()));
+        let merged = global.merge(project);
+        assert_eq!(merged.sandbox.container.oci_runtime(), Some("kata"));
+    }
+
+    #[test]
+    fn container_oci_runtime_project_ignored_when_no_global() {
+        let global = Config::default();
+        let project = container_cfg(|c| c.oci_runtime = Some("kata".into()));
+        let merged = global.merge(project);
+        assert_eq!(merged.sandbox.container.oci_runtime(), None);
+    }
+
+    #[test]
+    fn container_oci_runtime_uses_global() {
+        let global = container_cfg(|c| c.oci_runtime = Some("kata".into()));
+        let project = Config::default();
+        let merged = global.merge(project);
+        assert_eq!(merged.sandbox.container.oci_runtime(), Some("kata"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1463,6 +1463,27 @@ pub struct ContainerConfig {
     /// boundary.
     #[serde(default)]
     pub oci_runtime: Option<String>,
+
+    /// Extra Linux capabilities to grant the container (docker/podman
+    /// `--cap-add`). Each entry is passed verbatim, e.g. "ALL" or "SYS_ADMIN".
+    /// Global-only: ignored in project config, since capabilities relax the
+    /// isolation boundary. Empty by default.
+    ///
+    /// Needed for docker-in-docker under a VM runtime (`oci_runtime: kata`),
+    /// where `--privileged` is not usable (it injects host device nodes that
+    /// collide with the guest's, failing to boot). Granting capabilities +
+    /// security_opt instead boots cleanly, and the daemon stays confined to
+    /// the guest VM.
+    #[serde(default)]
+    pub cap_add: Option<Vec<String>>,
+
+    /// Extra security options for the container (docker/podman
+    /// `--security-opt`). Each entry is passed verbatim, e.g.
+    /// "seccomp=unconfined" or "systempaths=unconfined". Global-only: ignored
+    /// in project config, since these relax the isolation boundary. Empty by
+    /// default. See `cap_add` for the docker-in-docker rationale.
+    #[serde(default)]
+    pub security_opt: Option<Vec<String>>,
 }
 
 impl ContainerConfig {
@@ -1483,6 +1504,18 @@ impl ContainerConfig {
         self.group_add.as_deref().unwrap_or(&[])
     }
 
+    /// Extra capabilities to pass to `docker/podman run --cap-add`.
+    /// Returns empty slice when unset.
+    pub fn cap_add(&self) -> &[String] {
+        self.cap_add.as_deref().unwrap_or(&[])
+    }
+
+    /// Extra security options to pass to `docker/podman run --security-opt`.
+    /// Returns empty slice when unset.
+    pub fn security_opt(&self) -> &[String] {
+        self.security_opt.as_deref().unwrap_or(&[])
+    }
+
     /// Files to mask out of the worktree bind mount (relative to worktree root).
     /// Returns empty slice when unset.
     pub fn excluded_files(&self) -> &[String] {
@@ -1501,9 +1534,9 @@ impl ContainerConfig {
     }
 
     /// Merge: project overrides global, per-field, EXCEPT for `devices`,
-    /// `group_add` and `oci_runtime` which are security-sensitive and
-    /// global-only. Warnings for project-level attempts are emitted in
-    /// `Config::merge` where both values are visible.
+    /// `group_add`, `oci_runtime`, `cap_add` and `security_opt` which are
+    /// security-sensitive and global-only. Warnings for project-level attempts
+    /// are emitted in `Config::merge` where both values are visible.
     fn merge(global: Self, project: Self) -> Self {
         // Security: excluded_files is global-only. Project config cannot set it --
         // otherwise a repo's .workmux.yaml could delete user-level secret
@@ -1522,6 +1555,8 @@ impl ContainerConfig {
             group_add: global.group_add,
             excluded_files: global.excluded_files,
             oci_runtime: global.oci_runtime,
+            cap_add: global.cap_add,
+            security_opt: global.security_opt,
         }
     }
 }
@@ -2565,11 +2600,13 @@ impl Config {
                 self.sandbox.agent_config_dir.clone()
             },
             lima: LimaConfig::merge(self.sandbox.lima, project.sandbox.lima),
-            // Security: sandbox.container.devices, group_add and oci_runtime
-            // are global-only. devices/group_add expose host hardware and can
-            // expand filesystem access via supplementary groups; oci_runtime
-            // changes the isolation boundary (e.g. a VM runtime vs runc). A
-            // malicious repo must not be able to set them via .workmux.yaml.
+            // Security: sandbox.container.devices, group_add, oci_runtime,
+            // cap_add and security_opt are global-only. devices/group_add
+            // expose host hardware and can expand filesystem access via
+            // supplementary groups; oci_runtime changes the isolation boundary
+            // (e.g. a VM runtime vs runc); cap_add/security_opt relax the
+            // container's capability/seccomp/apparmor confinement. A malicious
+            // repo must not be able to set them via .workmux.yaml.
             container: {
                 if project.sandbox.container.devices.is_some() {
                     tracing::warn!(
@@ -2586,6 +2623,18 @@ impl Config {
                 if project.sandbox.container.oci_runtime.is_some() {
                     tracing::warn!(
                         "sandbox.container.oci_runtime in project config (.workmux.yaml) is ignored -- \
+                        move it to your global config (~/.config/workmux/config.yaml)"
+                    );
+                }
+                if project.sandbox.container.cap_add.is_some() {
+                    tracing::warn!(
+                        "sandbox.container.cap_add in project config (.workmux.yaml) is ignored -- \
+                        move it to your global config (~/.config/workmux/config.yaml)"
+                    );
+                }
+                if project.sandbox.container.security_opt.is_some() {
+                    tracing::warn!(
+                        "sandbox.container.security_opt in project config (.workmux.yaml) is ignored -- \
                         move it to your global config (~/.config/workmux/config.yaml)"
                     );
                 }
@@ -2944,6 +2993,11 @@ pub const EXAMPLE_PROJECT_CONFIG: &str = r#"# workmux project configuration
 #   #   # Set to e.g. "kata" for VM-based isolation (runtime must be installed
 #   #   # and registered). GLOBAL-ONLY: ignored in a project .workmux.yaml.
 #   #   # oci_runtime: kata
+#   #   # Extra capabilities / security options (docker --cap-add /
+#   #   # --security-opt). Empty by default. GLOBAL-ONLY. Main use: enabling
+#   #   # docker-in-docker under oci_runtime: kata (where --privileged fails).
+#   #   # cap_add: [ALL]
+#   #   # security_opt: [seccomp=unconfined, apparmor=unconfined, systempaths=unconfined]
 #   #   # Mask files out of the worktree bind mounts (paths relative to the
 #   #   # worktree root). Each listed file is shadowed by /dev/null so the
 #   #   # sandboxed agent cannot read it. Missing files are skipped.
@@ -3763,6 +3817,35 @@ agents:
         let project = container_cfg(|c| c.oci_runtime = Some("runc".into()));
         let merged = global.merge(project);
         assert_eq!(merged.sandbox.container.oci_runtime(), Some("kata"));
+    }
+
+    #[test]
+    fn container_cap_add_and_security_opt_are_global_only() {
+        // Capabilities / security options relax confinement, so a project
+        // .workmux.yaml must not be able to override the global values.
+        let global = container_cfg(|c| {
+            c.cap_add = Some(vec!["ALL".into()]);
+            c.security_opt = Some(vec!["seccomp=unconfined".into()]);
+        });
+        let project = container_cfg(|c| {
+            c.cap_add = Some(vec!["NET_ADMIN".into()]);
+            c.security_opt = Some(vec!["seccomp=default".into()]);
+        });
+        let merged = global.merge(project);
+        assert_eq!(merged.sandbox.container.cap_add(), &["ALL".to_string()]);
+        assert_eq!(
+            merged.sandbox.container.security_opt(),
+            &["seccomp=unconfined".to_string()]
+        );
+    }
+
+    #[test]
+    fn container_cap_add_project_ignored_when_no_global() {
+        let global = Config::default();
+        let project = container_cfg(|c| c.cap_add = Some(vec!["ALL".into()]));
+        let merged = global.merge(project);
+        assert!(merged.sandbox.container.cap_add().is_empty());
+        assert!(merged.sandbox.container.security_opt().is_empty());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1455,12 +1455,12 @@ pub struct ContainerConfig {
     #[serde(default)]
     pub excluded_files: Option<Vec<String>>,
 
-    /// OCI runtime to run the container under (docker/podman `--runtime`).
-    /// Unset = the runtime's default (runc). Set to e.g. "kata" to run the
-    /// container under a VM-based OCI runtime for stronger isolation. The named
-    /// runtime must be installed and registered with the container runtime.
-    /// Global-only: ignored in project config, since it changes the isolation
-    /// boundary.
+    /// OCI runtime to run the container under (docker/local Podman `--runtime`).
+    /// When unset, workmux omits `--runtime` and the engine uses its configured
+    /// default. Set to e.g. "kata" to run the container under a VM-based OCI
+    /// runtime for stronger isolation. The named runtime must be installed and
+    /// registered with the container runtime. Global-only: ignored in project
+    /// config, since it changes the isolation boundary.
     #[serde(default)]
     pub oci_runtime: Option<String>,
 
@@ -1480,8 +1480,8 @@ pub struct ContainerConfig {
     /// Extra security options for the container (docker/podman
     /// `--security-opt`). Each entry is passed verbatim, e.g.
     /// "seccomp=unconfined" or "systempaths=unconfined". Global-only: ignored
-    /// in project config, since these relax the isolation boundary. Empty by
-    /// default. See `cap_add` for the docker-in-docker rationale.
+    /// in project config, since these options control the isolation boundary.
+    /// Empty by default. See `cap_add` for the docker-in-docker rationale.
     #[serde(default)]
     pub security_opt: Option<Vec<String>>,
 }
@@ -2604,9 +2604,10 @@ impl Config {
             // cap_add and security_opt are global-only. devices/group_add
             // expose host hardware and can expand filesystem access via
             // supplementary groups; oci_runtime changes the isolation boundary
-            // (e.g. a VM runtime vs runc); cap_add/security_opt relax the
-            // container's capability/seccomp/apparmor confinement. A malicious
-            // repo must not be able to set them via .workmux.yaml.
+            // (e.g. a VM runtime vs runc); cap_add/security_opt control the
+            // container's capability/seccomp/apparmor confinement, and permissive
+            // values relax it. A malicious repo must not be able to set them via
+            // .workmux.yaml.
             container: {
                 if project.sandbox.container.devices.is_some() {
                     tracing::warn!(
@@ -2989,13 +2990,15 @@ pub const EXAMPLE_PROJECT_CONFIG: &str = r#"# workmux project configuration
 #   #   runtime: docker          # docker | podman | apple-container
 #   #   # memory: 16G            # VM memory limit (apple-container default: 16G)
 #   #   # cpus: 4                # VM CPU count (only passed when set)
-#   #   # OCI runtime to run under (docker/podman --runtime). Unset = runc.
+#   #   # OCI runtime to run under (docker/local Podman --runtime). Unset omits
+#   #   # the flag and uses the engine's configured default.
 #   #   # Set to e.g. "kata" for VM-based isolation (runtime must be installed
 #   #   # and registered). GLOBAL-ONLY: ignored in a project .workmux.yaml.
 #   #   # oci_runtime: kata
-#   #   # Extra capabilities / security options (docker --cap-add /
-#   #   # --security-opt). Empty by default. GLOBAL-ONLY. Main use: enabling
-#   #   # docker-in-docker under oci_runtime: kata (where --privileged fails).
+#   #   # Extra capabilities / security options (docker/podman --cap-add /
+#   #   # --security-opt). Empty by default and GLOBAL-ONLY. Permissive values
+#   #   # weaken host-kernel container isolation unless paired with a VM runtime.
+#   #   # Main use: docker-in-docker under oci_runtime: kata.
 #   #   # cap_add: [ALL]
 #   #   # security_opt: [seccomp=unconfined, apparmor=unconfined, systempaths=unconfined]
 #   #   # Mask files out of the worktree bind mounts (paths relative to the

--- a/src/sandbox/container.rs
+++ b/src/sandbox/container.rs
@@ -366,6 +366,19 @@ fn build_docker_run_args_inner(
         args.push(dev.to_arg());
     }
 
+    // Extra capabilities / security options (global-only). Applied in both
+    // network modes. Primary use: docker-in-docker under `oci_runtime: kata`,
+    // where `--privileged` cannot be used. These relax confinement only inside
+    // the (VM-isolated) guest.
+    for cap in config.container.cap_add() {
+        args.push("--cap-add".to_string());
+        args.push(cap.clone());
+    }
+    for opt in config.container.security_opt() {
+        args.push("--security-opt".to_string());
+        args.push(opt.clone());
+    }
+
     if network_deny {
         // Deny mode: start as root for iptables setup, drop privileges via setpriv.
         // Do NOT use --userns=keep-id (Podman) in deny mode since the container
@@ -1028,6 +1041,39 @@ mod tests {
         assert!(
             find_flag_value(&args, "--runtime").is_empty(),
             "no --runtime should be added when oci_runtime is unset, got: {args:?}"
+        );
+    }
+
+    #[test]
+    fn test_cap_add_and_security_opt_emitted() {
+        let config = sandbox_config(SandboxRuntime::Docker, |c| {
+            c.cap_add = Some(vec!["ALL".to_string()]);
+            c.security_opt = Some(vec![
+                "seccomp=unconfined".to_string(),
+                "systempaths=unconfined".to_string(),
+            ]);
+        });
+        let args = test_build_run_args(&config, false);
+
+        assert_eq!(find_flag_value(&args, "--cap-add"), vec!["ALL"]);
+        assert_eq!(
+            find_flag_value(&args, "--security-opt"),
+            vec!["seccomp=unconfined", "systempaths=unconfined"]
+        );
+    }
+
+    #[test]
+    fn test_cap_add_and_security_opt_absent_by_default() {
+        let config = sandbox_config(SandboxRuntime::Docker, |_| {});
+        let args = test_build_run_args(&config, false);
+
+        assert!(
+            find_flag_value(&args, "--cap-add").is_empty(),
+            "no --cap-add when cap_add is unset, got: {args:?}"
+        );
+        assert!(
+            find_flag_value(&args, "--security-opt").is_empty(),
+            "no --security-opt when security_opt is unset, got: {args:?}"
         );
     }
 

--- a/src/sandbox/container.rs
+++ b/src/sandbox/container.rs
@@ -287,6 +287,24 @@ fn build_docker_run_args_with_state_dir(
     )
 }
 
+fn podman_uses_remote_connection() -> bool {
+    !cfg!(target_os = "linux")
+        || std::env::var_os("CONTAINER_HOST").is_some()
+        || std::env::var_os("CONTAINER_CONNECTION").is_some()
+}
+
+fn validate_oci_runtime_support(runtime: SandboxRuntime, podman_remote: bool) -> Result<()> {
+    if runtime == SandboxRuntime::Podman && podman_remote {
+        anyhow::bail!(
+            "sandbox.container.oci_runtime is not supported by remote Podman; \
+             podman run --runtime is available only with local Podman on Linux. \
+             Use sandbox.container.runtime: docker, connect to local Podman, or \
+             unset sandbox.container.oci_runtime."
+        );
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_docker_run_args_inner(
     command: &str,
@@ -313,14 +331,14 @@ fn build_docker_run_args_inner(
     // Base command (no runtime name -- caller prepends that)
     args.push("run".to_string());
 
-    // Optional VM/sandboxed OCI runtime (docker/podman `--runtime`). Unset =
-    // the engine default (runc on Docker, crun on Podman). Placed right after
-    // `run` so it applies before all other flags; callers still insert `--name`
-    // at index 1. Apple Container manages its own VM and has no `--runtime`
-    // concept, so it's omitted there (matching the documented behavior).
-    if runtime != SandboxRuntime::AppleContainer
-        && let Some(oci_runtime) = config.container.oci_runtime()
+    // Optional VM/sandboxed OCI runtime. Apple Container manages its own VM
+    // and has no `--runtime` concept. Remote Podman does not expose its local
+    // engine's `--runtime` flag, so reject the setting instead of silently
+    // running under a different isolation boundary.
+    if let Some(oci_runtime) = config.container.oci_runtime()
+        && runtime != SandboxRuntime::AppleContainer
     {
+        validate_oci_runtime_support(runtime, podman_uses_remote_connection())?;
         args.push("--runtime".to_string());
         args.push(oci_runtime.to_string());
     }
@@ -372,9 +390,10 @@ fn build_docker_run_args_inner(
 
     // Extra capabilities / security options (global-only). Applied in both
     // network modes. Primary use: docker-in-docker under `oci_runtime: kata`,
-    // where `--privileged` cannot be used. These relax confinement only inside
-    // the (VM-isolated) guest. Apple Container doesn't accept Docker/Podman
-    // `--cap-add`/`--security-opt`, so they're omitted there.
+    // where `--privileged` cannot be used and the guest VM remains the isolation
+    // boundary. Permissive values weaken host-kernel container isolation when
+    // used without a VM-based OCI runtime. Apple Container doesn't accept
+    // Docker/Podman `--cap-add`/`--security-opt`, so they're omitted there.
     if runtime != SandboxRuntime::AppleContainer {
         for cap in config.container.cap_add() {
             args.push("--cap-add".to_string());
@@ -1049,6 +1068,28 @@ mod tests {
             find_flag_value(&args, "--runtime").is_empty(),
             "no --runtime should be added when oci_runtime is unset, got: {args:?}"
         );
+    }
+
+    #[test]
+    fn test_remote_podman_rejects_oci_runtime() {
+        let err = validate_oci_runtime_support(SandboxRuntime::Podman, true)
+            .expect_err("remote Podman must reject oci_runtime");
+        assert!(err.to_string().contains("remote Podman"));
+
+        assert!(validate_oci_runtime_support(SandboxRuntime::Podman, false).is_ok());
+        assert!(validate_oci_runtime_support(SandboxRuntime::Docker, true).is_ok());
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn test_oci_runtime_rejected_for_podman_on_remote_platform() {
+        let config = sandbox_config(SandboxRuntime::Podman, |c| {
+            c.oci_runtime = Some("crun".to_string());
+        });
+        let err = test_build_run_args_result(&config, false)
+            .expect_err("Podman is remote on non-Linux platforms");
+
+        assert!(err.to_string().contains("remote Podman"));
     }
 
     #[test]

--- a/src/sandbox/container.rs
+++ b/src/sandbox/container.rs
@@ -310,6 +310,15 @@ fn build_docker_run_args_inner(
 
     // Base command (no runtime name -- caller prepends that)
     args.push("run".to_string());
+
+    // Optional VM/sandboxed OCI runtime (docker/podman `--runtime`). Unset =
+    // the runtime's default (runc). Placed right after `run` so it applies
+    // before all other flags; callers still insert `--name` at index 1.
+    if let Some(oci_runtime) = config.container.oci_runtime() {
+        args.push("--runtime".to_string());
+        args.push(oci_runtime.to_string());
+    }
+
     args.push("--rm".to_string());
     args.push("-it".to_string());
 
@@ -997,6 +1006,29 @@ mod tests {
         assert!(args.contains(&"sh".to_string()));
         assert!(args.contains(&"-c".to_string()));
         assert!(args.contains(&"claude".to_string()));
+    }
+
+    #[test]
+    fn test_oci_runtime_inserted_after_run() {
+        let config = sandbox_config(SandboxRuntime::Docker, |c| {
+            c.oci_runtime = Some("kata".to_string());
+        });
+        let args = test_build_run_args(&config, false);
+
+        assert_eq!(args[0], "run");
+        assert_eq!(args[1], "--runtime");
+        assert_eq!(args[2], "kata");
+    }
+
+    #[test]
+    fn test_oci_runtime_absent_by_default() {
+        let config = sandbox_config(SandboxRuntime::Docker, |_| {});
+        let args = test_build_run_args(&config, false);
+
+        assert!(
+            find_flag_value(&args, "--runtime").is_empty(),
+            "no --runtime should be added when oci_runtime is unset, got: {args:?}"
+        );
     }
 
     #[test]

--- a/src/sandbox/container.rs
+++ b/src/sandbox/container.rs
@@ -306,23 +306,27 @@ fn build_docker_run_args_inner(
     let uid = unsafe { libc::getuid() };
     let gid = unsafe { libc::getgid() };
 
+    let runtime = config.runtime();
+
     let mut args = Vec::new();
 
     // Base command (no runtime name -- caller prepends that)
     args.push("run".to_string());
 
     // Optional VM/sandboxed OCI runtime (docker/podman `--runtime`). Unset =
-    // the runtime's default (runc). Placed right after `run` so it applies
-    // before all other flags; callers still insert `--name` at index 1.
-    if let Some(oci_runtime) = config.container.oci_runtime() {
+    // the engine default (runc on Docker, crun on Podman). Placed right after
+    // `run` so it applies before all other flags; callers still insert `--name`
+    // at index 1. Apple Container manages its own VM and has no `--runtime`
+    // concept, so it's omitted there (matching the documented behavior).
+    if runtime != SandboxRuntime::AppleContainer
+        && let Some(oci_runtime) = config.container.oci_runtime()
+    {
         args.push("--runtime".to_string());
         args.push(oci_runtime.to_string());
     }
 
     args.push("--rm".to_string());
     args.push("-it".to_string());
-
-    let runtime = config.runtime();
 
     // Resource limits: user config overrides runtime default.
     // Apple Container VMs default to 1 GB RAM which is too low for most workloads.
@@ -369,14 +373,17 @@ fn build_docker_run_args_inner(
     // Extra capabilities / security options (global-only). Applied in both
     // network modes. Primary use: docker-in-docker under `oci_runtime: kata`,
     // where `--privileged` cannot be used. These relax confinement only inside
-    // the (VM-isolated) guest.
-    for cap in config.container.cap_add() {
-        args.push("--cap-add".to_string());
-        args.push(cap.clone());
-    }
-    for opt in config.container.security_opt() {
-        args.push("--security-opt".to_string());
-        args.push(opt.clone());
+    // the (VM-isolated) guest. Apple Container doesn't accept Docker/Podman
+    // `--cap-add`/`--security-opt`, so they're omitted there.
+    if runtime != SandboxRuntime::AppleContainer {
+        for cap in config.container.cap_add() {
+            args.push("--cap-add".to_string());
+            args.push(cap.clone());
+        }
+        for opt in config.container.security_opt() {
+            args.push("--security-opt".to_string());
+            args.push(opt.clone());
+        }
     }
 
     if network_deny {
@@ -1074,6 +1081,42 @@ mod tests {
         assert!(
             find_flag_value(&args, "--security-opt").is_empty(),
             "no --security-opt when security_opt is unset, got: {args:?}"
+        );
+    }
+
+    #[test]
+    fn test_oci_runtime_omitted_on_apple_container() {
+        // Apple Container has no `--runtime` concept and would misread the
+        // value (e.g. treat `kata` as an Apple-native plugin), so a globally
+        // configured oci_runtime must be dropped rather than passed through.
+        let config = sandbox_config(SandboxRuntime::AppleContainer, |c| {
+            c.oci_runtime = Some("kata".to_string());
+        });
+        let args = test_build_run_args(&config, false);
+
+        assert!(
+            find_flag_value(&args, "--runtime").is_empty(),
+            "--runtime must be omitted on Apple Container, got: {args:?}"
+        );
+    }
+
+    #[test]
+    fn test_cap_add_and_security_opt_omitted_on_apple_container() {
+        // Apple Container does not accept Docker/Podman `--cap-add` /
+        // `--security-opt`; they must be dropped rather than passed through.
+        let config = sandbox_config(SandboxRuntime::AppleContainer, |c| {
+            c.cap_add = Some(vec!["ALL".to_string()]);
+            c.security_opt = Some(vec!["seccomp=unconfined".to_string()]);
+        });
+        let args = test_build_run_args(&config, false);
+
+        assert!(
+            find_flag_value(&args, "--cap-add").is_empty(),
+            "--cap-add must be omitted on Apple Container, got: {args:?}"
+        );
+        assert!(
+            find_flag_value(&args, "--security-opt").is_empty(),
+            "--security-opt must be omitted on Apple Container, got: {args:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Adds an optional `sandbox.container.oci_runtime` field that is passed straight
through to `docker`/`podman` as `--runtime <x>`. This lets the existing,
well-tested container backend run under an alternative OCI runtime — most
usefully a VM-based one such as [Kata Containers](https://katacontainers.io/) —
to get a hardware-VM isolation boundary around each sandbox.

- **Default unchanged.** Unset = the runtime's default (`runc`); no behavioral
  change for existing users.
- **Reuses the whole container path.** A real OCI runtime handles user mapping,
  bind mounts, local images, networking and TTY itself, so the sandbox image,
  mounts, `--user`, and guest→host RPC all work exactly as they do today — just
  inside a VM. No new `SandboxBackend` variant, no supervisor/multiplexer
  changes.
- **Global-only.** Like `devices`/`group_add`, `oci_runtime` changes the
  isolation boundary, so it is ignored in a project `.workmux.yaml` (with a
  warning) and must be set in the global config. This prevents an untrusted repo
  from selecting or downgrading the runtime.

The change is small because there's currently no `extra_args` escape hatch on
`docker run` — users can't do this themselves — which is exactly what justifies
a narrow, vendor-neutral `oci_runtime` passthrough rather than a bespoke VM
backend.

## Implementation

- `src/config.rs` — `oci_runtime: Option<String>` on `ContainerConfig`,
  accessor, global-only merge + project-override warning, config-template entry.
- `src/sandbox/container.rs` — insert `--runtime <x>` right after the `run`
  subcommand in `build_docker_run_args_inner`; both agent panes and
  `workmux sandbox shell` route through it.
- `docs/guide/sandbox/container.md` — config-table row + a short "Run under a
  VM-based OCI runtime" section.

## Testing

Unit tests: `--runtime` is emitted after `run` when set and absent when unset;
merge keeps the global value and drops the project value. Validated live under
**Kata** on Linux: a real agent booted in the VM, authenticated, and ran a
prompt; the worktree bind mount and file ownership were correct (guest uid →
host user, not root); the guest→host RPC callback over `host.docker.internal`
worked; and a **local** (never-pushed) image booted directly with no bridging.

## Example
Here is how I have this configured in my own environment (with loose sandboxing on the github token and dev projects, I know!)
```yaml
sandbox:
  enabled: true
  backend: container
  image: workmux-dev        # built from ./Dockerfile.sandbox
  container:
    # Run each sandbox under the Kata Containers VM runtime for hardware-VM
    # isolation. Requires the `kata` runtime registered with Docker (see
    # hosts/tiphys/default.nix). Global-only setting.
    oci_runtime: kata
    # Docker-in-Docker: let agents build/run containers via a dockerd running
    # INSIDE the kata guest (nested containers stay VM-isolated from the host).
    # We grant capabilities à la carte rather than --privileged, which does NOT
    # work under kata (it injects host device nodes that collide with the
    # guest's, failing to boot: "Creating container device /dev/full EEXIST").
    # These relax confinement only inside the VM. All global-only.
    #   cap_add        : dockerd needs broad caps (mount/cgroup/net); ALL is
    #                    bounded by the VM anyway.
    #   security_opt   : unconfined seccomp/apparmor for the daemon; systempaths
    #                    makes /proc/sys writable (dockerd sets ip_forward).
    #   group_add      : re-adds the docker group at runtime (workmux's
    #                    --user 1000:100 drops the image's supplementary groups),
    #                    so the agent can reach /var/run/docker.sock.
    cap_add: [ALL]
    security_opt:
      - seccomp=unconfined
      - apparmor=unconfined
      - systempaths=unconfined
    group_add: [docker]
  extra_mounts:
    - host_path: ~/dev
      writable: true
    # GitHub access so agents can open PRs with `gh`.    - host_path: ~/.config/gh
      guest_path: /tmp/.config/gh
      writable: false
```

## Note for reviewers testing under Docker ≥ 29.5 + Kata

Docker 29.5+ gives each container a private `time` namespace by default
([moby#52326]). Kata's guest agent rejects namespace types it doesn't support
and aborts container creation with `invalid namespace type`
([kata-containers#13080]) — the VM boots fine, it's the in-guest agent
rejecting the OCI spec. Disable it with the daemon feature flag
(`"features": { "time-namespaces": false }`, or `dockerd --feature
time-namespaces=false`, [moby#52577]). This is a host/runtime interaction, not
a workmux concern, so it's intentionally kept out of the user docs — flagging it
here only so a maintainer reproducing on Docker 29 + Kata isn't surprised.

[moby#52326]: https://github.com/moby/moby/pull/52326
[moby#52577]: https://github.com/moby/moby/pull/52577
[kata-containers#13080]: https://github.com/kata-containers/kata-containers/issues/13080

(related issue #196)
