### PR TITLE
Avoid sidebar cleanup error when closing the last non-sidebar pane

### DIFF
--- a/src/command/sidebar/runtime.rs
+++ b/src/command/sidebar/runtime.rs
@@ -225,11 +225,15 @@ fn schedule_current_pane_kill() {
         return;
     }
 
-    let cmd = format!(
-        "sleep 0.05; tmux kill-pane -t {} 2>/dev/null",
-        shell_quote(&pane)
-    );
+    let cmd = current_pane_kill_command(&pane);
     let _ = Cmd::new("tmux").args(&["run-shell", "-b", &cmd]).run();
+}
+
+fn current_pane_kill_command(pane: &str) -> String {
+    format!(
+        "sleep 0.05; tmux kill-pane -t {} 2>/dev/null || true",
+        shell_quote(pane)
+    )
 }
 
 fn process_event(
@@ -355,5 +359,13 @@ mod tests {
 
         assert!(app.should_quit);
         assert_eq!(app.quit_reason.as_deref(), Some("confirmed user exit"));
+    }
+
+    #[test]
+    fn delayed_pane_cleanup_is_idempotent() {
+        assert_eq!(
+            current_pane_kill_command("%79"),
+            "sleep 0.05; tmux kill-pane -t '%79' 2>/dev/null || true"
+        );
     }
 }


### PR DESCRIPTION
When a sidebar becomes the only pane left in its window, it schedules a delayed
`kill-pane` for itself and exits.

To reproduce:

1. Start a tmux session with at least two windows.
2. Enable the workmux sidebar.
3. Close the last non-sidebar pane in one of the windows.

With tmux's `remain-on-exit` option off, tmux may remove the sidebar pane before
the delayed command runs. `kill-pane` then exits with status 1 and attached tmux
clients may briefly show:

    'sleep 0.05; tmux kill-pane -t "<pane-id>" 2>/dev/null' returned 1

This makes the delayed cleanup best-effort by adding `|| true`. If the pane is
already gone, the intended result has already been reached.

I added a regression test for the generated cleanup command. I also reproduced
the notification with the original binary in a clean Ubuntu 24.04 container
using tmux 3.4 and an empty tmux configuration, and verified it is absent with
this change.
