### PR TITLE
Add Grok (SpaceXAI) as supported agent

### DIFF
--- a/.grok/hooks/workmux-status.json
+++ b/.grok/hooks/workmux-status.json
@@ -1,0 +1,54 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status working"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status waiting"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status working"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status done"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status done"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ editUrl: https://github.com/raine/workmux/edit/main/CHANGELOG.md
 <!-- skipped: v0.1.25 -->
 <!-- skipped: v0.1.8 -->
 
+## Unreleased
+
+- Add Grok (SpaceXAI) as a supported agent for status tracking, interactive
+  prompt injection, and skills. `workmux setup` installs status hooks and
+  bundled skills under `~/.grok/` or `$GROK_HOME`.
+
 ## v0.1.242 (2026-08-20)
 
 - `workmux setup` installs the Copilot CLI status hook once at the user level

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Each pane supports:
   flag)
 
 Built-in agents (`claude`, `gemini`, `agy`, `codex`, `opencode`, `kiro-cli`, `vibe`,
-`pi`, `omp`) are auto-detected when used as literal commands and receive prompt
+`pi`, `omp`, `grok`) are auto-detected when used as literal commands and receive prompt
 injection automatically, without needing the `<agent>` placeholder or a matching
 `agent` config:
 
@@ -769,7 +769,7 @@ done
 When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`,
 workmux automatically injects the prompt into panes running the configured agent
 command (e.g., `claude`, `codex`, `opencode`, `gemini`, `agy`, `kiro-cli`, `vibe`,
-`pi`, `omp`, or whatever you've set via the `agent` config or `--agent` flag) without
+`pi`, `omp`, `grok`, or whatever you've set via the `agent` config or `--agent` flag) without
 requiring any `.workmux.yaml` changes:
 
 - Panes with a command matching the configured agent are automatically started
@@ -1999,6 +1999,7 @@ at-a-glance visibility into what the agent in each window doing.
 | Pi           | ✅ Supported\*                                                              |
 | Oh My Pi    | ✅ Supported                                                                |
 | Gemini CLI   | ✅ Supported                                                                |
+| Grok         | ✅ Supported                                                                |
 | Antigravity CLI (`agy`) | ✅ Supported\*                                                   |
 | Kiro         | [Tracking issue](https://github.com/kirodotdev/Kiro/issues/5440)            |
 | Mistral Vibe | [Tracking issue](https://github.com/mistralai/mistral-vibe/discussions/334) |
@@ -2014,7 +2015,7 @@ at-a-glance visibility into what the agent in each window doing.
 ### Setup
 
 Run `workmux setup` to automatically detect Claude Code, Antigravity CLI,
-Copilot CLI, OpenCode, Pi, Oh My Pi, and other supported agent CLIs, install
+Copilot CLI, OpenCode, Pi, Oh My Pi, Grok, and other supported agent CLIs, install
 status tracking hooks, and install skills:
 
 ```bash

--- a/docs/src/content/docs/guide/agents.md
+++ b/docs/src/content/docs/guide/agents.md
@@ -7,7 +7,7 @@ workmux is designed with AI agent workflows in mind. Run multiple agents in para
 
 ## Agent integration
 
-When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`, workmux automatically injects the prompt into panes running the configured agent command (e.g., `claude`, `codex`, `opencode`, `gemini`, `agy`, `kiro-cli`, `vibe`, `pi`, `omp`, or whatever you've set via the `agent` config or `--agent` flag) without requiring any `.workmux.yaml` changes:
+When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`, workmux automatically injects the prompt into panes running the configured agent command (e.g., `claude`, `codex`, `opencode`, `gemini`, `agy`, `kiro-cli`, `vibe`, `pi`, `omp`, `grok`, or whatever you've set via the `agent` config or `--agent` flag) without requiring any `.workmux.yaml` changes:
 
 - Panes with a command matching the configured agent are automatically started with the given prompt.
 - You can keep your `.workmux.yaml` pane configuration simple (e.g., `panes: [{ command: "<agent>" }]`) and let workmux handle prompt injection at runtime.
@@ -133,7 +133,7 @@ Named agents are global-only for security. Define them in `~/.config/workmux/con
 
 ## Per-pane agents
 
-workmux automatically recognizes built-in agent commands (`claude`, `gemini`, `agy`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`, `omp`) in pane commands. This means prompt injection works without the `<agent>` placeholder or a matching `agent` config:
+workmux automatically recognizes built-in agent commands (`claude`, `gemini`, `agy`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`, `omp`, `grok`) in pane commands. This means prompt injection works without the `<agent>` placeholder or a matching `agent` config:
 
 ```yaml
 panes:

--- a/docs/src/content/docs/guide/configuration.md
+++ b/docs/src/content/docs/guide/configuration.md
@@ -194,7 +194,7 @@ Each pane supports:
 
 Named agent profiles can provide structured `command`, `args`, `env`, and `type` fields, including `env` values loaded with `from_env`. See [named agents](/guide/agents/#named-agents) for the full profile schema.
 
-Built-in agents (`claude`, `gemini`, `agy`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`, `omp`) are auto-detected when used as literal commands and receive prompt injection automatically, without needing the `<agent>` placeholder or a matching `agent` config:
+Built-in agents (`claude`, `gemini`, `agy`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`, `omp`, `grok`) are auto-detected when used as literal commands and receive prompt injection automatically, without needing the `<agent>` placeholder or a matching `agent` config:
 
 ```yaml
 panes:

--- a/docs/src/content/docs/guide/sidebar/customization.md
+++ b/docs/src/content/docs/guide/sidebar/customization.md
@@ -179,11 +179,12 @@ Default icons:
 - `kiro-cli` → `K`
 - `vibe` → `V`
 - `copilot` → `CP`
+- `grok` → `GK`
 
 Unknown agents render an empty icon.
 
 Default colors are brand accents: Claude orange, Codex teal, Gemini blue,
-Copilot purple, Vibe orange, Pi sage, OMP red/orange, OpenCode blue. Stale rows still dim
+Copilot purple, Grok blue, Vibe orange, Pi sage, OMP red/orange, OpenCode blue. Stale rows still dim
 and selected rows still take the highlight background; the icon color sits
 on top of those.
 

--- a/docs/src/content/docs/guide/status-tracking.mdx
+++ b/docs/src/content/docs/guide/status-tracking.mdx
@@ -31,6 +31,7 @@ doing.
 | Pi                      | ✅ Supported\*                                                              |
 | Oh My Pi                | ✅ Supported                                                                |
 | Gemini CLI              | ✅ Supported                                                                |
+| Grok                    | ✅ Supported                                                                |
 | Antigravity CLI (`agy`) | ✅ Supported\*                                                              |
 | Kiro                    | [Tracking issue](https://github.com/kirodotdev/Kiro/issues/5440)            |
 | Mistral Vibe            | [Tracking issue](https://github.com/mistralai/mistral-vibe/discussions/334) |
@@ -56,7 +57,7 @@ Run `workmux setup` to automatically detect your agent CLIs and install status t
 workmux setup
 ```
 
-This detects Claude Code, Antigravity CLI, Copilot CLI, OpenCode, Pi, and Oh My Pi by checking for their executable or configuration directories, then offers to install the appropriate hooks. For Claude Code, `CLAUDE_CONFIG_DIR` is respected when locating `settings.json`. Workmux will also prompt you on first run if it detects an agent without status tracking configured.
+This detects Claude Code, Antigravity CLI, Copilot CLI, OpenCode, Pi, Oh My Pi, and Grok by checking for their executable or configuration directories, then offers to install the appropriate hooks. For Claude Code, `CLAUDE_CONFIG_DIR` is respected when locating `settings.json`. Workmux will also prompt you on first run if it detects an agent without status tracking configured.
 
 Workmux automatically modifies your tmux `window-status-format` to display the status icons. This happens once per session and only affects the current tmux session (not your global config).
 
@@ -147,6 +148,21 @@ mkdir -p ~/.gemini
 curl -o ~/.gemini/settings.json \
   https://raw.githubusercontent.com/raine/workmux/main/resources/gemini/settings.json
 ```
+
+## Grok setup
+
+`workmux setup` installs Grok lifecycle hooks under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset. Start a new Grok session after setup so it discovers the hook.
+
+For manual setup, download the hooks configuration:
+
+```bash
+grok_home="${GROK_HOME:-$HOME/.grok}"
+mkdir -p "$grok_home/hooks"
+curl -o "$grok_home/hooks/workmux-status.json" \
+  https://raw.githubusercontent.com/raine/workmux/main/.grok/hooks/workmux-status.json
+```
+
+`UserPromptSubmit` and `PostToolUse` mark the pane working, `Notification` marks it waiting, and `Stop` or `SessionEnd` marks it done. Grok permission prompts do not all emit `Notification`, so some prompts may remain marked as working while waiting for input.
 
 ## Antigravity CLI (`agy`) setup
 

--- a/docs/src/content/docs/reference/commands/add.mdx
+++ b/docs/src/content/docs/reference/commands/add.mdx
@@ -209,7 +209,7 @@ workmux add feature/ai-session --mode session -p "Implement the new API"
 
 ## AI agent integration
 
-When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`, workmux automatically injects the prompt into panes running the configured agent command (e.g., `claude`, `codex`, `opencode`, `gemini`, `agy`, `kiro-cli`, `vibe`, `pi`, `omp`, or whatever you've set via the `agent` config or `--agent` flag) without requiring any `.workmux.yaml` changes:
+When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`, workmux automatically injects the prompt into panes running the configured agent command (e.g., `claude`, `codex`, `opencode`, `gemini`, `agy`, `kiro-cli`, `vibe`, `pi`, `omp`, `grok`, or whatever you've set via the `agent` config or `--agent` flag) without requiring any `.workmux.yaml` changes:
 
 - Panes with a command matching the configured agent are automatically started with the given prompt.
 - You can keep your `.workmux.yaml` pane configuration simple (e.g., `panes: [{ command: "<agent>" }]`) and let workmux handle prompt injection at runtime.

--- a/src/agent_identity.rs
+++ b/src/agent_identity.rs
@@ -32,6 +32,7 @@ pub enum AgentKind {
     KiroCli,
     Vibe,
     Copilot,
+    Grok,
 }
 
 impl AgentKind {
@@ -49,6 +50,7 @@ impl AgentKind {
             AgentKind::KiroCli => "kiro-cli",
             AgentKind::Vibe => "vibe",
             AgentKind::Copilot => "copilot",
+            AgentKind::Grok => "grok",
         }
     }
 
@@ -65,6 +67,7 @@ impl AgentKind {
             "kiro-cli" => Some(AgentKind::KiroCli),
             "vibe" => Some(AgentKind::Vibe),
             "copilot" => Some(AgentKind::Copilot),
+            "grok" => Some(AgentKind::Grok),
             _ => None,
         }
     }
@@ -83,6 +86,7 @@ impl AgentKind {
             AgentKind::KiroCli => "K",
             AgentKind::Vibe => "V",
             AgentKind::Copilot => "CP",
+            AgentKind::Grok => "GK",
         }
     }
 
@@ -100,6 +104,7 @@ impl AgentKind {
             AgentKind::KiroCli => "Kiro",
             AgentKind::Vibe => "Vibe",
             AgentKind::Copilot => "Copilot",
+            AgentKind::Grok => "Grok",
         }
     }
 
@@ -121,6 +126,7 @@ impl AgentKind {
             AgentKind::Omp => Color::Rgb(0xe0, 0x57, 0x35),
             AgentKind::OpenCode => Color::Blue,
             AgentKind::KiroCli => return None,
+            AgentKind::Grok => Color::Rgb(0x1d, 0x9b, 0xf0),
         })
     }
 }
@@ -264,6 +270,15 @@ mod tests {
     }
 
     #[test]
+    fn grok_command_matches() {
+        assert_eq!(classify("grok", ""), Some("grok".into()));
+        assert_eq!(classify("/usr/local/bin/grok", ""), Some("grok".into()));
+        assert_eq!(classify("grok", "anything"), Some("grok".into()));
+        assert_eq!(classify("grok-build", ""), None);
+        assert_eq!(classify("grokster", ""), None);
+    }
+
+    #[test]
     fn direct_stem_matches_for_known_binaries() {
         assert_eq!(classify("claude", ""), Some("claude".into()));
         assert_eq!(classify("gemini", ""), Some("gemini".into()));
@@ -271,6 +286,7 @@ mod tests {
         assert_eq!(classify("pi", ""), Some("pi".into()));
         assert_eq!(classify("omp", ""), Some("omp".into()));
         assert_eq!(classify("vibe", ""), Some("vibe".into()));
+        assert_eq!(classify("grok", ""), Some("grok".into()));
     }
 
     #[test]
@@ -384,6 +400,7 @@ mod tests {
             AgentKind::KiroCli,
             AgentKind::Vibe,
             AgentKind::Copilot,
+            AgentKind::Grok,
         ];
         for kind in all {
             assert!(!kind.default_icon().is_empty(), "{:?} icon empty", kind);

--- a/src/agent_setup/grok.rs
+++ b/src/agent_setup/grok.rs
@@ -1,0 +1,294 @@
+//! Grok (SpaceXAI) status tracking setup.
+//!
+//! Detects Grok via the `~/.grok/` directory (or `$GROK_HOME`).
+//! Installs hooks by merging into `~/.grok/hooks/workmux-status.json`.
+//! Grok's hook runner discovers JSON files in `~/.grok/hooks/` automatically,
+//! so no feature flag or config.toml change is required.
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::StatusCheck;
+use crate::agent_setup::json_config::{
+    self, EmptyJsonRoot, JsonHookInstallSpec, JsonHookUninstallSpec,
+};
+
+const HOOKS_JSON: &str = include_str!("../../.grok/hooks/workmux-status.json");
+
+fn grok_dir() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("GROK_HOME")
+        && !dir.is_empty()
+    {
+        return Some(PathBuf::from(dir));
+    }
+    home::home_dir().map(|h| h.join(".grok"))
+}
+
+fn hooks_dir() -> Option<PathBuf> {
+    grok_dir().map(|d| d.join("hooks"))
+}
+
+fn hooks_path() -> Option<PathBuf> {
+    hooks_dir().map(|d| d.join("workmux-status.json"))
+}
+
+pub fn detect() -> Option<&'static str> {
+    if grok_dir().is_some_and(|d| d.is_dir()) {
+        return Some("found ~/.grok/");
+    }
+    None
+}
+
+pub fn check() -> Result<StatusCheck> {
+    let Some(path) = hooks_path() else {
+        return Ok(StatusCheck::NotInstalled);
+    };
+    check_at(&path)
+}
+
+fn check_at(path: &Path) -> Result<StatusCheck> {
+    if !path.exists() {
+        return Ok(StatusCheck::NotInstalled);
+    }
+
+    let content = fs::read_to_string(path).context("Failed to read grok hooks file")?;
+    let config: Value =
+        serde_json::from_str(&content).context("grok hooks file is not valid JSON")?;
+
+    let required = [
+        ("UserPromptSubmit", "working"),
+        ("Notification", "waiting"),
+        ("PostToolUse", "working"),
+        ("Stop", "done"),
+        ("SessionEnd", "done"),
+    ];
+
+    if required
+        .iter()
+        .all(|(event, status)| has_status_hook(&config, event, status))
+    {
+        Ok(StatusCheck::Installed)
+    } else {
+        Ok(StatusCheck::NotInstalled)
+    }
+}
+
+fn has_status_hook(config: &Value, event: &str, status: &str) -> bool {
+    let expected = format!("workmux set-window-status {status}");
+    config["hooks"][event]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|group| group.get("hooks").and_then(Value::as_array))
+        .flatten()
+        .filter_map(|hook| hook.get("command").and_then(Value::as_str))
+        .any(|command| command.contains(&expected))
+}
+
+pub fn uninstall() -> Result<String> {
+    let Some(path) = hooks_path() else {
+        return Ok("Grok dir not found, nothing to uninstall".to_string());
+    };
+    uninstall_at(path)
+}
+
+fn uninstall_at(path: PathBuf) -> Result<String> {
+    let result = json_config::json_hook_uninstall(
+        &path,
+        &JsonHookUninstallSpec {
+            messages: json_config::JsonHookUninstallMessages {
+                file_missing: "No Grok workmux-status.json found",
+                not_found: "No workmux hooks found in Grok hooks file",
+                soft_read_error: None,
+                soft_parse_error: None,
+            },
+            delete_if_no_hooks_remain: true,
+            remove_plugins: false,
+            soft_errors: false,
+        },
+    )?;
+    Ok(result)
+}
+
+fn load_hooks() -> Result<Value> {
+    json_config::hooks_from_embedded(HOOKS_JSON, "hooks config missing hooks key")
+}
+
+fn install_hooks_at(path: &Path) -> Result<()> {
+    json_config::json_hook_install(
+        path,
+        &load_hooks()?,
+        &JsonHookInstallSpec {
+            read_context: "Failed to read grok hooks file",
+            parse_context: "grok hooks file is not valid JSON",
+            write_context: "Failed to write grok hooks file",
+            mkdir_context: "Failed to create ~/.grok/hooks/ directory",
+            empty_root: EmptyJsonRoot::HooksObject,
+        },
+    )
+}
+
+pub fn install() -> Result<String> {
+    let path = hooks_path().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+
+    install_hooks_at(&path)?;
+
+    Ok("Installed hooks to ~/.grok/hooks/workmux-status.json".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hooks_json_is_valid() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(HOOKS_JSON).expect("embedded hooks config is valid JSON");
+        let hooks = parsed.get("hooks").unwrap().as_object().unwrap();
+        assert!(hooks.contains_key("UserPromptSubmit"));
+        assert!(hooks.contains_key("Notification"));
+        assert!(hooks.contains_key("PostToolUse"));
+        assert!(hooks.contains_key("Stop"));
+        assert!(hooks.contains_key("SessionEnd"));
+    }
+
+    #[test]
+    fn test_hooks_json_contains_workmux_commands() {
+        assert!(HOOKS_JSON.contains("workmux set-window-status working"));
+        assert!(HOOKS_JSON.contains("workmux set-window-status waiting"));
+        assert!(HOOKS_JSON.contains("workmux set-window-status done"));
+    }
+
+    #[test]
+    fn test_load_hooks() {
+        let hooks = load_hooks().unwrap();
+        let obj = hooks.as_object().unwrap();
+        assert!(obj.contains_key("UserPromptSubmit"));
+        assert!(obj.contains_key("Notification"));
+        assert!(obj.contains_key("PostToolUse"));
+        assert!(obj.contains_key("Stop"));
+        assert!(obj.contains_key("SessionEnd"));
+    }
+
+    #[test]
+    fn test_check_requires_complete_hooks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("workmux-status.json");
+        let mut config: Value = serde_json::from_str(HOOKS_JSON).unwrap();
+        config["hooks"]
+            .as_object_mut()
+            .unwrap()
+            .remove("Notification");
+        fs::write(&path, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+
+        assert!(matches!(
+            check_at(&path).unwrap(),
+            StatusCheck::NotInstalled
+        ));
+
+        install_hooks_at(&path).unwrap();
+
+        assert!(matches!(check_at(&path).unwrap(), StatusCheck::Installed));
+    }
+
+    #[test]
+    fn test_install_upgrades_legacy_hooks_idempotently() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("workmux-status.json");
+        let mut config: Value = serde_json::from_str(HOOKS_JSON).unwrap();
+        config["hooks"]
+            .as_object_mut()
+            .unwrap()
+            .remove("Notification");
+        config["hooks"]["Stop"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({
+                "hooks": [{
+                    "type": "command",
+                    "command": "python3 my-hook.py"
+                }]
+            }));
+        fs::write(&path, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+
+        install_hooks_at(&path).unwrap();
+        install_hooks_at(&path).unwrap();
+
+        let installed: Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(has_status_hook(&installed, "Notification", "waiting"));
+        let notification_groups = installed["hooks"]["Notification"].as_array().unwrap();
+        assert_eq!(notification_groups.len(), 1);
+        assert!(
+            installed["hooks"]["Stop"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .flat_map(|group| group["hooks"].as_array().unwrap())
+                .any(|hook| hook["command"] == "python3 my-hook.py")
+        );
+    }
+
+    #[test]
+    fn test_uninstall_no_hooks_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hooks_path = tmp.path().join("workmux-status.json");
+        let result = uninstall_at(hooks_path).unwrap();
+        assert!(result.contains("No Grok workmux-status.json found"));
+    }
+
+    #[test]
+    fn test_uninstall_removes_hooks_keeps_others() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hooks_path = tmp.path().join("workmux-status.json");
+        std::fs::write(
+            &hooks_path,
+            r#"{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"workmux set-window-status done"}]},{"hooks":[{"type":"command","command":"python3 my-hook.py"}]}]}}"#,
+        )
+        .unwrap();
+        let result = uninstall_at(hooks_path.clone()).unwrap();
+        assert!(result.contains("Removed workmux hooks"));
+        assert!(hooks_path.exists());
+        let content = std::fs::read_to_string(&hooks_path).unwrap();
+        let config: Value = serde_json::from_str(&content).unwrap();
+        let stop = config["hooks"]["Stop"].as_array().unwrap();
+        assert_eq!(stop.len(), 1);
+        assert!(
+            stop[0]["hooks"][0]["command"]
+                .as_str()
+                .unwrap()
+                .contains("my-hook")
+        );
+    }
+
+    #[test]
+    fn test_uninstall_deletes_file_when_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hooks_path = tmp.path().join("workmux-status.json");
+        std::fs::write(
+            &hooks_path,
+            r#"{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"workmux set-window-status done"}]}]}}"#,
+        )
+        .unwrap();
+        let result = uninstall_at(hooks_path.clone()).unwrap();
+        assert!(result.contains("no hooks remain"));
+        assert!(!hooks_path.exists());
+    }
+
+    #[test]
+    fn test_uninstall_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hooks_path = tmp.path().join("workmux-status.json");
+        std::fs::write(
+            &hooks_path,
+            r#"{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"workmux set-window-status done"}]}]}}"#,
+        )
+        .unwrap();
+        let result1 = uninstall_at(hooks_path.clone()).unwrap();
+        assert!(result1.contains("no hooks remain"));
+        assert!(!hooks_path.exists());
+        let result2 = uninstall_at(hooks_path).unwrap();
+        assert!(result2.contains("No Grok"), "result2: {result2}");
+    }
+}

--- a/src/agent_setup/mod.rs
+++ b/src/agent_setup/mod.rs
@@ -10,6 +10,7 @@ pub mod codex;
 pub mod copilot;
 pub mod extension_file;
 pub mod gemini;
+pub mod grok;
 pub mod hooks;
 pub mod json_config;
 pub mod omp;
@@ -36,6 +37,7 @@ pub enum Agent {
     Codex,
     Copilot,
     Gemini,
+    Grok,
     OpenCode,
     Pi,
     #[serde(rename = "omp")]
@@ -50,6 +52,7 @@ impl Agent {
             Agent::Codex => "Codex",
             Agent::Copilot => "Copilot CLI",
             Agent::Gemini => "Gemini CLI",
+            Agent::Grok => "Grok",
             Agent::OpenCode => "OpenCode",
             Agent::Pi => "pi",
             Agent::Omp => "Oh My Pi",
@@ -65,6 +68,7 @@ impl Agent {
             Agent::Codex,
             Agent::Copilot,
             Agent::Gemini,
+            Agent::Grok,
             Agent::OpenCode,
             Agent::Pi,
             Agent::Omp,
@@ -157,6 +161,18 @@ pub fn check_all() -> Vec<AgentCheck> {
         });
     }
 
+    if let Some(reason) = grok::detect() {
+        let status = match grok::check() {
+            Ok(s) => s,
+            Err(e) => StatusCheck::Error(e.to_string()),
+        };
+        results.push(AgentCheck {
+            agent: Agent::Grok,
+            reason,
+            status,
+        });
+    }
+
     if let Some(reason) = pi::detect() {
         let status = match pi::check() {
             Ok(s) => s,
@@ -204,6 +220,7 @@ pub fn install(agent: Agent) -> Result<String> {
         Agent::Codex => codex::install(),
         Agent::Copilot => copilot::install(),
         Agent::Gemini => gemini::install(),
+        Agent::Grok => grok::install(),
         Agent::OpenCode => opencode::install(),
         Agent::Pi => pi::install(),
         Agent::Omp => omp::install(),
@@ -218,6 +235,7 @@ pub fn uninstall_one(agent: Agent) -> Result<String> {
         Agent::Codex => codex::uninstall(),
         Agent::Copilot => copilot::uninstall(),
         Agent::Gemini => gemini::uninstall(),
+        Agent::Grok => grok::uninstall(),
         Agent::OpenCode => opencode::uninstall(),
         Agent::Pi => pi::uninstall(),
         Agent::Omp => omp::uninstall(),
@@ -431,6 +449,7 @@ mod tests {
         assert_eq!(Agent::Codex.name(), "Codex");
         assert_eq!(Agent::Copilot.name(), "Copilot CLI");
         assert_eq!(Agent::Gemini.name(), "Gemini CLI");
+        assert_eq!(Agent::Grok.name(), "Grok");
         assert_eq!(Agent::OpenCode.name(), "OpenCode");
         assert_eq!(Agent::Pi.name(), "pi");
         assert_eq!(Agent::Omp.name(), "Oh My Pi");
@@ -449,6 +468,7 @@ mod tests {
             "\"copilot\""
         );
         assert_eq!(serde_json::to_string(&Agent::Gemini).unwrap(), "\"gemini\"");
+        assert_eq!(serde_json::to_string(&Agent::Grok).unwrap(), "\"grok\"");
         assert_eq!(
             serde_json::to_string(&Agent::OpenCode).unwrap(),
             "\"opencode\""
@@ -469,6 +489,8 @@ mod tests {
         assert_eq!(agent, Agent::Copilot);
         let agent: Agent = serde_json::from_str("\"gemini\"").unwrap();
         assert_eq!(agent, Agent::Gemini);
+        let agent: Agent = serde_json::from_str("\"grok\"").unwrap();
+        assert_eq!(agent, Agent::Grok);
         let agent: Agent = serde_json::from_str("\"opencode\"").unwrap();
         assert_eq!(agent, Agent::OpenCode);
         let agent: Agent = serde_json::from_str("\"pi\"").unwrap();

--- a/src/multiplexer/agent.rs
+++ b/src/multiplexer/agent.rs
@@ -246,6 +246,30 @@ impl AgentProfile for VibeProfile {
     }
 }
 
+pub struct GrokProfile;
+
+impl AgentProfile for GrokProfile {
+    fn name(&self) -> &'static str {
+        "grok"
+    }
+
+    fn needs_auto_status(&self) -> bool {
+        true
+    }
+
+    fn skip_permissions_flag(&self) -> Option<&'static str> {
+        Some("--yolo")
+    }
+
+    fn prompt_argument(&self, prompt_path: &str) -> String {
+        format!("--prompt-file {}", prompt_path)
+    }
+
+    fn continue_flag(&self) -> Option<&'static str> {
+        Some("--continue")
+    }
+}
+
 pub struct PiProfile;
 
 impl AgentProfile for PiProfile {
@@ -314,6 +338,7 @@ static PROFILES: &[&dyn AgentProfile] = &[
     &OmpProfile,
     &KiroProfile,
     &VibeProfile,
+    &GrokProfile,
 ];
 
 /// Check if a command matches a known agent profile.
@@ -731,6 +756,21 @@ mod tests {
             profile.skip_permissions_flag(),
             Some("--agent auto-approve")
         );
+        assert_eq!(profile.auto_name_command(), None);
+        assert_eq!(profile.continue_flag(), Some("--continue"));
+    }
+
+    #[test]
+    fn test_grok_profile() {
+        let profile = GrokProfile;
+        assert_eq!(profile.name(), "grok");
+        assert!(!profile.needs_bang_delay());
+        assert!(profile.needs_auto_status());
+        assert_eq!(
+            profile.prompt_argument("PROMPT.md"),
+            "--prompt-file PROMPT.md"
+        );
+        assert_eq!(profile.skip_permissions_flag(), Some("--yolo"));
         assert_eq!(profile.auto_name_command(), None);
         assert_eq!(profile.continue_flag(), Some("--continue"));
     }

--- a/src/multiplexer/agent.rs
+++ b/src/multiplexer/agent.rs
@@ -262,7 +262,7 @@ impl AgentProfile for GrokProfile {
     }
 
     fn prompt_argument(&self, prompt_path: &str) -> String {
-        format!("--prompt-file {}", prompt_path)
+        format!("\"$(cat {})\"", prompt_path)
     }
 
     fn continue_flag(&self) -> Option<&'static str> {
@@ -766,10 +766,7 @@ mod tests {
         assert_eq!(profile.name(), "grok");
         assert!(!profile.needs_bang_delay());
         assert!(profile.needs_auto_status());
-        assert_eq!(
-            profile.prompt_argument("PROMPT.md"),
-            "--prompt-file PROMPT.md"
-        );
+        assert_eq!(profile.prompt_argument("PROMPT.md"), "\"$(cat PROMPT.md)\"");
         assert_eq!(profile.skip_permissions_flag(), Some("--yolo"));
         assert_eq!(profile.auto_name_command(), None);
         assert_eq!(profile.continue_flag(), Some("--continue"));

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -65,6 +65,12 @@ fn skills_dir_with_env(
             Some(base.join("skills"))
         }
         Agent::OpenCode => Some(home.join(".config/opencode/skills")),
+        Agent::Grok => {
+            let base = get_env("GROK_HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| home.join(".grok"));
+            Some(base.join("skills"))
+        }
         Agent::Pi => {
             let pi_dir = get_env("PI_CODING_AGENT_DIR")
                 .map(PathBuf::from)


### PR DESCRIPTION
## Summary

Add [Grok Build](https://x.ai/cli) (SpaceXAI's terminal AI coding agent) as a first-class supported agent, alongside Claude, Codex, Gemini, OpenCode, Antigravity, Pi, Omp, Kiro, Vibe, and Copilot.

Once grok is detected via `~/.grok/` (or `$GROK_HOME`), workmux provides automatic detection, prompt injection, status tracking setup, skills installation, and sidebar/dashboard rendering — matching the pattern set by the existing agents.

## Changes

| Area | File | Change |
| --- | --- | --- |
| Identity | `src/agent_identity.rs` | `AgentKind::Grok` variant + classifier (matches bare `grok` stem, rejects `grok-build`/`grokster`) |
| Profile | `src/multiplexer/agent.rs` | `GrokProfile` implementing `AgentProfile`; registered in `PROFILES` |
| Setup | `src/agent_setup/grok.rs` (new) | Detect/install/uninstall status hook at `~/.grok/hooks/workmux-status.json` |
| Setup | `src/agent_setup/mod.rs` | `Agent::Grok` variant wired into `check_all`/`install`/`uninstall_one` |
| Skills | `src/skills.rs` | `skills_dir()` returns `~/.grok/skills/` so bundled skills auto-install |
| Hook template | `.grok/hooks/workmux-status.json` (new) | Embedded hook config (PascalCase grok events) |
| Docs | `docs/guide/agents.md` | Add `grok` to the agent list |
| Meta | `CHANGELOG.md` | Unreleased entry |

## Design decisions

- **Prompt injection**: a positional initial prompt keeps Grok interactive after the first turn. Grok's `--prompt-file` option is reserved for single-turn headless use.
- **Hook event names**: grok's native PascalCase (`UserPromptSubmit`, `PostToolUse`, `Notification`, `Stop`, `SessionEnd`) rather than the camelCase Claude-style form in `.github/hooks/`. This is grok's idiomatic format; the Cursor-compat layer maps camelCase anyway, but PascalCase is what grok users expect.
- **No features flag**: unlike Codex (which needs `hooks = true` in config.toml), grok discovers hook files in `~/.grok/hooks/*.json` automatically. The setup module is therefore simpler than `codex.rs`.
- **Status mapping**: `Notification` → `waiting`. Permission prompts in grok are handled outside the hook system, so `Notification` is the best available proxy for "needs user input". This matches what the grok-side integration guide documents.
- **Sidebar color**: `#1d9bf0` (X brand blue) for recognizability on both light and dark palettes.
- **`needs_auto_status = true`**: grok ships its own hook, but if a user has not yet run `workmux setup`, this falls back to tmux-based status detection so the agent still appears in the dashboard.

## Event → status mapping

| grok event                        | workmux status |
| --------------------------------- | -------------- |
| `UserPromptSubmit`, `PostToolUse` | `working`      |
| `Notification`                    | `waiting`      |
| `Stop`, `SessionEnd`              | `done`         |

## Verification

- `cargo check` clean
- `cargo test` — **1390 passed, 0 failed** (includes new tests below)
- `cargo fmt --all --check` clean
- `cargo clippy` clean (no new warnings)
- New tests: `grok_command_matches`, `every_variant_has_metadata_and_round_trips` (extended), `test_grok_profile`, `agent_setup::grok::tests::*` (5 tests covering hook validity, install idempotency, uninstall keeps others, uninstall deletes when empty, uninstall idempotent)

## Companion PR

The grok-build side ships a parallel hook example for manual installation: https://github.com/c2j/grok-build/pull/1 . Once this PR lands, `workmux setup` will install the hook automatically and the manual example becomes a fallback for users who want the hook without running setup.

## Out of scope

- Auto-name command (`-A`): grok does not have a cheap headless mode suitable for branch-name generation. Left as `None`; users provide explicit branch names.
- Container sandbox profile for grok: not grok-specific; sandbox works generically.
- A `/grok` workmux subcommand: not needed; the generic `workmux add -a grok` covers it.

## Checklist

- [x] Agent added to `AgentKind` with icon, label, color, and round-trip tests
- [x] `AgentProfile` implemented and registered in `PROFILES`
- [x] `agent_setup` module with detect/check/install/uninstall + tests
- [x] Skills directory wired up
- [x] Embedded hook template valid JSON, contains all three status commands
- [x] Docs: shared agent and status-tracking references updated
- [x] CHANGELOG entry
- [x] All tests pass; fmt + clippy clean