### PR TITLE
feat(agents): add Devin as a supported agent

### DIFF
--- a/.devin/hooks/workmux-status.json
+++ b/.devin/hooks/workmux-status.json
@@ -1,0 +1,37 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status working"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status working"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status done"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ include = [
     "/docker/**/*",
     "/.claude-plugin/**/*",
     "/.codex/hooks/**/*",
+    "/.devin/hooks/**/*",
     "/.github/hooks/**/*",
     "/resources/opencode/**/*",
     "/resources/gemini/**/*",

--- a/README.md
+++ b/README.md
@@ -762,7 +762,7 @@ done
 When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`,
 workmux automatically injects the prompt into panes running the configured agent
 command (e.g., `claude`, `codex`, `opencode`, `gemini`, `agy`, `kiro-cli`, `vibe`,
-`pi`, `omp`, or whatever you've set via the `agent` config or `--agent` flag) without
+`pi`, `omp`, `devin`, or whatever you've set via the `agent` config or `--agent` flag) without
 requiring any `.workmux.yaml` changes:
 
 - Panes with a command matching the configured agent are automatically started
@@ -1971,6 +1971,7 @@ at-a-glance visibility into what the agent in each window doing.
 | Claude Code  | ✅ Supported                                                                |
 | OpenCode     | ✅ Supported                                                                |
 | Codex        | ✅ Supported                                                                |
+| Devin        | ✅ Supported\*                                                              |
 | Copilot CLI  | ✅ Supported\*                                                              |
 | Pi           | ✅ Supported\*                                                              |
 | Oh My Pi    | ✅ Supported                                                                |
@@ -1981,6 +1982,7 @@ at-a-glance visibility into what the agent in each window doing.
 
 **Notes:**
 
+- **Devin**: No 💬 waiting state
 - **Copilot CLI**: No 💬 waiting state
 - **Pi**: No 💬 waiting state
 - **Antigravity CLI (`agy`)**: No 💬 waiting state
@@ -1990,7 +1992,7 @@ at-a-glance visibility into what the agent in each window doing.
 ### Setup
 
 Run `workmux setup` to automatically detect Claude Code, Antigravity CLI,
-Copilot CLI, OpenCode, Pi, Oh My Pi, and other supported agent CLIs, install
+Copilot CLI, Devin, OpenCode, Pi, Oh My Pi, and other supported agent CLIs, install
 status tracking hooks, and install skills:
 
 ```bash
@@ -2033,6 +2035,18 @@ curl -o .github/hooks/workmux-status/hooks.json \
 
 Note: Copilot hooks are per-repository. The waiting state is not supported due
 to limitations in the Copilot CLI hooks implementation.
+
+**Devin**: merge the hooks configuration into `~/.config/devin/config.json`
+(which also holds Devin's other settings, so merge rather than replace):
+
+```bash
+curl -s https://raw.githubusercontent.com/raine/workmux/main/.devin/hooks/workmux-status.json \
+  | jq -s '.[0] * .[1]' ~/.config/devin/config.json - > /tmp/devin-config.json \
+  && mv /tmp/devin-config.json ~/.config/devin/config.json
+```
+
+Devin does not currently expose a permission-prompt hook, so only
+working/done states are tracked (no waiting state).
 
 **Antigravity CLI (`agy`)**: `workmux setup` installs lifecycle hooks in
 `~/.gemini/config/hooks.json`. `PreInvocation` marks the pane working, and the

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -8,7 +8,7 @@ workmux is designed with AI agent workflows in mind. Run multiple agents in para
 
 ## Agent integration
 
-When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`, workmux automatically injects the prompt into panes running the configured agent command (e.g., `claude`, `codex`, `opencode`, `gemini`, `agy`, `kiro-cli`, `vibe`, `pi`, `omp`, or whatever you've set via the `agent` config or `--agent` flag) without requiring any `.workmux.yaml` changes:
+When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`, workmux automatically injects the prompt into panes running the configured agent command (e.g., `claude`, `codex`, `opencode`, `gemini`, `agy`, `kiro-cli`, `vibe`, `pi`, `omp`, `devin`, or whatever you've set via the `agent` config or `--agent` flag) without requiring any `.workmux.yaml` changes:
 
 - Panes with a command matching the configured agent are automatically started with the given prompt.
 - You can keep your `.workmux.yaml` pane configuration simple (e.g., `panes: [{ command: "<agent>" }]`) and let workmux handle prompt injection at runtime.
@@ -134,7 +134,7 @@ Named agents are global-only for security. Define them in `~/.config/workmux/con
 
 ## Per-pane agents
 
-workmux automatically recognizes built-in agent commands (`claude`, `gemini`, `agy`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`, `omp`) in pane commands. This means prompt injection works without the `<agent>` placeholder or a matching `agent` config:
+workmux automatically recognizes built-in agent commands (`claude`, `gemini`, `agy`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`, `omp`, `devin`) in pane commands. This means prompt injection works without the `<agent>` placeholder or a matching `agent` config:
 
 ```yaml
 panes:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -193,7 +193,7 @@ Each pane supports:
 
 Named agent profiles can provide structured `command`, `args`, `env`, and `type` fields, including `env` values loaded with `from_env`. See [named agents](/guide/agents#named-agents) for the full profile schema.
 
-Built-in agents (`claude`, `gemini`, `agy`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`, `omp`) are auto-detected when used as literal commands and receive prompt injection automatically, without needing the `<agent>` placeholder or a matching `agent` config:
+Built-in agents (`claude`, `gemini`, `agy`, `codex`, `opencode`, `kiro-cli`, `vibe`, `pi`, `omp`, `devin`) are auto-detected when used as literal commands and receive prompt injection automatically, without needing the `<agent>` placeholder or a matching `agent` config:
 
 ```yaml
 panes:

--- a/docs/guide/status-tracking.md
+++ b/docs/guide/status-tracking.md
@@ -17,6 +17,7 @@ Workmux can display the status of the agent in your tmux window list, giving you
 | Claude Code             | ✅ Supported                                                                |
 | OpenCode                | ✅ Supported                                                                |
 | Codex                   | ✅ Supported                                                                |
+| Devin                   | ✅ Supported\*                                                              |
 | Copilot CLI             | ✅ Supported\*                                                              |
 | Pi                      | ✅ Supported\*                                                              |
 | Oh My Pi                | ✅ Supported                                                                |
@@ -27,6 +28,7 @@ Workmux can display the status of the agent in your tmux window list, giving you
 
 **Notes:**
 
+- **Devin**: No 💬 waiting state
 - **Copilot CLI**: No 💬 waiting state
 - **Pi**: No 💬 waiting state
 - **Antigravity CLI (`agy`)**: No 💬 waiting state
@@ -46,7 +48,7 @@ Run `workmux setup` to automatically detect your agent CLIs and install status t
 workmux setup
 ```
 
-This detects Claude Code, Antigravity CLI, Copilot CLI, OpenCode, Pi, and Oh My Pi by checking for their executable or configuration directories, then offers to install the appropriate hooks. For Claude Code, `CLAUDE_CONFIG_DIR` is respected when locating `settings.json`. Workmux will also prompt you on first run if it detects an agent without status tracking configured.
+This detects Claude Code, Antigravity CLI, Copilot CLI, Devin, OpenCode, Pi, and Oh My Pi by checking for their executable or configuration directories, then offers to install the appropriate hooks. For Claude Code, `CLAUDE_CONFIG_DIR` is respected when locating `settings.json`. Workmux will also prompt you on first run if it detects an agent without status tracking configured.
 
 Workmux automatically modifies your tmux `window-status-format` to display the status icons. This happens once per session and only affects the current tmux session (not your global config).
 
@@ -98,6 +100,18 @@ curl -o ~/.config/opencode/plugins/workmux-status.ts \
 ```
 
 Restart OpenCode for the plugin to take effect.
+
+## Devin setup
+
+If you prefer manual setup, merge the hooks configuration into `~/.config/devin/config.json` (which also holds Devin's other settings, so merge rather than replace):
+
+```bash
+curl -s https://raw.githubusercontent.com/raine/workmux/main/.devin/hooks/workmux-status.json \
+  | jq -s '.[0] * .[1]' ~/.config/devin/config.json - > /tmp/devin-config.json \
+  && mv /tmp/devin-config.json ~/.config/devin/config.json
+```
+
+Devin does not currently expose a permission-prompt hook, so only working/done states are tracked (no waiting state).
 
 ## Codex setup
 

--- a/docs/reference/commands/add.md
+++ b/docs/reference/commands/add.md
@@ -181,7 +181,7 @@ workmux add feature/ai-session --mode session -p "Implement the new API"
 
 ## AI agent integration
 
-When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`, workmux automatically injects the prompt into panes running the configured agent command (e.g., `claude`, `codex`, `opencode`, `gemini`, `agy`, `kiro-cli`, `vibe`, `pi`, `omp`, or whatever you've set via the `agent` config or `--agent` flag) without requiring any `.workmux.yaml` changes:
+When you provide a prompt via `--prompt`, `--prompt-file`, or `--prompt-editor`, workmux automatically injects the prompt into panes running the configured agent command (e.g., `claude`, `codex`, `opencode`, `gemini`, `agy`, `kiro-cli`, `vibe`, `pi`, `omp`, `devin`, or whatever you've set via the `agent` config or `--agent` flag) without requiring any `.workmux.yaml` changes:
 
 - Panes with a command matching the configured agent are automatically started with the given prompt.
 - You can keep your `.workmux.yaml` pane configuration simple (e.g., `panes: [{ command: "<agent>" }]`) and let workmux handle prompt injection at runtime.

--- a/src/agent_identity.rs
+++ b/src/agent_identity.rs
@@ -32,6 +32,7 @@ pub enum AgentKind {
     KiroCli,
     Vibe,
     Copilot,
+    Devin,
 }
 
 impl AgentKind {
@@ -49,6 +50,7 @@ impl AgentKind {
             AgentKind::KiroCli => "kiro-cli",
             AgentKind::Vibe => "vibe",
             AgentKind::Copilot => "copilot",
+            AgentKind::Devin => "devin",
         }
     }
 
@@ -65,6 +67,7 @@ impl AgentKind {
             "kiro-cli" => Some(AgentKind::KiroCli),
             "vibe" => Some(AgentKind::Vibe),
             "copilot" => Some(AgentKind::Copilot),
+            "devin" => Some(AgentKind::Devin),
             _ => None,
         }
     }
@@ -83,6 +86,7 @@ impl AgentKind {
             AgentKind::KiroCli => "K",
             AgentKind::Vibe => "V",
             AgentKind::Copilot => "CP",
+            AgentKind::Devin => "D",
         }
     }
 
@@ -100,6 +104,7 @@ impl AgentKind {
             AgentKind::KiroCli => "Kiro",
             AgentKind::Vibe => "Vibe",
             AgentKind::Copilot => "Copilot",
+            AgentKind::Devin => "Devin",
         }
     }
 
@@ -116,6 +121,7 @@ impl AgentKind {
             AgentKind::Gemini => Color::Rgb(0x07, 0x8e, 0xfa),
             AgentKind::Antigravity => Color::Rgb(0x89, 0x57, 0xe5),
             AgentKind::Copilot => Color::Rgb(0x89, 0x57, 0xe5),
+            AgentKind::Devin => Color::Rgb(0x5b, 0x5f, 0xe0),
             AgentKind::Vibe => Color::Rgb(0xff, 0x82, 0x05),
             AgentKind::Pi => Color::Rgb(0x96, 0xbb, 0xb5),
             AgentKind::Omp => Color::Rgb(0xe0, 0x57, 0x35),
@@ -264,6 +270,12 @@ mod tests {
     }
 
     #[test]
+    fn devin_matches() {
+        assert_eq!(classify("devin", ""), Some("devin".into()));
+        assert_eq!(classify("/usr/local/bin/devin", ""), Some("devin".into()));
+    }
+
+    #[test]
     fn direct_stem_matches_for_known_binaries() {
         assert_eq!(classify("claude", ""), Some("claude".into()));
         assert_eq!(classify("gemini", ""), Some("gemini".into()));
@@ -384,6 +396,7 @@ mod tests {
             AgentKind::KiroCli,
             AgentKind::Vibe,
             AgentKind::Copilot,
+            AgentKind::Devin,
         ];
         for kind in all {
             assert!(!kind.default_icon().is_empty(), "{:?} icon empty", kind);

--- a/src/agent_setup/devin.rs
+++ b/src/agent_setup/devin.rs
@@ -1,0 +1,229 @@
+//! Devin CLI status tracking setup.
+//!
+//! Detects Devin via the `~/.config/devin/` directory.
+//! Installs hooks by merging into `~/.config/devin/config.json`, which
+//! also holds Devin's other user settings (mcpServers, permissions, ...),
+//! so uninstall must only ever touch the `hooks` key.
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::path::PathBuf;
+
+use super::StatusCheck;
+use crate::agent_setup::json_config::{
+    self, EmptyJsonRoot, JsonHookInstallSpec, JsonHookUninstallSpec,
+};
+
+/// Hooks configuration embedded at compile time.
+const HOOKS_JSON: &str = include_str!("../../.devin/hooks/workmux-status.json");
+
+fn devin_dir() -> Option<PathBuf> {
+    home::home_dir().map(|h| h.join(".config/devin"))
+}
+
+fn config_path() -> Option<PathBuf> {
+    devin_dir().map(|d| d.join("config.json"))
+}
+
+/// Detect if Devin is present via filesystem.
+pub fn detect() -> Option<&'static str> {
+    if devin_dir().is_some_and(|d| d.is_dir()) {
+        return Some("found ~/.config/devin/");
+    }
+    None
+}
+
+/// Check if workmux hooks are installed in Devin's config.json.
+pub fn check() -> Result<StatusCheck> {
+    let Some(path) = config_path() else {
+        return Ok(StatusCheck::NotInstalled);
+    };
+
+    json_config::check_hook_file(
+        &path,
+        "Failed to read ~/.config/devin/config.json",
+        "~/.config/devin/config.json is not valid JSON",
+    )
+}
+
+/// Remove workmux hooks from Devin's config.json.
+///
+/// Only removes workmux's own hook entries; config.json's other keys
+/// (mcpServers, permissions, ...) are left untouched, so the file is
+/// never deleted outright.
+pub fn uninstall() -> Result<String> {
+    let Some(path) = config_path() else {
+        return Ok("Devin config dir not found, nothing to uninstall".to_string());
+    };
+    uninstall_at(path)
+}
+
+fn uninstall_at(path: PathBuf) -> Result<String> {
+    json_config::json_hook_uninstall(
+        &path,
+        &JsonHookUninstallSpec {
+            messages: json_config::JsonHookUninstallMessages {
+                file_missing: "No Devin config.json found",
+                not_found: "No workmux hooks found in Devin config.json",
+                soft_read_error: None,
+                soft_parse_error: None,
+            },
+            delete_if_no_hooks_remain: false,
+            remove_plugins: false,
+            soft_errors: false,
+        },
+    )
+}
+
+fn load_hooks() -> Result<Value> {
+    json_config::hooks_from_embedded(HOOKS_JSON, "hooks config missing hooks key")
+}
+
+fn install_hooks_at(path: &std::path::Path) -> Result<()> {
+    json_config::json_hook_install(
+        path,
+        &load_hooks()?,
+        &JsonHookInstallSpec {
+            read_context: "Failed to read ~/.config/devin/config.json",
+            parse_context: "~/.config/devin/config.json is not valid JSON",
+            write_context: "Failed to write ~/.config/devin/config.json",
+            mkdir_context: "Failed to create ~/.config/devin/ directory",
+            empty_root: EmptyJsonRoot::Object,
+        },
+    )
+}
+
+/// Install workmux hooks into `~/.config/devin/config.json`.
+///
+/// Merges hook groups into existing hooks without clobbering or creating
+/// duplicates. Returns a description of what was done.
+pub fn install() -> Result<String> {
+    let path =
+        config_path().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+
+    install_hooks_at(&path).context("Failed to install Devin hooks")?;
+
+    Ok(format!("Installed hooks to {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_hooks_json_is_valid() {
+        let parsed: Value =
+            serde_json::from_str(HOOKS_JSON).expect("embedded hooks config is valid JSON");
+        let hooks = parsed.get("hooks").unwrap().as_object().unwrap();
+        assert!(hooks.contains_key("UserPromptSubmit"));
+        assert!(hooks.contains_key("PostToolUse"));
+        assert!(hooks.contains_key("Stop"));
+    }
+
+    #[test]
+    fn test_load_hooks() {
+        let hooks = load_hooks().unwrap();
+        let obj = hooks.as_object().unwrap();
+        assert!(obj.contains_key("UserPromptSubmit"));
+        assert!(obj.contains_key("PostToolUse"));
+        assert!(obj.contains_key("Stop"));
+    }
+
+    #[test]
+    fn test_install_preserves_other_config_keys() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        std::fs::write(
+            &path,
+            json!({
+                "version": 1,
+                "mcpServers": {"icm": {"command": "icm"}},
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        install_hooks_at(&path).unwrap();
+
+        let content: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(content["version"], 1);
+        assert!(content["mcpServers"]["icm"].is_object());
+        assert!(content["hooks"]["Stop"].is_array());
+    }
+
+    #[test]
+    fn test_install_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        std::fs::write(&path, "{}").unwrap();
+
+        install_hooks_at(&path).unwrap();
+        install_hooks_at(&path).unwrap();
+
+        let content: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let stop = content["hooks"]["Stop"].as_array().unwrap();
+        assert_eq!(stop.len(), 1);
+    }
+
+    #[test]
+    fn test_uninstall_no_config_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        let result = uninstall_at(path).unwrap();
+        assert!(result.contains("No Devin config.json found"));
+    }
+
+    #[test]
+    fn test_uninstall_removes_hooks_keeps_other_keys() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        std::fs::write(
+            &path,
+            json!({
+                "version": 1,
+                "hooks": {
+                    "Stop": [{
+                        "matcher": "",
+                        "hooks": [{"type": "command", "command": "workmux set-window-status done"}]
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let result = uninstall_at(path.clone()).unwrap();
+        assert!(result.contains("Removed workmux hooks"));
+
+        let content: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(content["version"], 1);
+        assert!(content.get("hooks").is_none());
+    }
+
+    #[test]
+    fn test_uninstall_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        std::fs::write(
+            &path,
+            json!({
+                "hooks": {
+                    "Stop": [{
+                        "matcher": "",
+                        "hooks": [{"type": "command", "command": "workmux set-window-status done"}]
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let result1 = uninstall_at(path.clone()).unwrap();
+        assert!(result1.contains("Removed workmux hooks"));
+        let result2 = uninstall_at(path).unwrap();
+        assert!(result2.contains("No workmux hooks found"));
+    }
+}

--- a/src/agent_setup/mod.rs
+++ b/src/agent_setup/mod.rs
@@ -8,6 +8,7 @@ pub mod antigravity;
 pub mod claude;
 pub mod codex;
 pub mod copilot;
+pub mod devin;
 pub mod extension_file;
 pub mod gemini;
 pub mod hooks;
@@ -35,6 +36,7 @@ pub enum Agent {
     Claude,
     Codex,
     Copilot,
+    Devin,
     Gemini,
     OpenCode,
     Pi,
@@ -49,6 +51,7 @@ impl Agent {
             Agent::Claude => "Claude Code",
             Agent::Codex => "Codex",
             Agent::Copilot => "Copilot CLI",
+            Agent::Devin => "Devin",
             Agent::Gemini => "Gemini CLI",
             Agent::OpenCode => "OpenCode",
             Agent::Pi => "pi",
@@ -64,6 +67,7 @@ impl Agent {
             Agent::Claude,
             Agent::Codex,
             Agent::Copilot,
+            Agent::Devin,
             Agent::Gemini,
             Agent::OpenCode,
             Agent::Pi,
@@ -145,6 +149,18 @@ pub fn check_all() -> Vec<AgentCheck> {
         });
     }
 
+    if let Some(reason) = devin::detect() {
+        let status = match devin::check() {
+            Ok(s) => s,
+            Err(e) => StatusCheck::Error(e.to_string()),
+        };
+        results.push(AgentCheck {
+            agent: Agent::Devin,
+            reason,
+            status,
+        });
+    }
+
     if let Some(reason) = gemini::detect() {
         let status = match gemini::check() {
             Ok(s) => s,
@@ -203,6 +219,7 @@ pub fn install(agent: Agent) -> Result<String> {
         Agent::Claude => claude::install(),
         Agent::Codex => codex::install(),
         Agent::Copilot => copilot::install(),
+        Agent::Devin => devin::install(),
         Agent::Gemini => gemini::install(),
         Agent::OpenCode => opencode::install(),
         Agent::Pi => pi::install(),
@@ -217,6 +234,7 @@ pub fn uninstall_one(agent: Agent) -> Result<String> {
         Agent::Claude => claude::uninstall(),
         Agent::Codex => codex::uninstall(),
         Agent::Copilot => copilot::uninstall(),
+        Agent::Devin => devin::uninstall(),
         Agent::Gemini => gemini::uninstall(),
         Agent::OpenCode => opencode::uninstall(),
         Agent::Pi => pi::uninstall(),
@@ -430,6 +448,7 @@ mod tests {
         assert_eq!(Agent::Claude.name(), "Claude Code");
         assert_eq!(Agent::Codex.name(), "Codex");
         assert_eq!(Agent::Copilot.name(), "Copilot CLI");
+        assert_eq!(Agent::Devin.name(), "Devin");
         assert_eq!(Agent::Gemini.name(), "Gemini CLI");
         assert_eq!(Agent::OpenCode.name(), "OpenCode");
         assert_eq!(Agent::Pi.name(), "pi");
@@ -448,6 +467,7 @@ mod tests {
             serde_json::to_string(&Agent::Copilot).unwrap(),
             "\"copilot\""
         );
+        assert_eq!(serde_json::to_string(&Agent::Devin).unwrap(), "\"devin\"");
         assert_eq!(serde_json::to_string(&Agent::Gemini).unwrap(), "\"gemini\"");
         assert_eq!(
             serde_json::to_string(&Agent::OpenCode).unwrap(),
@@ -467,6 +487,8 @@ mod tests {
         assert_eq!(agent, Agent::Codex);
         let agent: Agent = serde_json::from_str("\"copilot\"").unwrap();
         assert_eq!(agent, Agent::Copilot);
+        let agent: Agent = serde_json::from_str("\"devin\"").unwrap();
+        assert_eq!(agent, Agent::Devin);
         let agent: Agent = serde_json::from_str("\"gemini\"").unwrap();
         assert_eq!(agent, Agent::Gemini);
         let agent: Agent = serde_json::from_str("\"opencode\"").unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1890,6 +1890,7 @@ impl SandboxConfig {
             match agent {
                 "claude" => Some(home.join(".claude")),
                 "copilot" => Some(home.join(".copilot")),
+                "devin" => Some(home.join(".config/devin")),
                 "gemini" => Some(home.join(".gemini")),
                 "agy" => Some(home.join(".gemini/antigravity-cli")),
                 "codex" => Some(home.join(".codex")),
@@ -4281,6 +4282,10 @@ extra_mounts:
             .unwrap();
         let home = home::home_dir().unwrap();
         assert_eq!(dir, home.join(".claude"));
+        let dir = config
+            .resolved_agent_config_dir_with_env("devin", |_| None)
+            .unwrap();
+        assert_eq!(dir, home.join(".config/devin"));
         let dir = config
             .resolved_agent_config_dir_with_env("agy", |_| None)
             .unwrap();

--- a/src/multiplexer/agent.rs
+++ b/src/multiplexer/agent.rs
@@ -294,6 +294,22 @@ impl AgentProfile for OmpProfile {
     }
 }
 
+pub struct DevinProfile;
+
+impl AgentProfile for DevinProfile {
+    fn name(&self) -> &'static str {
+        "devin"
+    }
+
+    fn skip_permissions_flag(&self) -> Option<&'static str> {
+        Some("--permission-mode dangerous")
+    }
+
+    fn continue_flag(&self) -> Option<&'static str> {
+        Some("--continue")
+    }
+}
+
 pub struct DefaultProfile;
 
 impl AgentProfile for DefaultProfile {
@@ -314,6 +330,7 @@ static PROFILES: &[&dyn AgentProfile] = &[
     &OmpProfile,
     &KiroProfile,
     &VibeProfile,
+    &DevinProfile,
 ];
 
 /// Check if a command matches a known agent profile.
@@ -702,6 +719,23 @@ mod tests {
             Some(r#"codex exec --config model_reasoning_effort="low" -m gpt-5.1-codex-mini"#)
         );
         assert_eq!(profile.continue_flag(), Some("resume --last"));
+    }
+
+    #[test]
+    fn test_devin_profile() {
+        let profile = DevinProfile;
+        assert_eq!(profile.name(), "devin");
+        assert!(!profile.needs_bang_delay());
+        assert!(!profile.needs_auto_status());
+        assert_eq!(
+            profile.prompt_argument("PROMPT.md"),
+            "-- \"$(cat PROMPT.md)\""
+        );
+        assert_eq!(
+            profile.skip_permissions_flag(),
+            Some("--permission-mode dangerous")
+        );
+        assert_eq!(profile.continue_flag(), Some("--continue"));
     }
 
     #[test]

--- a/src/sandbox/container.rs
+++ b/src/sandbox/container.rs
@@ -635,7 +635,10 @@ fn build_docker_run_args_inner(
     if let Some(config_dir) = config.resolved_agent_config_dir(agent) {
         let target = match agent {
             "claude" => "/tmp/.claude",
+            "copilot" => "/tmp/.copilot",
+            "devin" => "/tmp/.config/devin",
             "gemini" => "/tmp/.gemini",
+            "agy" => "/tmp/.gemini/antigravity-cli",
             "codex" => "/home/user/.codex",
             "opencode" => "/tmp/.local/share/opencode",
             "pi" => "/tmp/.pi/agent",

--- a/src/sandbox/lima/mounts.rs
+++ b/src/sandbox/lima/mounts.rs
@@ -277,7 +277,10 @@ fn generate_mounts_with_state_root(
     if let Some(auth_dir) = config.sandbox.resolved_agent_config_dir(agent) {
         let guest_subpath = match agent {
             "claude" => ".claude",
+            "copilot" => ".copilot",
+            "devin" => ".config/devin",
             "gemini" => ".gemini",
+            "agy" => ".gemini/antigravity-cli",
             "codex" => ".codex",
             "opencode" => ".local/share/opencode",
             "pi" => ".pi/agent",

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -74,7 +74,7 @@ fn skills_dir_with_env(
         Agent::Omp => {
             Some(crate::agent_setup::omp::omp_agent_dir_with_env(home, get_env).join("skills"))
         }
-        Agent::Antigravity | Agent::Codex | Agent::Copilot | Agent::Gemini => None,
+        Agent::Antigravity | Agent::Codex | Agent::Copilot | Agent::Devin | Agent::Gemini => None,
     }
 }
 


### PR DESCRIPTION
Wires Devin CLI (cli.devin.ai) into the same extension points Copilot CLI used to land: AgentKind classification for the sidebar, an AgentProfile for prompt injection (Devin takes -- <prompt> and --permission-mode dangerous like Claude Code), status-tracking setup via ~/.config/devin/config.json's hooks key, and sandbox config-dir mounts for both the container and Lima backends.

Devin has no permission-prompt hook today, so status tracking only covers working/done, not waiting (same limitation as Copilot CLI and Antigravity).

While touching the sandbox config-dir mount match arms for Devin, also fill in the pre-existing gaps for copilot/agy: both already default-resolve a config dir in resolved_agent_config_dir but were missing from the match in container.rs and lima/mounts.rs, so any container-or-Lima sandboxed run with agent "copilot" or "agy" would have hit the unreachable!() panic.
