### PR TITLE
dashboard: add close_on_jump to keep the dashboard open after a jump

### DIFF
--- a/docs/src/content/docs/guide/dashboard/configuration.md
+++ b/docs/src/content/docs/guide/dashboard/configuration.md
@@ -11,6 +11,7 @@ dashboard:
   merge: "!workmux merge"
   preview_size: 60
   agent_columns: [number, project, worktree, git, pr, status, time, title]
+  close_on_jump: true
 ```
 
 The `commit` and `merge` values are text sent to the agent's pane. Use the `!` prefix to run shell commands (supported by Claude, Gemini, and other agents).
@@ -23,6 +24,18 @@ The `commit` and `merge` values are text sent to the agent's pane. Use the `!` p
 | `merge`         | `!workmux merge`                                            | Shell command via agent                   |
 | `preview_size`  | `60`                                                        | Preview pane height as percentage (10-90) |
 | `agent_columns` | `[number, project, worktree, git, pr, status, time, title]` | Agents table columns, in display order    |
+| `close_on_jump` | `true`                                                      | Close the dashboard after a jump          |
+
+## Staying open after a jump
+
+Jumping to an agent or worktree closes the dashboard. This includes `Enter`, `1`-`9`, `Bksp`, command-palette jumps, and double-clicking a row. Set `close_on_jump: false` to keep the dashboard open while moving between agents and worktrees:
+
+```yaml
+dashboard:
+  close_on_jump: false
+```
+
+The jump still updates the pane history used by `Bksp`. The `p` peek action always keeps the dashboard open and does not update pane history. Multiplexers such as Zellij that keep the dashboard open after jumps retain that behavior regardless of this setting.
 
 ## Columns
 

--- a/docs/src/content/docs/guide/dashboard/index.mdx
+++ b/docs/src/content/docs/guide/dashboard/index.mdx
@@ -49,31 +49,33 @@ The dashboard has two views, toggled with `Tab`:
 
 ## Keybindings (Agents view)
 
-| Key       | Action                                  |
-| --------- | --------------------------------------- |
-| `1`-`9`   | Quick jump to agent (closes dashboard)  |
-| `Tab`     | Switch to worktree view                 |
-| `Bksp`    | Toggle between current and last agent   |
-| `d`       | View diff (opens WIP view)              |
-| `o`       | Open PR in browser                      |
-| `O`       | Open PR checks in browser               |
-| `p`       | Peek at agent (dashboard stays open)    |
-| `s`       | Cycle sort mode                         |
-| `F`       | Toggle session filter                   |
-| `f`       | Toggle stale filter (show/hide stale)   |
-| `i`       | Enter input mode (type to agent)        |
-| `X`       | Kill selected agent                     |
-| `R`       | Sweep (bulk remove merged/gone)         |
-| `Ctrl+u`  | Scroll preview up                       |
-| `Ctrl+d`  | Scroll preview down                     |
-| `+`/`-`   | Resize preview pane                     |
-| `Enter`   | Go to selected agent (closes dashboard) |
-| `/`       | Filter agents by name                   |
-| `j`/`k`   | Navigate up/down                        |
-| `T`       | Cycle theme                             |
-| `:`       | Open command palette                    |
-| `q`/`Esc` | Quit                                    |
-| `Ctrl+c`  | Quit (works from any view)              |
+| Key       | Action                                |
+| --------- | ------------------------------------- |
+| `1`-`9`   | Quick jump to agent                   |
+| `Tab`     | Switch to worktree view               |
+| `Bksp`    | Toggle between current and last agent |
+| `d`       | View diff (opens WIP view)            |
+| `o`       | Open PR in browser                    |
+| `O`       | Open PR checks in browser             |
+| `p`       | Peek at agent (dashboard stays open)  |
+| `s`       | Cycle sort mode                       |
+| `F`       | Toggle session filter                 |
+| `f`       | Toggle stale filter (show/hide stale) |
+| `i`       | Enter input mode (type to agent)      |
+| `X`       | Kill selected agent                   |
+| `R`       | Sweep (bulk remove merged/gone)       |
+| `Ctrl+u`  | Scroll preview up                     |
+| `Ctrl+d`  | Scroll preview down                   |
+| `+`/`-`   | Resize preview pane                   |
+| `Enter`   | Go to selected agent                  |
+| `/`       | Filter agents by name                 |
+| `j`/`k`   | Navigate up/down                      |
+| `T`       | Cycle theme                           |
+| `:`       | Open command palette                  |
+| `q`/`Esc` | Quit                                  |
+| `Ctrl+c`  | Quit (works from any view)            |
+
+Agent jumps close the dashboard by default. See [`close_on_jump`](/guide/dashboard/configuration/#staying-open-after-a-jump) to keep it open.
 
 ## Keybindings (Worktrees view)
 
@@ -96,6 +98,8 @@ The dashboard has two views, toggled with `Tab`:
 | `:`       | Open command palette                   |
 | `q`/`Esc` | Quit                                   |
 | `Ctrl+c`  | Quit (works from any view)             |
+
+Worktree jumps follow the [`close_on_jump`](/guide/dashboard/configuration/#staying-open-after-a-jump) setting.
 
 ## Mouse controls
 

--- a/src/command/dashboard/app/agents.rs
+++ b/src/command/dashboard/app/agents.rs
@@ -26,6 +26,10 @@ pub(crate) struct PaneTarget {
     pub window_name: String,
 }
 
+fn should_close_after_jump(mux_exits_on_jump: bool, close_on_jump: bool) -> bool {
+    mux_exits_on_jump && close_on_jump
+}
+
 impl App {
     /// Apply name and stale filters to the cached agent list, sort, and restore selection.
     /// This is fast (in-memory only) and safe to call on every filter keystroke.
@@ -268,8 +272,7 @@ impl App {
             return;
         }
 
-        // Exit dashboard after jump (or keep open, depending on multiplexer)
-        if self.mux.should_exit_on_jump() {
+        if self.should_close_after_jump() {
             self.should_jump = true;
         }
 
@@ -277,6 +280,13 @@ impl App {
             self.last_pane_id = Some(current.to_string());
             save_last_pane_id(current);
         }
+    }
+
+    pub(crate) fn should_close_after_jump(&self) -> bool {
+        should_close_after_jump(
+            self.mux.should_exit_on_jump(),
+            self.config.dashboard.close_on_jump(),
+        )
     }
 
     pub fn jump_to_selected(&mut self) {
@@ -604,5 +614,18 @@ impl App {
                 ));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_close_after_jump;
+
+    #[test]
+    fn jump_closes_only_when_config_and_multiplexer_allow_it() {
+        assert!(should_close_after_jump(true, true));
+        assert!(!should_close_after_jump(true, false));
+        assert!(!should_close_after_jump(false, true));
+        assert!(!should_close_after_jump(false, false));
     }
 }

--- a/src/command/dashboard/app/worktrees.rs
+++ b/src/command/dashboard/app/worktrees.rs
@@ -902,8 +902,7 @@ impl App {
         self.trigger_worktree_refetch();
     }
 
-    /// Open a tmux window/session for the selected worktree via workflow::open,
-    /// then close the dashboard.
+    /// Open a multiplexer window or session for the selected worktree.
     pub fn open_selected_worktree(&mut self) {
         let Some(selected) = self.worktree_table_state.selected() else {
             return;
@@ -921,7 +920,9 @@ impl App {
 
         let mut options = workflow::types::SetupOptions::new(false, false, true);
         options.mode = self.config.mode();
-        if workflow::open(&handle, &ctx, options, false, None, None, None).is_ok() {
+        if workflow::open(&handle, &ctx, options, false, None, None, None).is_ok()
+            && self.should_close_after_jump()
+        {
             self.should_jump = true;
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,10 @@ pub struct DashboardConfig {
     /// Default: "priority"
     #[serde(default)]
     pub sort_mode: Option<String>,
+
+    /// Close the dashboard after jumping to an agent or worktree.
+    /// Default: true.
+    pub close_on_jump: Option<bool>,
 }
 
 /// A configurable column of the dashboard agents table.
@@ -183,6 +187,12 @@ impl DashboardConfig {
     /// Default: false
     pub fn show_check_counts(&self) -> bool {
         self.show_check_counts.unwrap_or(false)
+    }
+
+    /// Whether the dashboard closes after jumping to an agent or worktree.
+    /// Default: true.
+    pub fn close_on_jump(&self) -> bool {
+        self.close_on_jump.unwrap_or(true)
     }
 }
 
@@ -2727,6 +2737,10 @@ impl Config {
                 .clone()
                 .or_else(|| self.dashboard.agent_columns.clone()),
             sort_mode: project.dashboard.sort_mode.or(self.dashboard.sort_mode),
+            close_on_jump: project
+                .dashboard
+                .close_on_jump
+                .or(self.dashboard.close_on_jump),
         };
 
         // Sidebar config: per-field override
@@ -3213,6 +3227,7 @@ pub const EXAMPLE_PROJECT_CONFIG: &str = r#"# workmux project configuration
 #   preview_size: 60
 #   agent_columns: [number, project, worktree, git, pr, status, time, title]
 #   sort_mode: priority
+#   close_on_jump: true
 
 #-------------------------------------------------------------------------------
 # Sidebar
@@ -3390,6 +3405,34 @@ mod tests {
     };
     use crate::test_support;
     use tempfile::TempDir;
+
+    #[test]
+    fn dashboard_closes_on_jump_by_default() {
+        assert!(Config::default().dashboard.close_on_jump());
+    }
+
+    #[test]
+    fn dashboard_close_on_jump_can_be_disabled() {
+        let config: Config =
+            serde_yaml::from_str("dashboard:\n  close_on_jump: false\n").expect("config parses");
+        assert!(!config.dashboard.close_on_jump());
+    }
+
+    #[test]
+    fn dashboard_close_on_jump_project_value_overrides_global() {
+        let global: Config = serde_yaml::from_str("dashboard:\n  close_on_jump: false\n")
+            .expect("global config parses");
+        let project: Config = serde_yaml::from_str("dashboard:\n  close_on_jump: true\n")
+            .expect("project config parses");
+        assert!(global.merge(project).dashboard.close_on_jump());
+    }
+
+    #[test]
+    fn dashboard_close_on_jump_inherits_global_value() {
+        let global: Config = serde_yaml::from_str("dashboard:\n  close_on_jump: false\n")
+            .expect("global config parses");
+        assert!(!global.merge(Config::default()).dashboard.close_on_jump());
+    }
 
     #[test]
     fn agent_columns_default_when_unset() {


### PR DESCRIPTION
## Why

`Enter` and the `1`-`9` quick jumps switch to the agent's pane and close the dashboard. When the dashboard is used as a monitor — hopping between a few agents to see what each is doing — that means reopening it after every hop.

`p` already switches without closing, but it is a separate key rather than a choice about how jumping behaves, so the muscle memory for `Enter` and the number keys is the one that keeps closing the view.

## What

New `dashboard.close_on_jump` option, default `true` (today's behaviour):

```yaml
dashboard:
  close_on_jump: false
```

The check sits next to the existing `should_exit_on_jump()` one in `switch_to_pane_and_track`, which means:

- every jump path is covered at once — `Enter`, the number keys and the `Bksp` toggle — instead of special-casing one binding;
- the jump itself is untouched, including the pane history that `Bksp` walks through, so this is purely about whether the view closes;
- multiplexers that already keep the dashboard open on a jump keep deciding for themselves.

`p` is unchanged and never closes the dashboard, whatever the setting.

## Testing

- Two unit tests: the default stays `true`, and the option parses and disables closing.
- Full suite green (1419 passed), `cargo fmt --check` clean.