### PR TITLE
sidebar: ignore Access events in config watcher

### DIFF
--- a/src/command/sidebar/daemon.rs
+++ b/src/command/sidebar/daemon.rs
@@ -1169,6 +1169,25 @@ fn spawn_git_worker(
     (cache, tx)
 }
 
+const CONFIG_BASENAMES: [&str; 4] = ["config.yaml", "config.yml", ".workmux.yaml", ".workmux.yml"];
+
+/// Whether a filesystem event on a watched config dir should schedule a
+/// config reload.
+///
+/// Access events (open/read/close-nowrite) must be ignored: on Linux the
+/// notify backend also reports reads of watched files, and a reload itself
+/// reads the config — so reacting to Access events makes every reload
+/// schedule the next one, reloading and re-rendering every sidebar client
+/// once per debounce interval, forever.
+fn config_event_triggers_reload(event: &notify::Event) -> bool {
+    !matches!(event.kind, notify::EventKind::Access(_))
+        && event.paths.iter().any(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| CONFIG_BASENAMES.contains(&n))
+        })
+}
+
 /// Spawn a thread that watches the global config file and per-project
 /// `.workmux.yaml` files and bumps `config_version` whenever a reload succeeds.
 ///
@@ -1233,8 +1252,6 @@ fn spawn_config_watcher(
                 }
             }
         }
-
-        let interesting_basenames = ["config.yaml", "config.yml", ".workmux.yaml", ".workmux.yml"];
 
         while !term.load(Ordering::Relaxed) {
             // 1. Reconcile per-project watches from incoming path sets.
@@ -1303,12 +1320,7 @@ fn spawn_config_watcher(
 
             match fs_rx.recv_timeout(timeout) {
                 Ok(Ok(event)) => {
-                    let interesting = event.paths.iter().any(|p| {
-                        p.file_name()
-                            .and_then(|n| n.to_str())
-                            .is_some_and(|n| interesting_basenames.contains(&n))
-                    });
-                    if interesting {
+                    if config_event_triggers_reload(&event) {
                         // Lock the deadline on the FIRST event in a burst; do
                         // not slide it forward on every subsequent event.
                         pending_reload_at.get_or_insert(Instant::now() + debounce);
@@ -2010,6 +2022,46 @@ mod tests {
         assert!(!github_fetch_due(false, Duration::from_secs(29)));
         assert!(github_fetch_due(false, Duration::from_secs(30)));
         assert!(github_fetch_due(true, Duration::ZERO));
+    }
+
+    #[test]
+    fn config_reload_triggers_on_mutations_of_config_files() {
+        use notify::event::{CreateKind, ModifyKind, RemoveKind};
+
+        let config = PathBuf::from("/home/u/.config/workmux/config.yaml");
+        for kind in [
+            notify::EventKind::Modify(ModifyKind::Any),
+            notify::EventKind::Create(CreateKind::File),
+            notify::EventKind::Remove(RemoveKind::File),
+        ] {
+            let event = notify::Event::new(kind).add_path(config.clone());
+            assert!(config_event_triggers_reload(&event), "kind: {kind:?}");
+        }
+
+        let project = notify::Event::new(notify::EventKind::Modify(ModifyKind::Any))
+            .add_path(PathBuf::from("/repo/.workmux.yaml"));
+        assert!(config_event_triggers_reload(&project));
+    }
+
+    #[test]
+    fn config_reload_ignores_access_events_and_other_files() {
+        use notify::event::{AccessKind, AccessMode, ModifyKind};
+
+        // A reload reads the config; reacting to that read would schedule the
+        // next reload and loop forever.
+        let config = PathBuf::from("/home/u/.config/workmux/config.yaml");
+        for kind in [
+            notify::EventKind::Access(AccessKind::Open(AccessMode::Read)),
+            notify::EventKind::Access(AccessKind::Read),
+            notify::EventKind::Access(AccessKind::Close(AccessMode::Read)),
+        ] {
+            let event = notify::Event::new(kind).add_path(config.clone());
+            assert!(!config_event_triggers_reload(&event), "kind: {kind:?}");
+        }
+
+        let unrelated = notify::Event::new(notify::EventKind::Modify(ModifyKind::Any))
+            .add_path(PathBuf::from("/home/u/.config/workmux/other.txt"));
+        assert!(!config_event_triggers_reload(&unrelated));
     }
 
     #[test]

--- a/src/command/sidebar/daemon.rs
+++ b/src/command/sidebar/daemon.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use ignore::gitignore::Gitignore;
-use notify::{RecursiveMode, Watcher};
+use notify::{EventKindMask, RecursiveMode, Watcher};
 use signal_hook::iterator::{Handle as SignalHandle, Signals};
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
@@ -902,6 +902,11 @@ fn spawn_github_worker(
     (path_cache, check_path_cache, tx)
 }
 
+/// Configure filesystem watchers for mutation events without read noise.
+fn mutation_watcher_config() -> notify::Config {
+    notify::Config::default().with_event_kinds(EventKindMask::CORE)
+}
+
 /// Spawn a background thread that watches for git changes and updates the cache.
 ///
 /// Uses the `notify` crate for OS-level filesystem event detection (FSEvents on macOS).
@@ -942,7 +947,7 @@ fn spawn_git_worker(
                     fs_overflow_clone.store(true, Ordering::Relaxed);
                 }
             },
-            notify::Config::default(),
+            mutation_watcher_config(),
         ) {
             Ok(w) => Some(w),
             Err(e) => {
@@ -1174,12 +1179,14 @@ const CONFIG_BASENAMES: [&str; 4] = ["config.yaml", "config.yml", ".workmux.yaml
 /// Whether a filesystem event on a watched config dir should schedule a
 /// config reload.
 ///
-/// Access events (open/read/close-nowrite) must be ignored: on Linux the
-/// notify backend also reports reads of watched files, and a reload itself
-/// reads the config — so reacting to Access events makes every reload
-/// schedule the next one, reloading and re-rendering every sidebar client
-/// once per debounce interval, forever.
+/// Access events must be ignored because reading a config file produces them
+/// on Linux. Reacting to those reads makes each reload schedule another one.
+/// Rescan events reload defensively because their paths may be incomplete.
 fn config_event_triggers_reload(event: &notify::Event) -> bool {
+    if event.need_rescan() {
+        return true;
+    }
+
     !matches!(event.kind, notify::EventKind::Access(_))
         && event.paths.iter().any(|p| {
             p.file_name()
@@ -1208,11 +1215,17 @@ fn spawn_config_watcher(
         let overflow_clone = overflow.clone();
         let mut watcher: notify::RecommendedWatcher = match notify::RecommendedWatcher::new(
             move |event: notify::Result<notify::Event>| {
+                if event
+                    .as_ref()
+                    .is_ok_and(|event| !config_event_triggers_reload(event))
+                {
+                    return;
+                }
                 if let Err(mpsc::TrySendError::Full(_)) = fs_tx.try_send(event) {
                     overflow_clone.store(true, Ordering::Relaxed);
                 }
             },
-            notify::Config::default(),
+            mutation_watcher_config(),
         ) {
             Ok(w) => w,
             Err(e) => {
@@ -2025,8 +2038,13 @@ mod tests {
     }
 
     #[test]
+    fn mutation_watchers_exclude_access_events() {
+        assert_eq!(mutation_watcher_config().event_kinds(), EventKindMask::CORE);
+    }
+
+    #[test]
     fn config_reload_triggers_on_mutations_of_config_files() {
-        use notify::event::{CreateKind, ModifyKind, RemoveKind};
+        use notify::event::{CreateKind, ModifyKind, RemoveKind, RenameMode};
 
         let config = PathBuf::from("/home/u/.config/workmux/config.yaml");
         for kind in [
@@ -2041,19 +2059,24 @@ mod tests {
         let project = notify::Event::new(notify::EventKind::Modify(ModifyKind::Any))
             .add_path(PathBuf::from("/repo/.workmux.yaml"));
         assert!(config_event_triggers_reload(&project));
+
+        let atomic_rename = notify::Event::new(notify::EventKind::Modify(ModifyKind::Name(
+            RenameMode::Both,
+        )))
+        .add_path(PathBuf::from("/home/u/.config/workmux/config.yaml.tmp"))
+        .add_path(config);
+        assert!(config_event_triggers_reload(&atomic_rename));
     }
 
     #[test]
     fn config_reload_ignores_access_events_and_other_files() {
         use notify::event::{AccessKind, AccessMode, ModifyKind};
 
-        // A reload reads the config; reacting to that read would schedule the
-        // next reload and loop forever.
         let config = PathBuf::from("/home/u/.config/workmux/config.yaml");
         for kind in [
-            notify::EventKind::Access(AccessKind::Open(AccessMode::Read)),
-            notify::EventKind::Access(AccessKind::Read),
+            notify::EventKind::Access(AccessKind::Open(AccessMode::Any)),
             notify::EventKind::Access(AccessKind::Close(AccessMode::Read)),
+            notify::EventKind::Access(AccessKind::Close(AccessMode::Write)),
         ] {
             let event = notify::Event::new(kind).add_path(config.clone());
             assert!(!config_event_triggers_reload(&event), "kind: {kind:?}");
@@ -2062,6 +2085,14 @@ mod tests {
         let unrelated = notify::Event::new(notify::EventKind::Modify(ModifyKind::Any))
             .add_path(PathBuf::from("/home/u/.config/workmux/other.txt"));
         assert!(!config_event_triggers_reload(&unrelated));
+    }
+
+    #[test]
+    fn config_reload_triggers_on_rescan() {
+        let event =
+            notify::Event::new(notify::EventKind::Other).set_flag(notify::event::Flag::Rescan);
+
+        assert!(config_event_triggers_reload(&event));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #217

## Problem

`spawn_config_watcher` filters fs events only by basename, not by event kind. On Linux, `notify`'s inotify backend also delivers Access events (open/read/close-nowrite) — and a config reload reads the watched file itself. So every reload scheduled the next one after the 200 ms debounce: `config_version` bumped ~5×/s forever, re-rendering every sidebar client on each bump (visible flicker; 180k+ bump lines in my log over a day). Details and repro in #217.

## Fix

Extract the filter into `config_event_triggers_reload()` and reject `EventKind::Access(_)`. Mutations (create/modify/remove/rename) still trigger reloads, so atomic-rename editor saves keep working.

## Testing

- Two new unit tests: mutation kinds on config basenames trigger a reload; Access kinds and unrelated files don't.
- `cargo test` (1397 passed), `cargo fmt --check` clean, `cargo clippy` introduces no new warnings.
- Verified live on the affected machine (Linux, tmux 3.6): with the patched daemon, `touch config.yaml` produces exactly one `config_version` bump followed by silence; before the patch it bumped every ~203 ms indefinitely.