### PR TITLE
dashboard: make the agents table columns configurable

### DIFF
--- a/docs/src/content/docs/guide/dashboard/configuration.md
+++ b/docs/src/content/docs/guide/dashboard/configuration.md
@@ -10,32 +10,32 @@ dashboard:
   commit: "Commit staged changes with a descriptive message"
   merge: "!workmux merge"
   preview_size: 60
-  columns: [number, project, worktree, git, pr, status, time, title]
+  agent_columns: [number, project, worktree, git, pr, status, time, title]
 ```
 
 The `commit` and `merge` values are text sent to the agent's pane. Use the `!` prefix to run shell commands (supported by Claude, Gemini, and other agents).
 
 ## Defaults
 
-| Option         | Default value                                               | Description                               |
-| -------------- | ----------------------------------------------------------- | ----------------------------------------- |
-| `commit`       | `Commit staged changes with a descriptive message`          | Natural language prompt                   |
-| `merge`        | `!workmux merge`                                            | Shell command via agent                   |
-| `preview_size` | `60`                                                        | Preview pane height as percentage (10-90) |
-| `columns`      | `[number, project, worktree, git, pr, status, time, title]` | Agents table columns, in display order    |
+| Option          | Default value                                               | Description                               |
+| --------------- | ----------------------------------------------------------- | ----------------------------------------- |
+| `commit`        | `Commit staged changes with a descriptive message`          | Natural language prompt                   |
+| `merge`         | `!workmux merge`                                            | Shell command via agent                   |
+| `preview_size`  | `60`                                                        | Preview pane height as percentage (10-90) |
+| `agent_columns` | `[number, project, worktree, git, pr, status, time, title]` | Agents table columns, in display order    |
 
 ## Columns
 
-`columns` sets which columns the agents table shows and in what order. For example, to read the title first and keep the elapsed time out of the way:
+`agent_columns` sets which columns the agents table shows and in what order. For example, to read the title first and keep the elapsed time out of the way:
 
 ```yaml
 dashboard:
-  columns: [number, status, title, project, worktree, git, pr, time]
+  agent_columns: [number, status, title, project, worktree, git, pr, time]
 ```
 
 | Column     | Content                                          |
 | ---------- | ------------------------------------------------ |
-| `number`   | Jump key of the row, shown under the `#` header   |
+| `number`   | Jump key of the row, shown under the `#` header  |
 | `project`  | Project name                                     |
 | `worktree` | Worktree name, with a pane number when it splits |
 | `git`      | Branch state, staged and unstaged changes        |
@@ -44,7 +44,7 @@ dashboard:
 | `time`     | Time since the last status change                |
 | `title`    | Agent session title                              |
 
-A column left out of the list is not rendered, so `columns: [worktree, status, title]` gives a table of just those three. Repeating a column has no effect, and an empty list falls back to the default order.
+A column left out of the list is not rendered, so `agent_columns: [worktree, status, title]` gives a table of just those three. Repeating a column has no effect, and an empty list falls back to the default order.
 
 Dropping `number` hides the jump key, and `1`-`9` still jump to the first nine rows. The `pr` column appears only while at least one agent has a pull request or checks to report, wherever it is placed in the list. A trailing `title` takes the width left over by the other columns; anywhere else it sizes to its content, and the leftover width sits at the right edge of the table.
 

--- a/docs/src/content/docs/guide/dashboard/configuration.md
+++ b/docs/src/content/docs/guide/dashboard/configuration.md
@@ -10,30 +10,42 @@ dashboard:
   commit: "Commit staged changes with a descriptive message"
   merge: "!workmux merge"
   preview_size: 60
-  columns: [status, time, title]
+  columns: [project, worktree, git, pr, status, time, title]
 ```
 
 The `commit` and `merge` values are text sent to the agent's pane. Use the `!` prefix to run shell commands (supported by Claude, Gemini, and other agents).
 
 ## Defaults
 
-| Option         | Default value                                      | Description                               |
-| -------------- | -------------------------------------------------- | ----------------------------------------- |
-| `commit`       | `Commit staged changes with a descriptive message` | Natural language prompt                   |
-| `merge`        | `!workmux merge`                                   | Shell command via agent                   |
-| `preview_size` | `60`                                               | Preview pane height as percentage (10-90) |
-| `columns`      | `[status, time, title]`                            | Order of the trailing table columns       |
+| Option         | Default value                                            | Description                               |
+| -------------- | -------------------------------------------------------- | ----------------------------------------- |
+| `commit`       | `Commit staged changes with a descriptive message`       | Natural language prompt                   |
+| `merge`        | `!workmux merge`                                         | Shell command via agent                   |
+| `preview_size` | `60`                                                     | Preview pane height as percentage (10-90) |
+| `columns`      | `[project, worktree, git, pr, status, time, title]`      | Agents table columns, in display order    |
 
 ## Columns
 
-`columns` sets the order of the columns that follow the fixed `#`, `Project`, `Worktree`, `Git` and optional `PR` ones. For example, to read the title first and keep the elapsed time out of the way:
+`columns` sets which columns the agents table shows and in what order. The `#` jump key column always comes first; every other column is listed here. For example, to read the title first and keep the elapsed time out of the way:
 
 ```yaml
 dashboard:
-  columns: [status, title, time]
+  columns: [status, title, project, worktree, git, pr, time]
 ```
 
-Any of `status`, `time` and `title` may be listed, in any order. A column left out of the list is not rendered, so `columns: [status, title]` drops the elapsed time entirely. Repeating a column has no effect, and an empty list falls back to the default order.
+| Column     | Content                                          |
+| ---------- | ------------------------------------------------ |
+| `project`  | Project name                                     |
+| `worktree` | Worktree name, with a pane number when it splits |
+| `git`      | Branch state, staged and unstaged changes        |
+| `pr`       | Pull request number and check status             |
+| `status`   | Agent status icons                               |
+| `time`     | Time since the last status change                |
+| `title`    | Agent session title                              |
+
+A column left out of the list is not rendered, so `columns: [worktree, status, title]` gives a table of just those three next to the jump key. Repeating a column has no effect, and an empty list falls back to the default order.
+
+The `pr` column appears only while at least one agent has a pull request or checks to report, wherever it is placed in the list. `title` takes the width left over by the other columns, so a list without it leaves the right edge of the table empty.
 
 ## Preview size
 

--- a/docs/src/content/docs/guide/dashboard/configuration.md
+++ b/docs/src/content/docs/guide/dashboard/configuration.md
@@ -46,7 +46,7 @@ dashboard:
 
 A column left out of the list is not rendered, so `columns: [worktree, status, title]` gives a table of just those three. Repeating a column has no effect, and an empty list falls back to the default order.
 
-Dropping `number` hides the jump key, and `1`-`9` still jump to the first nine rows. The `pr` column appears only while at least one agent has a pull request or checks to report, wherever it is placed in the list. `title` takes the width left over by the other columns, so a list without it leaves the right edge of the table empty.
+Dropping `number` hides the jump key, and `1`-`9` still jump to the first nine rows. The `pr` column appears only while at least one agent has a pull request or checks to report, wherever it is placed in the list. A trailing `title` takes the width left over by the other columns; anywhere else it sizes to its content, and the leftover width sits at the right edge of the table.
 
 ## Preview size
 

--- a/docs/src/content/docs/guide/dashboard/configuration.md
+++ b/docs/src/content/docs/guide/dashboard/configuration.md
@@ -10,31 +10,32 @@ dashboard:
   commit: "Commit staged changes with a descriptive message"
   merge: "!workmux merge"
   preview_size: 60
-  columns: [project, worktree, git, pr, status, time, title]
+  columns: [number, project, worktree, git, pr, status, time, title]
 ```
 
 The `commit` and `merge` values are text sent to the agent's pane. Use the `!` prefix to run shell commands (supported by Claude, Gemini, and other agents).
 
 ## Defaults
 
-| Option         | Default value                                            | Description                               |
-| -------------- | -------------------------------------------------------- | ----------------------------------------- |
-| `commit`       | `Commit staged changes with a descriptive message`       | Natural language prompt                   |
-| `merge`        | `!workmux merge`                                         | Shell command via agent                   |
-| `preview_size` | `60`                                                     | Preview pane height as percentage (10-90) |
-| `columns`      | `[project, worktree, git, pr, status, time, title]`      | Agents table columns, in display order    |
+| Option         | Default value                                               | Description                               |
+| -------------- | ----------------------------------------------------------- | ----------------------------------------- |
+| `commit`       | `Commit staged changes with a descriptive message`          | Natural language prompt                   |
+| `merge`        | `!workmux merge`                                            | Shell command via agent                   |
+| `preview_size` | `60`                                                        | Preview pane height as percentage (10-90) |
+| `columns`      | `[number, project, worktree, git, pr, status, time, title]` | Agents table columns, in display order    |
 
 ## Columns
 
-`columns` sets which columns the agents table shows and in what order. The `#` jump key column always comes first; every other column is listed here. For example, to read the title first and keep the elapsed time out of the way:
+`columns` sets which columns the agents table shows and in what order. For example, to read the title first and keep the elapsed time out of the way:
 
 ```yaml
 dashboard:
-  columns: [status, title, project, worktree, git, pr, time]
+  columns: [number, status, title, project, worktree, git, pr, time]
 ```
 
 | Column     | Content                                          |
 | ---------- | ------------------------------------------------ |
+| `number`   | Jump key of the row, shown under the `#` header   |
 | `project`  | Project name                                     |
 | `worktree` | Worktree name, with a pane number when it splits |
 | `git`      | Branch state, staged and unstaged changes        |
@@ -43,9 +44,9 @@ dashboard:
 | `time`     | Time since the last status change                |
 | `title`    | Agent session title                              |
 
-A column left out of the list is not rendered, so `columns: [worktree, status, title]` gives a table of just those three next to the jump key. Repeating a column has no effect, and an empty list falls back to the default order.
+A column left out of the list is not rendered, so `columns: [worktree, status, title]` gives a table of just those three. Repeating a column has no effect, and an empty list falls back to the default order.
 
-The `pr` column appears only while at least one agent has a pull request or checks to report, wherever it is placed in the list. `title` takes the width left over by the other columns, so a list without it leaves the right edge of the table empty.
+Dropping `number` hides the jump key, and `1`-`9` still jump to the first nine rows. The `pr` column appears only while at least one agent has a pull request or checks to report, wherever it is placed in the list. `title` takes the width left over by the other columns, so a list without it leaves the right edge of the table empty.
 
 ## Preview size
 

--- a/docs/src/content/docs/guide/dashboard/configuration.md
+++ b/docs/src/content/docs/guide/dashboard/configuration.md
@@ -10,6 +10,7 @@ dashboard:
   commit: "Commit staged changes with a descriptive message"
   merge: "!workmux merge"
   preview_size: 60
+  columns: [status, time, title]
 ```
 
 The `commit` and `merge` values are text sent to the agent's pane. Use the `!` prefix to run shell commands (supported by Claude, Gemini, and other agents).
@@ -21,6 +22,18 @@ The `commit` and `merge` values are text sent to the agent's pane. Use the `!` p
 | `commit`       | `Commit staged changes with a descriptive message` | Natural language prompt                   |
 | `merge`        | `!workmux merge`                                   | Shell command via agent                   |
 | `preview_size` | `60`                                               | Preview pane height as percentage (10-90) |
+| `columns`      | `[status, time, title]`                            | Order of the trailing table columns       |
+
+## Columns
+
+`columns` sets the order of the columns that follow the fixed `#`, `Project`, `Worktree`, `Git` and optional `PR` ones. For example, to read the title first and keep the elapsed time out of the way:
+
+```yaml
+dashboard:
+  columns: [status, title, time]
+```
+
+Any of `status`, `time` and `title` may be listed, in any order. A column left out of the list is not rendered, so `columns: [status, title]` drops the elapsed time entirely. Repeating a column has no effect, and an empty list falls back to the default order.
 
 ## Preview size
 

--- a/docs/src/content/docs/guide/dashboard/index.mdx
+++ b/docs/src/content/docs/guide/dashboard/index.mdx
@@ -120,6 +120,9 @@ released when the dashboard exits.
 - **Time**: Time since last status change
 - **Title**: Claude Code session title (auto-generated summary)
 
+The **Status**, **Time** and **Title** columns can be reordered, or left out, with
+the [`columns`](/guide/dashboard/configuration#columns) option.
+
 ## Live preview
 
 The bottom half of the dashboard shows a live preview of the selected agent's terminal output. The preview auto-scrolls to show the latest output, but you can scroll through history with `Ctrl+u`/`Ctrl+d`.

--- a/docs/src/content/docs/guide/dashboard/index.mdx
+++ b/docs/src/content/docs/guide/dashboard/index.mdx
@@ -122,7 +122,7 @@ released when the dashboard exits.
 - **Title** (`title`): Claude Code session title (auto-generated summary)
 
 Every column of the agents table can be reordered, or left out, with the
-[`columns`](/guide/dashboard/configuration#columns) option, using the names in
+[`agent_columns`](/guide/dashboard/configuration#columns) option, using the names in
 parentheses above.
 
 ## Live preview

--- a/docs/src/content/docs/guide/dashboard/index.mdx
+++ b/docs/src/content/docs/guide/dashboard/index.mdx
@@ -120,8 +120,8 @@ released when the dashboard exits.
 - **Time**: Time since last status change
 - **Title**: Claude Code session title (auto-generated summary)
 
-The **Status**, **Time** and **Title** columns can be reordered, or left out, with
-the [`columns`](/guide/dashboard/configuration#columns) option.
+Every column except **#** can be reordered, or left out, with the
+[`columns`](/guide/dashboard/configuration#columns) option.
 
 ## Live preview
 

--- a/docs/src/content/docs/guide/dashboard/index.mdx
+++ b/docs/src/content/docs/guide/dashboard/index.mdx
@@ -112,16 +112,18 @@ released when the dashboard exits.
 
 ## Columns
 
-- **#**: Quick jump key (1-9)
-- **Project**: Project name (from `__worktrees` path or directory name)
-- **Agent**: Worktree/window name
-- **Git**: Diff stats showing branch changes (dim) and uncommitted changes (bright)
-- **Status**: Agent status icon (🤖 working, 💬 waiting, ✅ done, or "stale")
-- **Time**: Time since last status change
-- **Title**: Claude Code session title (auto-generated summary)
+- **#** (`number`): Quick jump key (1-9)
+- **Project** (`project`): Project name (from `__worktrees` path or directory name)
+- **Worktree** (`worktree`): Worktree/window name
+- **Git** (`git`): Diff stats showing branch changes (dim) and uncommitted changes (bright)
+- **PR** (`pr`): Pull request number and check status, shown once an agent has one
+- **Status** (`status`): Agent status icon (🤖 working, 💬 waiting, ✅ done, or "stale")
+- **Time** (`time`): Time since last status change
+- **Title** (`title`): Claude Code session title (auto-generated summary)
 
-Every column can be reordered, or left out, with the
-[`columns`](/guide/dashboard/configuration#columns) option.
+Every column of the agents table can be reordered, or left out, with the
+[`columns`](/guide/dashboard/configuration#columns) option, using the names in
+parentheses above.
 
 ## Live preview
 

--- a/docs/src/content/docs/guide/dashboard/index.mdx
+++ b/docs/src/content/docs/guide/dashboard/index.mdx
@@ -120,7 +120,7 @@ released when the dashboard exits.
 - **Time**: Time since last status change
 - **Title**: Claude Code session title (auto-generated summary)
 
-Every column except **#** can be reordered, or left out, with the
+Every column can be reordered, or left out, with the
 [`columns`](/guide/dashboard/configuration#columns) option.
 
 ## Live preview

--- a/src/command/dashboard/ui/dashboard.rs
+++ b/src/command/dashboard/ui/dashboard.rs
@@ -11,6 +11,7 @@ use ratatui::{
 use std::collections::{BTreeMap, HashSet};
 
 use crate::agent_display::strip_oc_title_prefix;
+use crate::config::DashboardColumn;
 
 use super::super::app::{App, DashboardTab};
 use super::format;
@@ -152,6 +153,9 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
     // Show the GitHub column when at least one agent has a PR or checks.
     let show_pr_column = app.has_any_github_status();
     let show_check_counts = app.config.dashboard.show_check_counts();
+    // Header cells, row cells and width constraints are all derived from this
+    // one list, so a reordered config can never desynchronise them.
+    let trailing_columns = app.config.dashboard.columns();
 
     let header = format::resource_table_header(
         format::ResourceHeaderState {
@@ -163,7 +167,14 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
             pr_fetching: app.is_pr_fetching(),
         },
         show_pr_column,
-        &["Status", "Time", "Title"],
+        &trailing_columns
+            .iter()
+            .map(|column| match column {
+                DashboardColumn::Status => "Status",
+                DashboardColumn::Time => "Time",
+                DashboardColumn::Title => "Title",
+            })
+            .collect::<Vec<_>>(),
     );
 
     // Group agents by (session, window_name) to detect multi-pane windows
@@ -367,11 +378,30 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
                 }
 
                 let status_line = format::spans_to_line(status_spans);
-                cells.extend(vec![
-                    Cell::from(status_line),
-                    Cell::from(duration_line),
-                    Cell::from(title),
-                ]);
+                let mut status_cell = Some(status_line);
+                let mut duration_cell = Some(duration_line);
+                let mut title_cell = Some(title);
+                for column in &trailing_columns {
+                    // take() so each column is moved out once: columns() already
+                    // dropped duplicates, this keeps the compiler happy about it
+                    match column {
+                        DashboardColumn::Status => {
+                            if let Some(line) = status_cell.take() {
+                                cells.push(Cell::from(line));
+                            }
+                        }
+                        DashboardColumn::Time => {
+                            if let Some(line) = duration_cell.take() {
+                                cells.push(Cell::from(line));
+                            }
+                        }
+                        DashboardColumn::Title => {
+                            if let Some(line) = title_cell.take() {
+                                cells.push(Cell::from(line));
+                            }
+                        }
+                    }
+                }
 
                 let row = Row::new(cells);
                 // Subtle background for the active worktree row
@@ -396,11 +426,11 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
         constraints.push(Constraint::Length(max_pr_width as u16)); // PR: auto-sized
     }
 
-    constraints.extend(vec![
-        Constraint::Length(8),  // Status: fixed (icons)
-        Constraint::Length(10), // Time: HH:MM:SS + padding
-        Constraint::Fill(1),    // Title: takes remaining space
-    ]);
+    constraints.extend(trailing_columns.iter().map(|column| match column {
+        DashboardColumn::Status => Constraint::Length(8), // fixed (icons)
+        DashboardColumn::Time => Constraint::Length(10),  // HH:MM:SS + padding
+        DashboardColumn::Title => Constraint::Fill(1),    // takes remaining space
+    }));
 
     let highlight_symbol = Text::from(Line::from(Span::styled(
         "▌ ",

--- a/src/command/dashboard/ui/dashboard.rs
+++ b/src/command/dashboard/ui/dashboard.rs
@@ -16,6 +16,7 @@ use crate::config::DashboardColumn;
 use super::super::app::{App, DashboardTab};
 use super::format;
 use super::format::{format_git_status, format_pr_status, truncate};
+use super::theme::ThemePalette;
 use super::worktree::{render_worktree_preview, render_worktree_table};
 
 /// Render the tab header line showing Agents | Worktrees with active tab highlighted.
@@ -149,33 +150,145 @@ pub fn render_dashboard(f: &mut Frame, app: &mut App) {
     }
 }
 
+/// Per-agent cell content, assembled before the configured column order is
+/// applied so every column reads from the same row.
+struct AgentRowData {
+    jump_key: String,
+    project: String,
+    worktree_display: String,
+    worktree_base: String,
+    worktree_suffix: String,
+    is_main: bool,
+    is_current: bool,
+    git_spans: Vec<(String, Style)>,
+    pr_spans: Option<Vec<(String, Style)>>,
+    status_spans: Vec<(String, Style)>,
+    duration_line: Line<'static>,
+    title: String,
+}
+
+/// Auto-sized widths of the agents table columns that size to their content.
+struct AgentColumnWidths {
+    project: u16,
+    worktree: u16,
+    git: u16,
+    pr: u16,
+}
+
+/// Build the cell of one configured column for one agent row.
+fn agent_cell(
+    column: DashboardColumn,
+    row: &AgentRowData,
+    palette: &ThemePalette,
+) -> Cell<'static> {
+    match column {
+        DashboardColumn::Project => Cell::from(row.project.clone()),
+        DashboardColumn::Worktree => {
+            let worktree_style = format::make_row_style(row.is_current, row.is_main, palette);
+            // Worktree name with dimmed pane suffix
+            let worktree_line = if row.worktree_suffix.is_empty() {
+                Line::from(Span::styled(row.worktree_base.clone(), worktree_style))
+            } else {
+                Line::from(vec![
+                    Span::styled(row.worktree_base.clone(), worktree_style),
+                    Span::styled(
+                        row.worktree_suffix.clone(),
+                        Style::default().fg(palette.dimmed),
+                    ),
+                ])
+            };
+            Cell::from(worktree_line)
+        }
+        DashboardColumn::Git => Cell::from(format::spans_to_line(row.git_spans.clone())),
+        DashboardColumn::Pr => Cell::from(format::spans_to_line(
+            row.pr_spans.clone().unwrap_or_default(),
+        )),
+        DashboardColumn::Status => Cell::from(format::spans_to_line(row.status_spans.clone())),
+        DashboardColumn::Time => Cell::from(row.duration_line.clone()),
+        DashboardColumn::Title => Cell::from(row.title.clone()),
+    }
+}
+
+/// Assemble the agents table. Header cells, row cells and width constraints are
+/// all derived from `columns`, so a reordered config can never desynchronise
+/// them. The `#` jump key column is not part of the list and always comes first.
+fn build_agent_table(
+    columns: &[DashboardColumn],
+    row_data: Vec<AgentRowData>,
+    widths: AgentColumnWidths,
+    header_state: format::ResourceHeaderState<'_>,
+) -> Table<'static> {
+    let palette = header_state.palette;
+
+    let mut header_cells = vec![format::ResourceHeaderCell::Plain("#")];
+    header_cells.extend(columns.iter().map(|column| match column {
+        DashboardColumn::Project => format::ResourceHeaderCell::Plain("Project"),
+        DashboardColumn::Worktree => format::ResourceHeaderCell::Plain("Worktree"),
+        DashboardColumn::Git => format::ResourceHeaderCell::Git,
+        DashboardColumn::Pr => format::ResourceHeaderCell::Pr,
+        DashboardColumn::Status => format::ResourceHeaderCell::Plain("Status"),
+        DashboardColumn::Time => format::ResourceHeaderCell::Plain("Time"),
+        DashboardColumn::Title => format::ResourceHeaderCell::Plain("Title"),
+    }));
+
+    let rows: Vec<Row> = row_data
+        .into_iter()
+        .map(|row_data| {
+            let mut cells = vec![
+                Cell::from(row_data.jump_key.clone()).style(Style::default().fg(palette.keycap)),
+            ];
+            cells.extend(
+                columns
+                    .iter()
+                    .map(|column| agent_cell(*column, &row_data, palette)),
+            );
+
+            let row = Row::new(cells);
+            // Subtle background for the active worktree row
+            if row_data.is_current {
+                row.style(Style::default().bg(palette.current_row_bg))
+            } else {
+                row
+            }
+        })
+        .collect();
+
+    let mut constraints = vec![Constraint::Length(2)]; // #: jump key
+    constraints.extend(columns.iter().map(|column| match column {
+        DashboardColumn::Project => Constraint::Length(widths.project), // auto-sized
+        DashboardColumn::Worktree => Constraint::Length(widths.worktree), // auto-sized
+        DashboardColumn::Git => Constraint::Length(widths.git),         // auto-sized
+        DashboardColumn::Pr => Constraint::Length(widths.pr),           // auto-sized
+        DashboardColumn::Status => Constraint::Length(8),               // fixed (icons)
+        DashboardColumn::Time => Constraint::Length(10),                // HH:MM:SS + padding
+        DashboardColumn::Title => Constraint::Fill(1),                  // remaining space
+    }));
+
+    let highlight_symbol = Text::from(Line::from(Span::styled(
+        "▌ ",
+        Style::default().fg(palette.info),
+    )));
+    let row_highlight_style = Style::default().bg(palette.highlight_row_bg);
+
+    Table::new(rows, constraints)
+        .header(format::resource_table_header(header_state, &header_cells))
+        .block(Block::default())
+        .row_highlight_style(row_highlight_style)
+        .highlight_symbol(highlight_symbol)
+}
+
 fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
     // Show the GitHub column when at least one agent has a PR or checks.
     let show_pr_column = app.has_any_github_status();
     let show_check_counts = app.config.dashboard.show_check_counts();
-    // Header cells, row cells and width constraints are all derived from this
-    // one list, so a reordered config can never desynchronise them.
-    let trailing_columns = app.config.dashboard.columns();
-
-    let header = format::resource_table_header(
-        format::ResourceHeaderState {
-            palette: &app.palette,
-            spinner_frame: app.spinner_frame,
-            git_fetching: app
-                .is_git_fetching
-                .load(std::sync::atomic::Ordering::Relaxed),
-            pr_fetching: app.is_pr_fetching(),
-        },
-        show_pr_column,
-        &trailing_columns
-            .iter()
-            .map(|column| match column {
-                DashboardColumn::Status => "Status",
-                DashboardColumn::Time => "Time",
-                DashboardColumn::Title => "Title",
-            })
-            .collect::<Vec<_>>(),
-    );
+    // The PR column only carries content once an agent has GitHub status
+    let columns: Vec<DashboardColumn> = app
+        .config
+        .dashboard
+        .columns()
+        .into_iter()
+        .filter(|column| *column != DashboardColumn::Pr || show_pr_column)
+        .collect();
 
     // Group agents by (session, window_name) to detect multi-pane windows
     let mut window_groups: BTreeMap<(String, String), Vec<usize>> = BTreeMap::new();
@@ -272,7 +385,7 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
                 None
             };
 
-            (
+            AgentRowData {
                 jump_key,
                 project,
                 worktree_display,
@@ -285,25 +398,28 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
                 status_spans,
                 duration_line,
                 title,
-            )
+            }
         })
         .collect();
 
     // Calculate max project name width (with padding, capped)
-    let project_names: Vec<String> = row_data.iter().map(|r| r.1.clone()).collect();
+    let project_names: Vec<String> = row_data.iter().map(|r| r.project.clone()).collect();
     let max_project_width = format::calc_column_width(&project_names, 5, 20, 2);
 
     // Calculate max worktree name width (with padding, capped)
     // Use at least 8 to fit the "Worktree" header, at most 25 to keep layout compact
-    let worktree_names: Vec<String> = row_data.iter().map(|r| r.2.clone()).collect();
+    let worktree_names: Vec<String> = row_data
+        .iter()
+        .map(|r| r.worktree_display.clone())
+        .collect();
     let max_worktree_width = format::calc_column_width(&worktree_names, 8, 25, 1);
 
     // Calculate max git status width (sum of all span character counts)
     // Use chars().count() instead of len() because Nerd Font icons are multi-byte
     let max_git_width = row_data
         .iter()
-        .map(|(_, _, _, _, _, _, _, git_spans, _, _, _, _)| {
-            git_spans
+        .map(|r| {
+            r.git_spans
                 .iter()
                 .map(|(text, _)| text.chars().count())
                 .sum::<usize>()
@@ -314,133 +430,38 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
         + 1; // padding
 
     // Calculate max PR status width (only if showing PR column)
-    let max_pr_width = if show_pr_column {
-        row_data
-            .iter()
-            .filter_map(|(_, _, _, _, _, _, _, _, pr_spans, _, _, _)| pr_spans.as_ref())
-            .map(|spans| {
-                spans
-                    .iter()
-                    .map(|(text, _)| text.chars().count())
-                    .sum::<usize>()
-            })
-            .max()
-            .unwrap_or(4)
-            .clamp(4, 20) // Accommodate check icons + counts + inline timer
-            + 1
-    } else {
-        0
-    };
+    let max_pr_width = row_data
+        .iter()
+        .filter_map(|r| r.pr_spans.as_ref())
+        .map(|spans| {
+            spans
+                .iter()
+                .map(|(text, _)| text.chars().count())
+                .sum::<usize>()
+        })
+        .max()
+        .unwrap_or(4)
+        .clamp(4, 20) // Accommodate check icons + counts + inline timer
+        + 1;
 
-    let rows: Vec<Row> = row_data
-        .into_iter()
-        .map(
-            |(
-                jump_key,
-                project,
-                _worktree_display,
-                worktree_base,
-                worktree_suffix,
-                is_main,
-                is_current,
-                git_spans,
-                pr_spans,
-                status_spans,
-                duration_line,
-                title,
-            )| {
-                let worktree_style = format::make_row_style(is_current, is_main, &app.palette);
-
-                // Worktree name with dimmed pane suffix
-                let worktree_line = if worktree_suffix.is_empty() {
-                    Line::from(Span::styled(worktree_base, worktree_style))
-                } else {
-                    Line::from(vec![
-                        Span::styled(worktree_base, worktree_style),
-                        Span::styled(worktree_suffix, Style::default().fg(app.palette.dimmed)),
-                    ])
-                };
-
-                // Convert git spans to a Line
-                let git_line = format::spans_to_line(git_spans);
-
-                let mut cells = vec![
-                    Cell::from(jump_key).style(Style::default().fg(app.palette.keycap)),
-                    Cell::from(project),
-                    Cell::from(worktree_line),
-                    Cell::from(git_line),
-                ];
-
-                // Add PR cell if column is shown
-                if let Some(pr_spans) = pr_spans {
-                    let pr_line = format::spans_to_line(pr_spans);
-                    cells.push(Cell::from(pr_line));
-                }
-
-                let status_line = format::spans_to_line(status_spans);
-                let mut status_cell = Some(status_line);
-                let mut duration_cell = Some(duration_line);
-                let mut title_cell = Some(title);
-                for column in &trailing_columns {
-                    // take() so each column is moved out once: columns() already
-                    // dropped duplicates, this keeps the compiler happy about it
-                    match column {
-                        DashboardColumn::Status => {
-                            if let Some(line) = status_cell.take() {
-                                cells.push(Cell::from(line));
-                            }
-                        }
-                        DashboardColumn::Time => {
-                            if let Some(line) = duration_cell.take() {
-                                cells.push(Cell::from(line));
-                            }
-                        }
-                        DashboardColumn::Title => {
-                            if let Some(line) = title_cell.take() {
-                                cells.push(Cell::from(line));
-                            }
-                        }
-                    }
-                }
-
-                let row = Row::new(cells);
-                // Subtle background for the active worktree row
-                if is_current {
-                    row.style(Style::default().bg(app.palette.current_row_bg))
-                } else {
-                    row
-                }
-            },
-        )
-        .collect();
-
-    // Build column constraints conditionally based on whether PR column is shown
-    let mut constraints = vec![
-        Constraint::Length(2),                    // #: jump key
-        Constraint::Length(max_project_width),    // Project: auto-sized
-        Constraint::Length(max_worktree_width),   // Worktree: auto-sized
-        Constraint::Length(max_git_width as u16), // Git: auto-sized
-    ];
-
-    if show_pr_column {
-        constraints.push(Constraint::Length(max_pr_width as u16)); // PR: auto-sized
-    }
-
-    constraints.extend(trailing_columns.iter().map(|column| match column {
-        DashboardColumn::Status => Constraint::Length(8), // fixed (icons)
-        DashboardColumn::Time => Constraint::Length(10),  // HH:MM:SS + padding
-        DashboardColumn::Title => Constraint::Fill(1),    // takes remaining space
-    }));
-
-    let highlight_symbol = Text::from(Line::from(Span::styled(
-        "▌ ",
-        Style::default().fg(app.palette.info),
-    )));
-    let table = Table::new(rows, constraints)
-        .header(header)
-        .block(Block::default())
-        .row_highlight_style(Style::default().bg(app.palette.highlight_row_bg))
-        .highlight_symbol(highlight_symbol);
+    let table = build_agent_table(
+        &columns,
+        row_data,
+        AgentColumnWidths {
+            project: max_project_width,
+            worktree: max_worktree_width,
+            git: max_git_width as u16,
+            pr: max_pr_width as u16,
+        },
+        format::ResourceHeaderState {
+            palette: &app.palette,
+            spinner_frame: app.spinner_frame,
+            git_fetching: app
+                .is_git_fetching
+                .load(std::sync::atomic::Ordering::Relaxed),
+            pr_fetching: app.is_pr_fetching(),
+        },
+    );
 
     f.render_stateful_widget(table, area, &mut app.table_state);
 }
@@ -727,4 +748,119 @@ fn render_worktree_footer_normal(f: &mut Frame, app: &App, area: Rect) {
     items.push(footer_cmd("q", "Quit", dimmed, bold_text));
 
     render_pinned_footer(f, area, &items, dimmed, bold_text, pipe_style);
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::widgets::TableState;
+
+    use super::*;
+    use crate::config::{ThemeConfig, ThemeMode};
+
+    fn palette() -> ThemePalette {
+        ThemePalette::from_config(&ThemeConfig::default(), ThemeMode::Dark)
+    }
+
+    fn row(palette: &ThemePalette) -> AgentRowData {
+        AgentRowData {
+            jump_key: "1".to_string(),
+            project: "proj".to_string(),
+            worktree_display: "wt".to_string(),
+            worktree_base: "wt".to_string(),
+            worktree_suffix: String::new(),
+            is_main: false,
+            is_current: false,
+            git_spans: vec![("+1".to_string(), Style::default())],
+            pr_spans: Some(vec![("#7".to_string(), Style::default())]),
+            status_spans: vec![("work".to_string(), Style::default())],
+            duration_line: format::elapsed_time_line("00:42".to_string(), Some(42), palette),
+            title: "the title".to_string(),
+        }
+    }
+
+    /// Render the agents table and return one line of the output buffer.
+    fn render_line(columns: &[DashboardColumn], line: u16) -> String {
+        let palette = palette();
+        let table = build_agent_table(
+            columns,
+            vec![row(&palette)],
+            AgentColumnWidths {
+                project: 8,
+                worktree: 9,
+                git: 6,
+                pr: 5,
+            },
+            format::ResourceHeaderState {
+                palette: &palette,
+                spinner_frame: 0,
+                git_fetching: false,
+                pr_fetching: false,
+            },
+        );
+
+        let width = 80u16;
+        let mut terminal = Terminal::new(TestBackend::new(width, 4)).unwrap();
+        terminal
+            .draw(|f| f.render_stateful_widget(table, f.area(), &mut TableState::default()))
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        (0..width)
+            .map(|x| buffer[(x, line)].symbol())
+            .collect::<String>()
+            .trim_end()
+            .to_string()
+    }
+
+    #[test]
+    fn agents_table_header_follows_column_order() {
+        assert_eq!(
+            render_line(&crate::config::DEFAULT_DASHBOARD_COLUMNS, 0),
+            "#  Project  Worktree  Git    PR    Status   Time       Title"
+        );
+        assert_eq!(
+            render_line(
+                &[
+                    DashboardColumn::Title,
+                    DashboardColumn::Status,
+                    DashboardColumn::Project,
+                ],
+                0
+            ),
+            "#  Title                                                       Status   Project"
+        );
+    }
+
+    #[test]
+    fn agents_table_rows_follow_column_order() {
+        assert_eq!(
+            render_line(&crate::config::DEFAULT_DASHBOARD_COLUMNS, 1),
+            "1  proj     wt        +1     #7    work     00:42      the title"
+        );
+        assert_eq!(
+            render_line(
+                &[
+                    DashboardColumn::Title,
+                    DashboardColumn::Status,
+                    DashboardColumn::Project,
+                ],
+                1
+            ),
+            "1  the title                                                   work     proj"
+        );
+    }
+
+    #[test]
+    fn agents_table_omits_unlisted_columns() {
+        assert_eq!(
+            render_line(&[DashboardColumn::Worktree, DashboardColumn::Title], 0),
+            "#  Worktree  Title"
+        );
+        assert_eq!(
+            render_line(&[DashboardColumn::Worktree, DashboardColumn::Title], 1),
+            "1  wt        the title"
+        );
+    }
 }

--- a/src/command/dashboard/ui/dashboard.rs
+++ b/src/command/dashboard/ui/dashboard.rs
@@ -182,6 +182,9 @@ fn agent_cell(
     palette: &ThemePalette,
 ) -> Cell<'static> {
     match column {
+        DashboardColumn::Number => {
+            Cell::from(row.jump_key.clone()).style(Style::default().fg(palette.keycap))
+        }
         DashboardColumn::Project => Cell::from(row.project.clone()),
         DashboardColumn::Worktree => {
             let worktree_style = format::make_row_style(row.is_current, row.is_main, palette);
@@ -211,7 +214,7 @@ fn agent_cell(
 
 /// Assemble the agents table. Header cells, row cells and width constraints are
 /// all derived from `columns`, so a reordered config can never desynchronise
-/// them. The `#` jump key column is not part of the list and always comes first.
+/// them.
 fn build_agent_table(
     columns: &[DashboardColumn],
     row_data: Vec<AgentRowData>,
@@ -220,28 +223,27 @@ fn build_agent_table(
 ) -> Table<'static> {
     let palette = header_state.palette;
 
-    let mut header_cells = vec![format::ResourceHeaderCell::Plain("#")];
-    header_cells.extend(columns.iter().map(|column| match column {
-        DashboardColumn::Project => format::ResourceHeaderCell::Plain("Project"),
-        DashboardColumn::Worktree => format::ResourceHeaderCell::Plain("Worktree"),
-        DashboardColumn::Git => format::ResourceHeaderCell::Git,
-        DashboardColumn::Pr => format::ResourceHeaderCell::Pr,
-        DashboardColumn::Status => format::ResourceHeaderCell::Plain("Status"),
-        DashboardColumn::Time => format::ResourceHeaderCell::Plain("Time"),
-        DashboardColumn::Title => format::ResourceHeaderCell::Plain("Title"),
-    }));
+    let header_cells: Vec<format::ResourceHeaderCell> = columns
+        .iter()
+        .map(|column| match column {
+            DashboardColumn::Number => format::ResourceHeaderCell::Plain("#"),
+            DashboardColumn::Project => format::ResourceHeaderCell::Plain("Project"),
+            DashboardColumn::Worktree => format::ResourceHeaderCell::Plain("Worktree"),
+            DashboardColumn::Git => format::ResourceHeaderCell::Git,
+            DashboardColumn::Pr => format::ResourceHeaderCell::Pr,
+            DashboardColumn::Status => format::ResourceHeaderCell::Plain("Status"),
+            DashboardColumn::Time => format::ResourceHeaderCell::Plain("Time"),
+            DashboardColumn::Title => format::ResourceHeaderCell::Plain("Title"),
+        })
+        .collect();
 
     let rows: Vec<Row> = row_data
         .into_iter()
         .map(|row_data| {
-            let mut cells = vec![
-                Cell::from(row_data.jump_key.clone()).style(Style::default().fg(palette.keycap)),
-            ];
-            cells.extend(
-                columns
-                    .iter()
-                    .map(|column| agent_cell(*column, &row_data, palette)),
-            );
+            let cells: Vec<Cell> = columns
+                .iter()
+                .map(|column| agent_cell(*column, &row_data, palette))
+                .collect();
 
             let row = Row::new(cells);
             // Subtle background for the active worktree row
@@ -253,16 +255,19 @@ fn build_agent_table(
         })
         .collect();
 
-    let mut constraints = vec![Constraint::Length(2)]; // #: jump key
-    constraints.extend(columns.iter().map(|column| match column {
-        DashboardColumn::Project => Constraint::Length(widths.project), // auto-sized
-        DashboardColumn::Worktree => Constraint::Length(widths.worktree), // auto-sized
-        DashboardColumn::Git => Constraint::Length(widths.git),         // auto-sized
-        DashboardColumn::Pr => Constraint::Length(widths.pr),           // auto-sized
-        DashboardColumn::Status => Constraint::Length(8),               // fixed (icons)
-        DashboardColumn::Time => Constraint::Length(10),                // HH:MM:SS + padding
-        DashboardColumn::Title => Constraint::Fill(1),                  // remaining space
-    }));
+    let constraints: Vec<Constraint> = columns
+        .iter()
+        .map(|column| match column {
+            DashboardColumn::Number => Constraint::Length(2), // jump key
+            DashboardColumn::Project => Constraint::Length(widths.project), // auto-sized
+            DashboardColumn::Worktree => Constraint::Length(widths.worktree), // auto-sized
+            DashboardColumn::Git => Constraint::Length(widths.git), // auto-sized
+            DashboardColumn::Pr => Constraint::Length(widths.pr), // auto-sized
+            DashboardColumn::Status => Constraint::Length(8), // fixed (icons)
+            DashboardColumn::Time => Constraint::Length(10),  // HH:MM:SS + padding
+            DashboardColumn::Title => Constraint::Fill(1),    // remaining space
+        })
+        .collect();
 
     let highlight_symbol = Text::from(Line::from(Span::styled(
         "▌ ",
@@ -814,6 +819,14 @@ mod tests {
             .to_string()
     }
 
+    /// Reordered list, including the `#` jump key away from its usual place.
+    const REORDERED: [DashboardColumn; 4] = [
+        DashboardColumn::Title,
+        DashboardColumn::Status,
+        DashboardColumn::Number,
+        DashboardColumn::Project,
+    ];
+
     #[test]
     fn agents_table_header_follows_column_order() {
         assert_eq!(
@@ -821,15 +834,8 @@ mod tests {
             "#  Project  Worktree  Git    PR    Status   Time       Title"
         );
         assert_eq!(
-            render_line(
-                &[
-                    DashboardColumn::Title,
-                    DashboardColumn::Status,
-                    DashboardColumn::Project,
-                ],
-                0
-            ),
-            "#  Title                                                       Status   Project"
+            render_line(&REORDERED, 0),
+            "Title                                                       Status   #  Project"
         );
     }
 
@@ -840,15 +846,8 @@ mod tests {
             "1  proj     wt        +1     #7    work     00:42      the title"
         );
         assert_eq!(
-            render_line(
-                &[
-                    DashboardColumn::Title,
-                    DashboardColumn::Status,
-                    DashboardColumn::Project,
-                ],
-                1
-            ),
-            "1  the title                                                   work     proj"
+            render_line(&REORDERED, 1),
+            "the title                                                   work     1  proj"
         );
     }
 
@@ -856,11 +855,11 @@ mod tests {
     fn agents_table_omits_unlisted_columns() {
         assert_eq!(
             render_line(&[DashboardColumn::Worktree, DashboardColumn::Title], 0),
-            "#  Worktree  Title"
+            "Worktree  Title"
         );
         assert_eq!(
             render_line(&[DashboardColumn::Worktree, DashboardColumn::Title], 1),
-            "1  wt        the title"
+            "wt        the title"
         );
     }
 }

--- a/src/command/dashboard/ui/dashboard.rs
+++ b/src/command/dashboard/ui/dashboard.rs
@@ -173,6 +173,24 @@ struct AgentColumnWidths {
     worktree: u16,
     git: u16,
     pr: u16,
+    title: u16,
+}
+
+/// Columns to render, given the configured order. The PR column carries content
+/// only once an agent has GitHub status, so it drops out until then, unless it
+/// is the only thing left to show and dropping it would blank the table.
+fn visible_columns(configured: &[DashboardColumn], show_pr_column: bool) -> Vec<DashboardColumn> {
+    let visible: Vec<DashboardColumn> = configured
+        .iter()
+        .copied()
+        .filter(|column| *column != DashboardColumn::Pr || show_pr_column)
+        .collect();
+
+    if visible.is_empty() {
+        configured.to_vec()
+    } else {
+        visible
+    }
 }
 
 /// Build the cell of one configured column for one agent row.
@@ -255,9 +273,11 @@ fn build_agent_table(
         })
         .collect();
 
+    let last_column = columns.len().saturating_sub(1);
     let constraints: Vec<Constraint> = columns
         .iter()
-        .map(|column| match column {
+        .enumerate()
+        .map(|(index, column)| match column {
             DashboardColumn::Number => Constraint::Length(2), // jump key
             DashboardColumn::Project => Constraint::Length(widths.project), // auto-sized
             DashboardColumn::Worktree => Constraint::Length(widths.worktree), // auto-sized
@@ -265,7 +285,12 @@ fn build_agent_table(
             DashboardColumn::Pr => Constraint::Length(widths.pr), // auto-sized
             DashboardColumn::Status => Constraint::Length(8), // fixed (icons)
             DashboardColumn::Time => Constraint::Length(10),  // HH:MM:SS + padding
-            DashboardColumn::Title => Constraint::Fill(1),    // remaining space
+            // A Fill column absorbs slack at its own position, which would
+            // strand every column after it against the right edge. Only the
+            // trailing title takes the remaining width; elsewhere it sizes to
+            // its content like any other column, leaving the slack at the end.
+            DashboardColumn::Title if index == last_column => Constraint::Fill(1),
+            DashboardColumn::Title => Constraint::Length(widths.title),
         })
         .collect();
 
@@ -286,14 +311,7 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
     // Show the GitHub column when at least one agent has a PR or checks.
     let show_pr_column = app.has_any_github_status();
     let show_check_counts = app.config.dashboard.show_check_counts();
-    // The PR column only carries content once an agent has GitHub status
-    let columns: Vec<DashboardColumn> = app
-        .config
-        .dashboard
-        .columns()
-        .into_iter()
-        .filter(|column| *column != DashboardColumn::Pr || show_pr_column)
-        .collect();
+    let columns = visible_columns(&app.config.dashboard.columns(), show_pr_column);
 
     // Group agents by (session, window_name) to detect multi-pane windows
     let mut window_groups: BTreeMap<(String, String), Vec<usize>> = BTreeMap::new();
@@ -449,6 +467,11 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
         .clamp(4, 20) // Accommodate check icons + counts + inline timer
         + 1;
 
+    // Title width, used when the title is not the trailing column and so has to
+    // size to its content. Capped to leave room for the columns after it.
+    let titles: Vec<String> = row_data.iter().map(|r| r.title.clone()).collect();
+    let max_title_width = format::calc_column_width(&titles, 5, 60, 1);
+
     let table = build_agent_table(
         &columns,
         row_data,
@@ -457,6 +480,7 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
             worktree: max_worktree_width,
             git: max_git_width as u16,
             pr: max_pr_width as u16,
+            title: max_title_width,
         },
         format::ResourceHeaderState {
             palette: &app.palette,
@@ -796,6 +820,7 @@ mod tests {
                 worktree: 9,
                 git: 6,
                 pr: 5,
+                title: 12,
             },
             format::ResourceHeaderState {
                 palette: &palette,
@@ -835,7 +860,7 @@ mod tests {
         );
         assert_eq!(
             render_line(&REORDERED, 0),
-            "Title                                                       Status   #  Project"
+            "Title        Status   #  Project"
         );
     }
 
@@ -845,10 +870,7 @@ mod tests {
             render_line(&crate::config::DEFAULT_DASHBOARD_COLUMNS, 1),
             "1  proj     wt        +1     #7    work     00:42      the title"
         );
-        assert_eq!(
-            render_line(&REORDERED, 1),
-            "the title                                                   work     1  proj"
-        );
+        assert_eq!(render_line(&REORDERED, 1), "the title    work     1  proj");
     }
 
     #[test]
@@ -860,6 +882,39 @@ mod tests {
         assert_eq!(
             render_line(&[DashboardColumn::Worktree, DashboardColumn::Title], 1),
             "wt        the title"
+        );
+    }
+
+    #[test]
+    fn agents_table_keeps_columns_after_a_title_contiguous() {
+        // A Fill title would push Status and Project to the right edge
+        assert_eq!(
+            render_line(&[DashboardColumn::Title, DashboardColumn::Status], 0),
+            "Title        Status"
+        );
+        assert_eq!(
+            render_line(&[DashboardColumn::Title, DashboardColumn::Status], 1),
+            "the title    work"
+        );
+    }
+
+    #[test]
+    fn pr_column_hidden_until_an_agent_has_github_status() {
+        assert_eq!(
+            visible_columns(&[DashboardColumn::Worktree, DashboardColumn::Pr], false),
+            vec![DashboardColumn::Worktree]
+        );
+        assert_eq!(
+            visible_columns(&[DashboardColumn::Worktree, DashboardColumn::Pr], true),
+            vec![DashboardColumn::Worktree, DashboardColumn::Pr]
+        );
+    }
+
+    #[test]
+    fn hiding_the_pr_column_never_empties_the_table() {
+        assert_eq!(
+            visible_columns(&[DashboardColumn::Pr], false),
+            vec![DashboardColumn::Pr]
         );
     }
 }

--- a/src/command/dashboard/ui/dashboard.rs
+++ b/src/command/dashboard/ui/dashboard.rs
@@ -11,7 +11,7 @@ use ratatui::{
 use std::collections::{BTreeMap, HashSet};
 
 use crate::agent_display::strip_oc_title_prefix;
-use crate::config::DashboardColumn;
+use crate::config::AgentColumn;
 
 use super::super::app::{App, DashboardTab};
 use super::format;
@@ -179,11 +179,11 @@ struct AgentColumnWidths {
 /// Columns to render, given the configured order. The PR column carries content
 /// only once an agent has GitHub status, so it drops out until then, unless it
 /// is the only thing left to show and dropping it would blank the table.
-fn visible_columns(configured: &[DashboardColumn], show_pr_column: bool) -> Vec<DashboardColumn> {
-    let visible: Vec<DashboardColumn> = configured
+fn visible_columns(configured: &[AgentColumn], show_pr_column: bool) -> Vec<AgentColumn> {
+    let visible: Vec<AgentColumn> = configured
         .iter()
         .copied()
-        .filter(|column| *column != DashboardColumn::Pr || show_pr_column)
+        .filter(|column| *column != AgentColumn::Pr || show_pr_column)
         .collect();
 
     if visible.is_empty() {
@@ -194,17 +194,13 @@ fn visible_columns(configured: &[DashboardColumn], show_pr_column: bool) -> Vec<
 }
 
 /// Build the cell of one configured column for one agent row.
-fn agent_cell(
-    column: DashboardColumn,
-    row: &AgentRowData,
-    palette: &ThemePalette,
-) -> Cell<'static> {
+fn agent_cell(column: AgentColumn, row: &AgentRowData, palette: &ThemePalette) -> Cell<'static> {
     match column {
-        DashboardColumn::Number => {
+        AgentColumn::Number => {
             Cell::from(row.jump_key.clone()).style(Style::default().fg(palette.keycap))
         }
-        DashboardColumn::Project => Cell::from(row.project.clone()),
-        DashboardColumn::Worktree => {
+        AgentColumn::Project => Cell::from(row.project.clone()),
+        AgentColumn::Worktree => {
             let worktree_style = format::make_row_style(row.is_current, row.is_main, palette);
             // Worktree name with dimmed pane suffix
             let worktree_line = if row.worktree_suffix.is_empty() {
@@ -220,13 +216,13 @@ fn agent_cell(
             };
             Cell::from(worktree_line)
         }
-        DashboardColumn::Git => Cell::from(format::spans_to_line(row.git_spans.clone())),
-        DashboardColumn::Pr => Cell::from(format::spans_to_line(
+        AgentColumn::Git => Cell::from(format::spans_to_line(row.git_spans.clone())),
+        AgentColumn::Pr => Cell::from(format::spans_to_line(
             row.pr_spans.clone().unwrap_or_default(),
         )),
-        DashboardColumn::Status => Cell::from(format::spans_to_line(row.status_spans.clone())),
-        DashboardColumn::Time => Cell::from(row.duration_line.clone()),
-        DashboardColumn::Title => Cell::from(row.title.clone()),
+        AgentColumn::Status => Cell::from(format::spans_to_line(row.status_spans.clone())),
+        AgentColumn::Time => Cell::from(row.duration_line.clone()),
+        AgentColumn::Title => Cell::from(row.title.clone()),
     }
 }
 
@@ -234,7 +230,7 @@ fn agent_cell(
 /// all derived from `columns`, so a reordered config can never desynchronise
 /// them.
 fn build_agent_table(
-    columns: &[DashboardColumn],
+    columns: &[AgentColumn],
     row_data: Vec<AgentRowData>,
     widths: AgentColumnWidths,
     header_state: format::ResourceHeaderState<'_>,
@@ -244,14 +240,14 @@ fn build_agent_table(
     let header_cells: Vec<format::ResourceHeaderCell> = columns
         .iter()
         .map(|column| match column {
-            DashboardColumn::Number => format::ResourceHeaderCell::Plain("#"),
-            DashboardColumn::Project => format::ResourceHeaderCell::Plain("Project"),
-            DashboardColumn::Worktree => format::ResourceHeaderCell::Plain("Worktree"),
-            DashboardColumn::Git => format::ResourceHeaderCell::Git,
-            DashboardColumn::Pr => format::ResourceHeaderCell::Pr,
-            DashboardColumn::Status => format::ResourceHeaderCell::Plain("Status"),
-            DashboardColumn::Time => format::ResourceHeaderCell::Plain("Time"),
-            DashboardColumn::Title => format::ResourceHeaderCell::Plain("Title"),
+            AgentColumn::Number => format::ResourceHeaderCell::Plain("#"),
+            AgentColumn::Project => format::ResourceHeaderCell::Plain("Project"),
+            AgentColumn::Worktree => format::ResourceHeaderCell::Plain("Worktree"),
+            AgentColumn::Git => format::ResourceHeaderCell::Git,
+            AgentColumn::Pr => format::ResourceHeaderCell::Pr,
+            AgentColumn::Status => format::ResourceHeaderCell::Plain("Status"),
+            AgentColumn::Time => format::ResourceHeaderCell::Plain("Time"),
+            AgentColumn::Title => format::ResourceHeaderCell::Plain("Title"),
         })
         .collect();
 
@@ -278,19 +274,19 @@ fn build_agent_table(
         .iter()
         .enumerate()
         .map(|(index, column)| match column {
-            DashboardColumn::Number => Constraint::Length(2), // jump key
-            DashboardColumn::Project => Constraint::Length(widths.project), // auto-sized
-            DashboardColumn::Worktree => Constraint::Length(widths.worktree), // auto-sized
-            DashboardColumn::Git => Constraint::Length(widths.git), // auto-sized
-            DashboardColumn::Pr => Constraint::Length(widths.pr), // auto-sized
-            DashboardColumn::Status => Constraint::Length(8), // fixed (icons)
-            DashboardColumn::Time => Constraint::Length(10),  // HH:MM:SS + padding
+            AgentColumn::Number => Constraint::Length(2), // jump key
+            AgentColumn::Project => Constraint::Length(widths.project), // auto-sized
+            AgentColumn::Worktree => Constraint::Length(widths.worktree), // auto-sized
+            AgentColumn::Git => Constraint::Length(widths.git), // auto-sized
+            AgentColumn::Pr => Constraint::Length(widths.pr), // auto-sized
+            AgentColumn::Status => Constraint::Length(8), // fixed (icons)
+            AgentColumn::Time => Constraint::Length(10),  // HH:MM:SS + padding
             // A Fill column absorbs slack at its own position, which would
             // strand every column after it against the right edge. Only the
             // trailing title takes the remaining width; elsewhere it sizes to
             // its content like any other column, leaving the slack at the end.
-            DashboardColumn::Title if index == last_column => Constraint::Fill(1),
-            DashboardColumn::Title => Constraint::Length(widths.title),
+            AgentColumn::Title if index == last_column => Constraint::Fill(1),
+            AgentColumn::Title => Constraint::Length(widths.title),
         })
         .collect();
 
@@ -311,7 +307,7 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
     // Show the GitHub column when at least one agent has a PR or checks.
     let show_pr_column = app.has_any_github_status();
     let show_check_counts = app.config.dashboard.show_check_counts();
-    let columns = visible_columns(&app.config.dashboard.columns(), show_pr_column);
+    let columns = visible_columns(&app.config.dashboard.agent_columns(), show_pr_column);
 
     // Group agents by (session, window_name) to detect multi-pane windows
     let mut window_groups: BTreeMap<(String, String), Vec<usize>> = BTreeMap::new();
@@ -810,7 +806,7 @@ mod tests {
     }
 
     /// Render the agents table and return one line of the output buffer.
-    fn render_line(columns: &[DashboardColumn], line: u16) -> String {
+    fn render_line(columns: &[AgentColumn], line: u16) -> String {
         let palette = palette();
         let table = build_agent_table(
             columns,
@@ -845,17 +841,17 @@ mod tests {
     }
 
     /// Reordered list, including the `#` jump key away from its usual place.
-    const REORDERED: [DashboardColumn; 4] = [
-        DashboardColumn::Title,
-        DashboardColumn::Status,
-        DashboardColumn::Number,
-        DashboardColumn::Project,
+    const REORDERED: [AgentColumn; 4] = [
+        AgentColumn::Title,
+        AgentColumn::Status,
+        AgentColumn::Number,
+        AgentColumn::Project,
     ];
 
     #[test]
     fn agents_table_header_follows_column_order() {
         assert_eq!(
-            render_line(&crate::config::DEFAULT_DASHBOARD_COLUMNS, 0),
+            render_line(&crate::config::DEFAULT_AGENT_COLUMNS, 0),
             "#  Project  Worktree  Git    PR    Status   Time       Title"
         );
         assert_eq!(
@@ -867,7 +863,7 @@ mod tests {
     #[test]
     fn agents_table_rows_follow_column_order() {
         assert_eq!(
-            render_line(&crate::config::DEFAULT_DASHBOARD_COLUMNS, 1),
+            render_line(&crate::config::DEFAULT_AGENT_COLUMNS, 1),
             "1  proj     wt        +1     #7    work     00:42      the title"
         );
         assert_eq!(render_line(&REORDERED, 1), "the title    work     1  proj");
@@ -876,11 +872,11 @@ mod tests {
     #[test]
     fn agents_table_omits_unlisted_columns() {
         assert_eq!(
-            render_line(&[DashboardColumn::Worktree, DashboardColumn::Title], 0),
+            render_line(&[AgentColumn::Worktree, AgentColumn::Title], 0),
             "Worktree  Title"
         );
         assert_eq!(
-            render_line(&[DashboardColumn::Worktree, DashboardColumn::Title], 1),
+            render_line(&[AgentColumn::Worktree, AgentColumn::Title], 1),
             "wt        the title"
         );
     }
@@ -889,11 +885,11 @@ mod tests {
     fn agents_table_keeps_columns_after_a_title_contiguous() {
         // A Fill title would push Status and Project to the right edge
         assert_eq!(
-            render_line(&[DashboardColumn::Title, DashboardColumn::Status], 0),
+            render_line(&[AgentColumn::Title, AgentColumn::Status], 0),
             "Title        Status"
         );
         assert_eq!(
-            render_line(&[DashboardColumn::Title, DashboardColumn::Status], 1),
+            render_line(&[AgentColumn::Title, AgentColumn::Status], 1),
             "the title    work"
         );
     }
@@ -901,20 +897,20 @@ mod tests {
     #[test]
     fn pr_column_hidden_until_an_agent_has_github_status() {
         assert_eq!(
-            visible_columns(&[DashboardColumn::Worktree, DashboardColumn::Pr], false),
-            vec![DashboardColumn::Worktree]
+            visible_columns(&[AgentColumn::Worktree, AgentColumn::Pr], false),
+            vec![AgentColumn::Worktree]
         );
         assert_eq!(
-            visible_columns(&[DashboardColumn::Worktree, DashboardColumn::Pr], true),
-            vec![DashboardColumn::Worktree, DashboardColumn::Pr]
+            visible_columns(&[AgentColumn::Worktree, AgentColumn::Pr], true),
+            vec![AgentColumn::Worktree, AgentColumn::Pr]
         );
     }
 
     #[test]
     fn hiding_the_pr_column_never_empties_the_table() {
         assert_eq!(
-            visible_columns(&[DashboardColumn::Pr], false),
-            vec![DashboardColumn::Pr]
+            visible_columns(&[AgentColumn::Pr], false),
+            vec![AgentColumn::Pr]
         );
     }
 }

--- a/src/command/dashboard/ui/format.rs
+++ b/src/command/dashboard/ui/format.rs
@@ -320,37 +320,39 @@ pub(crate) struct ResourceHeaderState<'a> {
     pub pr_fetching: bool,
 }
 
-/// Build the shared prefix columns for agent and worktree resource tables.
+/// A header cell of an agent or worktree resource table.
+pub(crate) enum ResourceHeaderCell {
+    /// Plain label with no fetch state.
+    Plain(&'static str),
+    /// `Git` label, spinning while git data is being fetched.
+    Git,
+    /// `PR` label, spinning while GitHub data is being fetched.
+    Pr,
+}
+
+/// Build the header row for agent and worktree resource tables.
 pub(crate) fn resource_table_header(
     state: ResourceHeaderState<'_>,
-    show_pr_column: bool,
-    trailing_columns: &[&'static str],
+    columns: &[ResourceHeaderCell],
 ) -> Row<'static> {
-    let git_header = build_column_header(
-        "Git",
-        state.git_fetching,
-        state.spinner_frame,
-        state.palette,
-    );
     let header_style = Style::default().fg(state.palette.header).bold();
-    let mut header_cells = vec![
-        Cell::from("#").style(header_style),
-        Cell::from("Project").style(header_style),
-        Cell::from("Worktree").style(header_style),
-        Cell::from(git_header),
-    ];
+    let header_cells = columns.iter().map(|column| match column {
+        ResourceHeaderCell::Plain(label) => Cell::from(*label).style(header_style),
+        ResourceHeaderCell::Git => Cell::from(build_column_header(
+            "Git",
+            state.git_fetching,
+            state.spinner_frame,
+            state.palette,
+        )),
+        ResourceHeaderCell::Pr => Cell::from(build_column_header(
+            "PR",
+            state.pr_fetching,
+            state.spinner_frame,
+            state.palette,
+        )),
+    });
 
-    if show_pr_column {
-        let pr_header =
-            build_column_header("PR", state.pr_fetching, state.spinner_frame, state.palette);
-        header_cells.push(Cell::from(pr_header));
-    }
-
-    for column in trailing_columns {
-        header_cells.push(Cell::from(*column).style(header_style));
-    }
-
-    Row::new(header_cells).height(1)
+    Row::new(header_cells.collect::<Vec<_>>()).height(1)
 }
 
 /// Bordered panel block with dashboard header styling.

--- a/src/command/dashboard/ui/worktree.rs
+++ b/src/command/dashboard/ui/worktree.rs
@@ -12,7 +12,8 @@ use super::super::agent;
 use super::super::app::App;
 use super::format;
 use super::format::{
-    AgentStatusFormat, format_agent_status_summary, format_git_status, format_pr_status, truncate,
+    AgentStatusFormat, ResourceHeaderCell, format_agent_status_summary, format_git_status,
+    format_pr_status, truncate,
 };
 
 /// Render the worktree table in the given area.
@@ -30,6 +31,21 @@ pub fn render_worktree_table(f: &mut Frame, app: &mut App, area: Rect) {
         worktree.pr_info.is_some() || app.get_checks_for_worktree(worktree).is_some()
     });
 
+    let mut header_cells = vec![
+        ResourceHeaderCell::Plain("#"),
+        ResourceHeaderCell::Plain("Project"),
+        ResourceHeaderCell::Plain("Worktree"),
+        ResourceHeaderCell::Git,
+    ];
+    if show_pr_column {
+        header_cells.push(ResourceHeaderCell::Pr);
+    }
+    header_cells.extend([
+        ResourceHeaderCell::Plain("Mux"),
+        ResourceHeaderCell::Plain("Age"),
+        ResourceHeaderCell::Plain("Agent"),
+    ]);
+
     let header = format::resource_table_header(
         format::ResourceHeaderState {
             palette: &app.palette,
@@ -39,8 +55,7 @@ pub fn render_worktree_table(f: &mut Frame, app: &mut App, area: Rect) {
                 .load(std::sync::atomic::Ordering::Relaxed),
             pr_fetching: app.is_pr_fetching(),
         },
-        show_pr_column,
-        &["Mux", "Age", "Agent"],
+        &header_cells,
     );
 
     // Pre-compute row data

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,9 +92,9 @@ pub struct DashboardConfig {
     #[serde(default)]
     pub show_check_counts: Option<bool>,
 
-    /// Order of the trailing columns in the agents table, after the fixed
-    /// `#`, `Project`, `Worktree`, `Git` and optional `PR` columns.
-    /// Default: status, time, title.
+    /// Columns of the agents table, in display order, following the `#` jump
+    /// key column. Columns left out of the list are not rendered.
+    /// Default: project, worktree, git, pr, status, time, title.
     pub columns: Option<Vec<DashboardColumn>>,
 }
 
@@ -102,6 +102,15 @@ pub struct DashboardConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DashboardColumn {
+    /// Project name.
+    Project,
+    /// Worktree name, with a pane suffix for multi-pane windows.
+    Worktree,
+    /// Git status of the worktree.
+    Git,
+    /// Pull request and check status. Rendered only while at least one agent
+    /// has GitHub status to show.
+    Pr,
     /// Agent status (icons).
     Status,
     /// Time elapsed in the current status.
@@ -110,8 +119,12 @@ pub enum DashboardColumn {
     Title,
 }
 
-/// Trailing columns used when the config does not set `dashboard.columns`.
-pub const DEFAULT_DASHBOARD_COLUMNS: [DashboardColumn; 3] = [
+/// Columns used when the config does not set `dashboard.columns`.
+pub const DEFAULT_DASHBOARD_COLUMNS: [DashboardColumn; 7] = [
+    DashboardColumn::Project,
+    DashboardColumn::Worktree,
+    DashboardColumn::Git,
+    DashboardColumn::Pr,
     DashboardColumn::Status,
     DashboardColumn::Time,
     DashboardColumn::Title,
@@ -134,9 +147,9 @@ impl DashboardConfig {
         self.preview_size.unwrap_or(60).clamp(10, 90)
     }
 
-    /// Trailing columns of the agents table, in display order.
-    /// Duplicates are dropped so a column is never rendered twice, and an
-    /// empty or absent list falls back to the default order.
+    /// Columns of the agents table, in display order, following the `#` jump
+    /// key column. Duplicates are dropped so a column is never rendered twice,
+    /// and an empty or absent list falls back to the default order.
     pub fn columns(&self) -> Vec<DashboardColumn> {
         let Some(configured) = self.columns.as_ref() else {
             return DEFAULT_DASHBOARD_COLUMNS.to_vec();
@@ -3041,10 +3054,13 @@ pub const EXAMPLE_PROJECT_CONFIG: &str = r#"# workmux project configuration
 # Actions for dashboard keybindings (c = commit, m = merge).
 # Values are sent to the agent's pane. Use ! prefix for shell commands.
 # Preview size (10-90): larger = more preview, less table. Use +/- keys to adjust.
+# Columns of the agents table, in display order, after the fixed # jump key.
+# Omit a column to hide it: project, worktree, git, pr, status, time, title.
 # dashboard:
 #   commit: "Commit staged changes with a descriptive message"
 #   merge: "!workmux merge"
 #   preview_size: 60
+#   columns: [project, worktree, git, pr, status, time, title]
 
 #-------------------------------------------------------------------------------
 # Sidebar
@@ -3211,9 +3227,9 @@ mod tests {
 
     use super::{
         AgentEnvValue, AgentIconConfig, AgentIconDetails, AllowedDomainDetails, AllowedDomainEntry,
-        Config, ContainerConfig, ContainerDevice, DashboardColumn, ExtraMount, FileConfig,
-        LayoutConfig, LimaConfig, NetworkConfig, NetworkPolicy, PaneConfig, SandboxConfig,
-        SandboxRuntime, SandboxTarget, SidebarHeight, SidebarPosition, SidebarWidth,
+        Config, ContainerConfig, ContainerDevice, DEFAULT_DASHBOARD_COLUMNS, DashboardColumn,
+        ExtraMount, FileConfig, LayoutConfig, LimaConfig, NetworkConfig, NetworkPolicy, PaneConfig,
+        SandboxConfig, SandboxRuntime, SandboxTarget, SidebarHeight, SidebarPosition, SidebarWidth,
         SplitDirection, ToolchainMode, WindowPlacement, is_agent_command, validate_domain,
         validate_group_add_entry, validate_layouts_config,
     };
@@ -3226,6 +3242,10 @@ mod tests {
         assert_eq!(
             config.dashboard.columns(),
             vec![
+                DashboardColumn::Project,
+                DashboardColumn::Worktree,
+                DashboardColumn::Git,
+                DashboardColumn::Pr,
                 DashboardColumn::Status,
                 DashboardColumn::Time,
                 DashboardColumn::Title
@@ -3235,13 +3255,19 @@ mod tests {
 
     #[test]
     fn dashboard_columns_follow_configured_order() {
-        let config: Config = serde_yaml::from_str("dashboard:\n  columns: [status, title, time]\n")
-            .expect("config parses");
+        let config: Config = serde_yaml::from_str(
+            "dashboard:\n  columns: [title, status, worktree, git, pr, project, time]\n",
+        )
+        .expect("config parses");
         assert_eq!(
             config.dashboard.columns(),
             vec![
-                DashboardColumn::Status,
                 DashboardColumn::Title,
+                DashboardColumn::Status,
+                DashboardColumn::Worktree,
+                DashboardColumn::Git,
+                DashboardColumn::Pr,
+                DashboardColumn::Project,
                 DashboardColumn::Time
             ]
         );
@@ -3262,7 +3288,29 @@ mod tests {
     fn dashboard_columns_empty_list_falls_back_to_default() {
         let config: Config =
             serde_yaml::from_str("dashboard:\n  columns: []\n").expect("config parses");
-        assert_eq!(config.dashboard.columns().len(), 3);
+        assert_eq!(config.dashboard.columns(), DEFAULT_DASHBOARD_COLUMNS);
+    }
+
+    #[test]
+    fn dashboard_columns_project_overrides_global() {
+        let global: Config = serde_yaml::from_str("dashboard:\n  columns: [status, title]\n")
+            .expect("config parses");
+        let project: Config = serde_yaml::from_str("dashboard:\n  columns: [title, status]\n")
+            .expect("config parses");
+        assert_eq!(
+            global.merge(project).dashboard.columns(),
+            vec![DashboardColumn::Title, DashboardColumn::Status]
+        );
+    }
+
+    #[test]
+    fn dashboard_columns_inherit_global_when_project_unset() {
+        let global: Config = serde_yaml::from_str("dashboard:\n  columns: [status, title]\n")
+            .expect("config parses");
+        assert_eq!(
+            global.merge(Config::default()).dashboard.columns(),
+            vec![DashboardColumn::Status, DashboardColumn::Title]
+        );
     }
 
     fn cfg(edit: impl FnOnce(&mut Config)) -> Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,9 +92,9 @@ pub struct DashboardConfig {
     #[serde(default)]
     pub show_check_counts: Option<bool>,
 
-    /// Columns of the agents table, in display order, following the `#` jump
-    /// key column. Columns left out of the list are not rendered.
-    /// Default: project, worktree, git, pr, status, time, title.
+    /// Columns of the agents table, in display order. Columns left out of the
+    /// list are not rendered.
+    /// Default: number, project, worktree, git, pr, status, time, title.
     pub columns: Option<Vec<DashboardColumn>>,
 }
 
@@ -102,6 +102,8 @@ pub struct DashboardConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DashboardColumn {
+    /// Jump key of the row, shown under the `#` header.
+    Number,
     /// Project name.
     Project,
     /// Worktree name, with a pane suffix for multi-pane windows.
@@ -120,7 +122,8 @@ pub enum DashboardColumn {
 }
 
 /// Columns used when the config does not set `dashboard.columns`.
-pub const DEFAULT_DASHBOARD_COLUMNS: [DashboardColumn; 7] = [
+pub const DEFAULT_DASHBOARD_COLUMNS: [DashboardColumn; 8] = [
+    DashboardColumn::Number,
     DashboardColumn::Project,
     DashboardColumn::Worktree,
     DashboardColumn::Git,
@@ -147,9 +150,9 @@ impl DashboardConfig {
         self.preview_size.unwrap_or(60).clamp(10, 90)
     }
 
-    /// Columns of the agents table, in display order, following the `#` jump
-    /// key column. Duplicates are dropped so a column is never rendered twice,
-    /// and an empty or absent list falls back to the default order.
+    /// Columns of the agents table, in display order. Duplicates are dropped so
+    /// a column is never rendered twice, and an empty or absent list falls back
+    /// to the default order.
     pub fn columns(&self) -> Vec<DashboardColumn> {
         let Some(configured) = self.columns.as_ref() else {
             return DEFAULT_DASHBOARD_COLUMNS.to_vec();
@@ -3054,13 +3057,13 @@ pub const EXAMPLE_PROJECT_CONFIG: &str = r#"# workmux project configuration
 # Actions for dashboard keybindings (c = commit, m = merge).
 # Values are sent to the agent's pane. Use ! prefix for shell commands.
 # Preview size (10-90): larger = more preview, less table. Use +/- keys to adjust.
-# Columns of the agents table, in display order, after the fixed # jump key.
-# Omit a column to hide it: project, worktree, git, pr, status, time, title.
+# Columns of the agents table, in display order. Omit a column to hide it:
+# number, project, worktree, git, pr, status, time, title.
 # dashboard:
 #   commit: "Commit staged changes with a descriptive message"
 #   merge: "!workmux merge"
 #   preview_size: 60
-#   columns: [project, worktree, git, pr, status, time, title]
+#   columns: [number, project, worktree, git, pr, status, time, title]
 
 #-------------------------------------------------------------------------------
 # Sidebar
@@ -3242,6 +3245,7 @@ mod tests {
         assert_eq!(
             config.dashboard.columns(),
             vec![
+                DashboardColumn::Number,
                 DashboardColumn::Project,
                 DashboardColumn::Worktree,
                 DashboardColumn::Git,
@@ -3256,7 +3260,7 @@ mod tests {
     #[test]
     fn dashboard_columns_follow_configured_order() {
         let config: Config = serde_yaml::from_str(
-            "dashboard:\n  columns: [title, status, worktree, git, pr, project, time]\n",
+            "dashboard:\n  columns: [title, status, number, worktree, git, pr, project, time]\n",
         )
         .expect("config parses");
         assert_eq!(
@@ -3264,6 +3268,7 @@ mod tests {
             vec![
                 DashboardColumn::Title,
                 DashboardColumn::Status,
+                DashboardColumn::Number,
                 DashboardColumn::Worktree,
                 DashboardColumn::Git,
                 DashboardColumn::Pr,

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,7 +91,31 @@ pub struct DashboardConfig {
     /// Show check pass/total counts alongside check icon (default: false)
     #[serde(default)]
     pub show_check_counts: Option<bool>,
+
+    /// Order of the trailing columns in the agents table, after the fixed
+    /// `#`, `Project`, `Worktree`, `Git` and optional `PR` columns.
+    /// Default: status, time, title.
+    pub columns: Option<Vec<DashboardColumn>>,
 }
+
+/// A configurable column of the dashboard agents table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DashboardColumn {
+    /// Agent status (icons).
+    Status,
+    /// Time elapsed in the current status.
+    Time,
+    /// Agent pane title.
+    Title,
+}
+
+/// Trailing columns used when the config does not set `dashboard.columns`.
+pub const DEFAULT_DASHBOARD_COLUMNS: [DashboardColumn; 3] = [
+    DashboardColumn::Status,
+    DashboardColumn::Time,
+    DashboardColumn::Title,
+];
 
 impl DashboardConfig {
     pub fn commit(&self) -> &str {
@@ -108,6 +132,28 @@ impl DashboardConfig {
     /// Default: 60
     pub fn preview_size(&self) -> u8 {
         self.preview_size.unwrap_or(60).clamp(10, 90)
+    }
+
+    /// Trailing columns of the agents table, in display order.
+    /// Duplicates are dropped so a column is never rendered twice, and an
+    /// empty or absent list falls back to the default order.
+    pub fn columns(&self) -> Vec<DashboardColumn> {
+        let Some(configured) = self.columns.as_ref() else {
+            return DEFAULT_DASHBOARD_COLUMNS.to_vec();
+        };
+
+        let mut seen = Vec::new();
+        for column in configured {
+            if !seen.contains(column) {
+                seen.push(*column);
+            }
+        }
+
+        if seen.is_empty() {
+            DEFAULT_DASHBOARD_COLUMNS.to_vec()
+        } else {
+            seen
+        }
     }
 
     /// Whether to show check pass/total counts alongside check icons.
@@ -2517,6 +2563,11 @@ impl Config {
                 .dashboard
                 .show_check_counts
                 .or(self.dashboard.show_check_counts),
+            columns: project
+                .dashboard
+                .columns
+                .clone()
+                .or_else(|| self.dashboard.columns.clone()),
         };
 
         // Sidebar config: per-field override
@@ -3160,14 +3211,59 @@ mod tests {
 
     use super::{
         AgentEnvValue, AgentIconConfig, AgentIconDetails, AllowedDomainDetails, AllowedDomainEntry,
-        Config, ContainerConfig, ContainerDevice, ExtraMount, FileConfig, LayoutConfig, LimaConfig,
-        NetworkConfig, NetworkPolicy, PaneConfig, SandboxConfig, SandboxRuntime, SandboxTarget,
-        SidebarHeight, SidebarPosition, SidebarWidth, SplitDirection, ToolchainMode,
-        WindowPlacement, is_agent_command, validate_domain, validate_group_add_entry,
-        validate_layouts_config,
+        Config, ContainerConfig, ContainerDevice, DashboardColumn, ExtraMount, FileConfig,
+        LayoutConfig, LimaConfig, NetworkConfig, NetworkPolicy, PaneConfig, SandboxConfig,
+        SandboxRuntime, SandboxTarget, SidebarHeight, SidebarPosition, SidebarWidth,
+        SplitDirection, ToolchainMode, WindowPlacement, is_agent_command, validate_domain,
+        validate_group_add_entry, validate_layouts_config,
     };
     use crate::test_support;
     use tempfile::TempDir;
+
+    #[test]
+    fn dashboard_columns_default_when_unset() {
+        let config = Config::default();
+        assert_eq!(
+            config.dashboard.columns(),
+            vec![
+                DashboardColumn::Status,
+                DashboardColumn::Time,
+                DashboardColumn::Title
+            ]
+        );
+    }
+
+    #[test]
+    fn dashboard_columns_follow_configured_order() {
+        let config: Config = serde_yaml::from_str("dashboard:\n  columns: [status, title, time]\n")
+            .expect("config parses");
+        assert_eq!(
+            config.dashboard.columns(),
+            vec![
+                DashboardColumn::Status,
+                DashboardColumn::Title,
+                DashboardColumn::Time
+            ]
+        );
+    }
+
+    #[test]
+    fn dashboard_columns_drop_duplicates_and_allow_omitting() {
+        let config: Config =
+            serde_yaml::from_str("dashboard:\n  columns: [title, title, status]\n")
+                .expect("config parses");
+        assert_eq!(
+            config.dashboard.columns(),
+            vec![DashboardColumn::Title, DashboardColumn::Status]
+        );
+    }
+
+    #[test]
+    fn dashboard_columns_empty_list_falls_back_to_default() {
+        let config: Config =
+            serde_yaml::from_str("dashboard:\n  columns: []\n").expect("config parses");
+        assert_eq!(config.dashboard.columns().len(), 3);
+    }
 
     fn cfg(edit: impl FnOnce(&mut Config)) -> Config {
         let mut config = Config::default();

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,13 +95,13 @@ pub struct DashboardConfig {
     /// Columns of the agents table, in display order. Columns left out of the
     /// list are not rendered.
     /// Default: number, project, worktree, git, pr, status, time, title.
-    pub columns: Option<Vec<DashboardColumn>>,
+    pub agent_columns: Option<Vec<AgentColumn>>,
 }
 
 /// A configurable column of the dashboard agents table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
-pub enum DashboardColumn {
+pub enum AgentColumn {
     /// Jump key of the row, shown under the `#` header.
     Number,
     /// Project name.
@@ -121,16 +121,16 @@ pub enum DashboardColumn {
     Title,
 }
 
-/// Columns used when the config does not set `dashboard.columns`.
-pub const DEFAULT_DASHBOARD_COLUMNS: [DashboardColumn; 8] = [
-    DashboardColumn::Number,
-    DashboardColumn::Project,
-    DashboardColumn::Worktree,
-    DashboardColumn::Git,
-    DashboardColumn::Pr,
-    DashboardColumn::Status,
-    DashboardColumn::Time,
-    DashboardColumn::Title,
+/// Columns used when the config does not set `dashboard.agent_columns`.
+pub const DEFAULT_AGENT_COLUMNS: [AgentColumn; 8] = [
+    AgentColumn::Number,
+    AgentColumn::Project,
+    AgentColumn::Worktree,
+    AgentColumn::Git,
+    AgentColumn::Pr,
+    AgentColumn::Status,
+    AgentColumn::Time,
+    AgentColumn::Title,
 ];
 
 impl DashboardConfig {
@@ -153,9 +153,9 @@ impl DashboardConfig {
     /// Columns of the agents table, in display order. Duplicates are dropped so
     /// a column is never rendered twice, and an empty or absent list falls back
     /// to the default order.
-    pub fn columns(&self) -> Vec<DashboardColumn> {
-        let Some(configured) = self.columns.as_ref() else {
-            return DEFAULT_DASHBOARD_COLUMNS.to_vec();
+    pub fn agent_columns(&self) -> Vec<AgentColumn> {
+        let Some(configured) = self.agent_columns.as_ref() else {
+            return DEFAULT_AGENT_COLUMNS.to_vec();
         };
 
         let mut seen = Vec::new();
@@ -166,7 +166,7 @@ impl DashboardConfig {
         }
 
         if seen.is_empty() {
-            DEFAULT_DASHBOARD_COLUMNS.to_vec()
+            DEFAULT_AGENT_COLUMNS.to_vec()
         } else {
             seen
         }
@@ -2579,11 +2579,11 @@ impl Config {
                 .dashboard
                 .show_check_counts
                 .or(self.dashboard.show_check_counts),
-            columns: project
+            agent_columns: project
                 .dashboard
-                .columns
+                .agent_columns
                 .clone()
-                .or_else(|| self.dashboard.columns.clone()),
+                .or_else(|| self.dashboard.agent_columns.clone()),
         };
 
         // Sidebar config: per-field override
@@ -3063,7 +3063,7 @@ pub const EXAMPLE_PROJECT_CONFIG: &str = r#"# workmux project configuration
 #   commit: "Commit staged changes with a descriptive message"
 #   merge: "!workmux merge"
 #   preview_size: 60
-#   columns: [number, project, worktree, git, pr, status, time, title]
+#   agent_columns: [number, project, worktree, git, pr, status, time, title]
 
 #-------------------------------------------------------------------------------
 # Sidebar
@@ -3229,8 +3229,8 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{
-        AgentEnvValue, AgentIconConfig, AgentIconDetails, AllowedDomainDetails, AllowedDomainEntry,
-        Config, ContainerConfig, ContainerDevice, DEFAULT_DASHBOARD_COLUMNS, DashboardColumn,
+        AgentColumn, AgentEnvValue, AgentIconConfig, AgentIconDetails, AllowedDomainDetails,
+        AllowedDomainEntry, Config, ContainerConfig, ContainerDevice, DEFAULT_AGENT_COLUMNS,
         ExtraMount, FileConfig, LayoutConfig, LimaConfig, NetworkConfig, NetworkPolicy, PaneConfig,
         SandboxConfig, SandboxRuntime, SandboxTarget, SidebarHeight, SidebarPosition, SidebarWidth,
         SplitDirection, ToolchainMode, WindowPlacement, is_agent_command, validate_domain,
@@ -3240,81 +3240,82 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn dashboard_columns_default_when_unset() {
+    fn agent_columns_default_when_unset() {
         let config = Config::default();
         assert_eq!(
-            config.dashboard.columns(),
+            config.dashboard.agent_columns(),
             vec![
-                DashboardColumn::Number,
-                DashboardColumn::Project,
-                DashboardColumn::Worktree,
-                DashboardColumn::Git,
-                DashboardColumn::Pr,
-                DashboardColumn::Status,
-                DashboardColumn::Time,
-                DashboardColumn::Title
+                AgentColumn::Number,
+                AgentColumn::Project,
+                AgentColumn::Worktree,
+                AgentColumn::Git,
+                AgentColumn::Pr,
+                AgentColumn::Status,
+                AgentColumn::Time,
+                AgentColumn::Title
             ]
         );
     }
 
     #[test]
-    fn dashboard_columns_follow_configured_order() {
+    fn agent_columns_follow_configured_order() {
         let config: Config = serde_yaml::from_str(
-            "dashboard:\n  columns: [title, status, number, worktree, git, pr, project, time]\n",
+            "dashboard:\n  agent_columns: [title, status, number, worktree, git, pr, project, time]\n",
         )
         .expect("config parses");
         assert_eq!(
-            config.dashboard.columns(),
+            config.dashboard.agent_columns(),
             vec![
-                DashboardColumn::Title,
-                DashboardColumn::Status,
-                DashboardColumn::Number,
-                DashboardColumn::Worktree,
-                DashboardColumn::Git,
-                DashboardColumn::Pr,
-                DashboardColumn::Project,
-                DashboardColumn::Time
+                AgentColumn::Title,
+                AgentColumn::Status,
+                AgentColumn::Number,
+                AgentColumn::Worktree,
+                AgentColumn::Git,
+                AgentColumn::Pr,
+                AgentColumn::Project,
+                AgentColumn::Time
             ]
         );
     }
 
     #[test]
-    fn dashboard_columns_drop_duplicates_and_allow_omitting() {
+    fn agent_columns_drop_duplicates_and_allow_omitting() {
         let config: Config =
-            serde_yaml::from_str("dashboard:\n  columns: [title, title, status]\n")
+            serde_yaml::from_str("dashboard:\n  agent_columns: [title, title, status]\n")
                 .expect("config parses");
         assert_eq!(
-            config.dashboard.columns(),
-            vec![DashboardColumn::Title, DashboardColumn::Status]
+            config.dashboard.agent_columns(),
+            vec![AgentColumn::Title, AgentColumn::Status]
         );
     }
 
     #[test]
-    fn dashboard_columns_empty_list_falls_back_to_default() {
+    fn agent_columns_empty_list_falls_back_to_default() {
         let config: Config =
-            serde_yaml::from_str("dashboard:\n  columns: []\n").expect("config parses");
-        assert_eq!(config.dashboard.columns(), DEFAULT_DASHBOARD_COLUMNS);
+            serde_yaml::from_str("dashboard:\n  agent_columns: []\n").expect("config parses");
+        assert_eq!(config.dashboard.agent_columns(), DEFAULT_AGENT_COLUMNS);
     }
 
     #[test]
-    fn dashboard_columns_project_overrides_global() {
-        let global: Config = serde_yaml::from_str("dashboard:\n  columns: [status, title]\n")
+    fn agent_columns_project_overrides_global() {
+        let global: Config = serde_yaml::from_str("dashboard:\n  agent_columns: [status, title]\n")
             .expect("config parses");
-        let project: Config = serde_yaml::from_str("dashboard:\n  columns: [title, status]\n")
-            .expect("config parses");
+        let project: Config =
+            serde_yaml::from_str("dashboard:\n  agent_columns: [title, status]\n")
+                .expect("config parses");
         assert_eq!(
-            global.merge(project).dashboard.columns(),
-            vec![DashboardColumn::Title, DashboardColumn::Status]
+            global.merge(project).dashboard.agent_columns(),
+            vec![AgentColumn::Title, AgentColumn::Status]
         );
     }
 
     #[test]
-    fn dashboard_columns_inherit_global_when_project_unset() {
-        let global: Config = serde_yaml::from_str("dashboard:\n  columns: [status, title]\n")
+    fn agent_columns_inherit_global_when_project_unset() {
+        let global: Config = serde_yaml::from_str("dashboard:\n  agent_columns: [status, title]\n")
             .expect("config parses");
         assert_eq!(
-            global.merge(Config::default()).dashboard.columns(),
-            vec![DashboardColumn::Status, DashboardColumn::Title]
+            global.merge(Config::default()).dashboard.agent_columns(),
+            vec![AgentColumn::Status, AgentColumn::Title]
         );
     }
 


### PR DESCRIPTION
## Why

The agents table renders `Status`, `Time` and `Title` in a fixed order. Reading the title — usually the interesting part when scanning a list of agents — means skipping over an elapsed timer that sits between the status and it. The sidebar already lets its fields be arranged freely through `sidebar.templates`, so this brings the same idea to the dashboard in the smallest form that fits the table.

## What

New `dashboard.columns` option, listing the columns that follow the fixed `#`, `Project`, `Worktree`, `Git` and optional `PR` ones:

```yaml
dashboard:
  columns: [status, title, time]
```

Any of `status`, `time` and `title`, in any order. A column left out is not rendered, so `columns: [status, title]` drops the timer entirely. Duplicates are ignored and an empty list falls back to the default, so a malformed config degrades to today's layout rather than to a broken table.

Header cells, row cells and width constraints previously repeated the same order in three places. They now all derive from the configured list, so they cannot drift apart — the `Fill(1)` that lets `Title` take the remaining width follows the column wherever it is placed.

Defaults are unchanged: without the option the table renders exactly as before.

## Testing

- Four unit tests covering the default, a reordered list, duplicate handling and the empty-list fallback.
- Full suite green (1421 passed), `cargo fmt --check` clean, and `cargo clippy --all-targets` reports nothing in the touched files.
- Checked in a real terminal with `columns: [status, title, time]`: header and rows both follow the new order and the title keeps the flexible width.