### PR TITLE
dashboard: add an opt-in window index column

### DIFF
--- a/docs/src/content/docs/guide/dashboard/configuration.md
+++ b/docs/src/content/docs/guide/dashboard/configuration.md
@@ -10,6 +10,7 @@ dashboard:
   commit: "Commit staged changes with a descriptive message"
   merge: "!workmux merge"
   preview_size: 60
+  columns: [status, time, title]
 ```
 
 The `commit` and `merge` values are text sent to the agent's pane. Use the `!` prefix to run shell commands (supported by Claude, Gemini, and other agents).
@@ -21,6 +22,18 @@ The `commit` and `merge` values are text sent to the agent's pane. Use the `!` p
 | `commit`       | `Commit staged changes with a descriptive message` | Natural language prompt                   |
 | `merge`        | `!workmux merge`                                   | Shell command via agent                   |
 | `preview_size` | `60`                                               | Preview pane height as percentage (10-90) |
+| `columns`      | `[status, time, title]`                            | Order of the trailing table columns       |
+
+## Columns
+
+`columns` sets the order of the columns that follow the fixed `#`, `Project`, `Worktree`, `Git` and optional `PR` ones. For example, to read the title first and keep the elapsed time out of the way:
+
+```yaml
+dashboard:
+  columns: [status, title, time]
+```
+
+Any of `status`, `time` and `title` may be listed, in any order. A column left out of the list is not rendered, so `columns: [status, title]` drops the elapsed time entirely. Repeating a column has no effect, and an empty list falls back to the default order.
 
 ## Preview size
 

--- a/docs/src/content/docs/guide/dashboard/configuration.md
+++ b/docs/src/content/docs/guide/dashboard/configuration.md
@@ -10,7 +10,7 @@ dashboard:
   commit: "Commit staged changes with a descriptive message"
   merge: "!workmux merge"
   preview_size: 60
-  columns: [status, time, title]
+  columns: [window, status, time, title]
 ```
 
 The `commit` and `merge` values are text sent to the agent's pane. Use the `!` prefix to run shell commands (supported by Claude, Gemini, and other agents).
@@ -33,7 +33,9 @@ dashboard:
   columns: [status, title, time]
 ```
 
-Any of `status`, `time` and `title` may be listed, in any order. A column left out of the list is not rendered, so `columns: [status, title]` drops the elapsed time entirely. Repeating a column has no effect, and an empty list falls back to the default order.
+Any of `window`, `status`, `time` and `title` may be listed, in any order. `window` is not shown by default and prints the multiplexer window index, the same number `prefix + <n>` uses in tmux, which makes the table line up with the status bar. Backends that do not number their windows leave the cell blank.
+
+Any of them A column left out of the list is not rendered, so `columns: [status, title]` drops the elapsed time entirely. Repeating a column has no effect, and an empty list falls back to the default order.
 
 ## Preview size
 

--- a/docs/src/content/docs/guide/dashboard/index.mdx
+++ b/docs/src/content/docs/guide/dashboard/index.mdx
@@ -120,6 +120,9 @@ released when the dashboard exits.
 - **Time**: Time since last status change
 - **Title**: Claude Code session title (auto-generated summary)
 
+The **Status**, **Time** and **Title** columns can be reordered, or left out, with
+the [`columns`](/guide/dashboard/configuration#columns) option.
+
 ## Live preview
 
 The bottom half of the dashboard shows a live preview of the selected agent's terminal output. The preview auto-scrolls to show the latest output, but you can scroll through history with `Ctrl+u`/`Ctrl+d`.

--- a/docs/src/content/docs/guide/dashboard/index.mdx
+++ b/docs/src/content/docs/guide/dashboard/index.mdx
@@ -116,11 +116,12 @@ released when the dashboard exits.
 - **Project**: Project name (from `__worktrees` path or directory name)
 - **Agent**: Worktree/window name
 - **Git**: Diff stats showing branch changes (dim) and uncommitted changes (bright)
+- **Win**: Window index in the multiplexer, matching the tmux status bar (opt-in via `columns`)
 - **Status**: Agent status icon (🤖 working, 💬 waiting, ✅ done, or "stale")
 - **Time**: Time since last status change
 - **Title**: Claude Code session title (auto-generated summary)
 
-The **Status**, **Time** and **Title** columns can be reordered, or left out, with
+The **Win**, **Status**, **Time** and **Title** columns can be reordered, or left out, with
 the [`columns`](/guide/dashboard/configuration#columns) option.
 
 ## Live preview

--- a/src/command/dashboard/ui/dashboard.rs
+++ b/src/command/dashboard/ui/dashboard.rs
@@ -11,6 +11,7 @@ use ratatui::{
 use std::collections::{BTreeMap, HashSet};
 
 use crate::agent_display::strip_oc_title_prefix;
+use crate::config::DashboardColumn;
 
 use super::super::app::{App, DashboardTab};
 use super::format;
@@ -152,6 +153,9 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
     // Show the GitHub column when at least one agent has a PR or checks.
     let show_pr_column = app.has_any_github_status();
     let show_check_counts = app.config.dashboard.show_check_counts();
+    // Header cells, row cells and width constraints are all derived from this
+    // one list, so a reordered config can never desynchronise them.
+    let trailing_columns = app.config.dashboard.columns();
 
     let header = format::resource_table_header(
         format::ResourceHeaderState {
@@ -163,7 +167,14 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
             pr_fetching: app.is_pr_fetching(),
         },
         show_pr_column,
-        &["Status", "Time", "Title"],
+        &trailing_columns
+            .iter()
+            .map(|column| match column {
+                DashboardColumn::Status => "Status",
+                DashboardColumn::Time => "Time",
+                DashboardColumn::Title => "Title",
+            })
+            .collect::<Vec<_>>(),
     );
 
     // Group agents by (session, window_name) to detect multi-pane windows
@@ -367,11 +378,30 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
                 }
 
                 let status_line = format::spans_to_line(status_spans);
-                cells.extend(vec![
-                    Cell::from(status_line),
-                    Cell::from(duration_line),
-                    Cell::from(title),
-                ]);
+                let mut status_cell = Some(status_line);
+                let mut duration_cell = Some(duration_line);
+                let mut title_cell = Some(title);
+                for column in &trailing_columns {
+                    // take() so each column is moved out once: columns() already
+                    // dropped duplicates, this keeps the compiler happy about it
+                    match column {
+                        DashboardColumn::Status => {
+                            if let Some(line) = status_cell.take() {
+                                cells.push(Cell::from(line));
+                            }
+                        }
+                        DashboardColumn::Time => {
+                            if let Some(line) = duration_cell.take() {
+                                cells.push(Cell::from(line));
+                            }
+                        }
+                        DashboardColumn::Title => {
+                            if let Some(line) = title_cell.take() {
+                                cells.push(Cell::from(line));
+                            }
+                        }
+                    }
+                }
 
                 let row = Row::new(cells);
                 // Subtle background for the active worktree row
@@ -396,11 +426,11 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
         constraints.push(Constraint::Length(max_pr_width as u16)); // PR: auto-sized
     }
 
-    constraints.extend(vec![
-        Constraint::Length(8),  // Status: fixed (icons)
-        Constraint::Length(10), // Time: HH:MM:SS + padding
-        Constraint::Fill(1),    // Title: takes remaining space
-    ]);
+    constraints.extend(trailing_columns.iter().map(|column| match column {
+        DashboardColumn::Status => Constraint::Length(8), // fixed (icons)
+        DashboardColumn::Time => Constraint::Length(10),  // HH:MM:SS + padding
+        DashboardColumn::Title => Constraint::Fill(1),    // takes remaining space
+    }));
 
     let highlight_symbol = Text::from(Line::from(Span::styled(
         "▌ ",

--- a/src/command/dashboard/ui/dashboard.rs
+++ b/src/command/dashboard/ui/dashboard.rs
@@ -170,6 +170,7 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
         &trailing_columns
             .iter()
             .map(|column| match column {
+                DashboardColumn::Window => "Win",
                 DashboardColumn::Status => "Status",
                 DashboardColumn::Time => "Time",
                 DashboardColumn::Title => "Title",
@@ -247,6 +248,12 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
                 })
                 .unwrap_or_default();
             let status_spans = app.get_status_display(agent);
+            // Blank rather than a placeholder when the backend does not number
+            // its windows, so the column stays quiet on wezterm/zellij/kitty
+            let window_index_label = agent
+                .window_index
+                .map(|index| index.to_string())
+                .unwrap_or_default();
             let elapsed = app.get_elapsed(agent);
             let duration = elapsed
                 .map(|d| app.format_duration(d))
@@ -285,6 +292,7 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
                 status_spans,
                 duration_line,
                 title,
+                window_index_label,
             )
         })
         .collect();
@@ -302,7 +310,7 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
     // Use chars().count() instead of len() because Nerd Font icons are multi-byte
     let max_git_width = row_data
         .iter()
-        .map(|(_, _, _, _, _, _, _, git_spans, _, _, _, _)| {
+        .map(|(_, _, _, _, _, _, _, git_spans, _, _, _, _, _)| {
             git_spans
                 .iter()
                 .map(|(text, _)| text.chars().count())
@@ -317,7 +325,7 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
     let max_pr_width = if show_pr_column {
         row_data
             .iter()
-            .filter_map(|(_, _, _, _, _, _, _, _, pr_spans, _, _, _)| pr_spans.as_ref())
+            .filter_map(|(_, _, _, _, _, _, _, _, pr_spans, _, _, _, _)| pr_spans.as_ref())
             .map(|spans| {
                 spans
                     .iter()
@@ -348,6 +356,7 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
                 status_spans,
                 duration_line,
                 title,
+                window_index_label,
             )| {
                 let worktree_style = format::make_row_style(is_current, is_main, &app.palette);
 
@@ -378,6 +387,7 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
                 }
 
                 let status_line = format::spans_to_line(status_spans);
+                let mut window_cell = Some(window_index_label);
                 let mut status_cell = Some(status_line);
                 let mut duration_cell = Some(duration_line);
                 let mut title_cell = Some(title);
@@ -385,6 +395,14 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
                     // take() so each column is moved out once: columns() already
                     // dropped duplicates, this keeps the compiler happy about it
                     match column {
+                        DashboardColumn::Window => {
+                            if let Some(label) = window_cell.take() {
+                                cells.push(
+                                    Cell::from(label)
+                                        .style(Style::default().fg(app.palette.dimmed)),
+                                );
+                            }
+                        }
                         DashboardColumn::Status => {
                             if let Some(line) = status_cell.take() {
                                 cells.push(Cell::from(line));
@@ -427,6 +445,7 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
     }
 
     constraints.extend(trailing_columns.iter().map(|column| match column {
+        DashboardColumn::Window => Constraint::Length(4), // window index
         DashboardColumn::Status => Constraint::Length(8), // fixed (icons)
         DashboardColumn::Time => Constraint::Length(10),  // HH:MM:SS + padding
         DashboardColumn::Title => Constraint::Fill(1),    // takes remaining space

--- a/src/command/set_window_status.rs
+++ b/src/command/set_window_status.rs
@@ -325,6 +325,7 @@ mod tests {
             window: Some("wm-test".to_string()),
             session_id: Some("$1".to_string()),
             window_id: Some("@1".to_string()),
+            window_index: Some(1),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,8 @@ pub struct DashboardConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DashboardColumn {
+    /// Multiplexer window index, as shown in the tmux status bar.
+    Window,
     /// Agent status (icons).
     Status,
     /// Time elapsed in the current status.

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,7 +91,31 @@ pub struct DashboardConfig {
     /// Show check pass/total counts alongside check icon (default: false)
     #[serde(default)]
     pub show_check_counts: Option<bool>,
+
+    /// Order of the trailing columns in the agents table, after the fixed
+    /// `#`, `Project`, `Worktree`, `Git` and optional `PR` columns.
+    /// Default: status, time, title.
+    pub columns: Option<Vec<DashboardColumn>>,
 }
+
+/// A configurable column of the dashboard agents table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DashboardColumn {
+    /// Agent status (icons).
+    Status,
+    /// Time elapsed in the current status.
+    Time,
+    /// Agent pane title.
+    Title,
+}
+
+/// Trailing columns used when the config does not set `dashboard.columns`.
+pub const DEFAULT_DASHBOARD_COLUMNS: [DashboardColumn; 3] = [
+    DashboardColumn::Status,
+    DashboardColumn::Time,
+    DashboardColumn::Title,
+];
 
 impl DashboardConfig {
     pub fn commit(&self) -> &str {
@@ -108,6 +132,28 @@ impl DashboardConfig {
     /// Default: 60
     pub fn preview_size(&self) -> u8 {
         self.preview_size.unwrap_or(60).clamp(10, 90)
+    }
+
+    /// Trailing columns of the agents table, in display order.
+    /// Duplicates are dropped so a column is never rendered twice, and an
+    /// empty or absent list falls back to the default order.
+    pub fn columns(&self) -> Vec<DashboardColumn> {
+        let Some(configured) = self.columns.as_ref() else {
+            return DEFAULT_DASHBOARD_COLUMNS.to_vec();
+        };
+
+        let mut seen = Vec::new();
+        for column in configured {
+            if !seen.contains(column) {
+                seen.push(*column);
+            }
+        }
+
+        if seen.is_empty() {
+            DEFAULT_DASHBOARD_COLUMNS.to_vec()
+        } else {
+            seen
+        }
     }
 
     /// Whether to show check pass/total counts alongside check icons.
@@ -2517,6 +2563,11 @@ impl Config {
                 .dashboard
                 .show_check_counts
                 .or(self.dashboard.show_check_counts),
+            columns: project
+                .dashboard
+                .columns
+                .clone()
+                .or_else(|| self.dashboard.columns.clone()),
         };
 
         // Sidebar config: per-field override
@@ -3160,14 +3211,59 @@ mod tests {
 
     use super::{
         AgentEnvValue, AgentIconConfig, AgentIconDetails, AllowedDomainDetails, AllowedDomainEntry,
-        Config, ContainerConfig, ContainerDevice, ExtraMount, FileConfig, LayoutConfig, LimaConfig,
-        NetworkConfig, NetworkPolicy, PaneConfig, SandboxConfig, SandboxRuntime, SandboxTarget,
-        SidebarHeight, SidebarPosition, SidebarWidth, SplitDirection, ToolchainMode,
-        WindowPlacement, is_agent_command, validate_domain, validate_group_add_entry,
-        validate_layouts_config,
+        Config, ContainerConfig, ContainerDevice, DashboardColumn, ExtraMount, FileConfig,
+        LayoutConfig, LimaConfig, NetworkConfig, NetworkPolicy, PaneConfig, SandboxConfig,
+        SandboxRuntime, SandboxTarget, SidebarHeight, SidebarPosition, SidebarWidth,
+        SplitDirection, ToolchainMode, WindowPlacement, is_agent_command, validate_domain,
+        validate_group_add_entry, validate_layouts_config,
     };
     use crate::test_support;
     use tempfile::TempDir;
+
+    #[test]
+    fn dashboard_columns_default_when_unset() {
+        let config = Config::default();
+        assert_eq!(
+            config.dashboard.columns(),
+            vec![
+                DashboardColumn::Status,
+                DashboardColumn::Time,
+                DashboardColumn::Title
+            ]
+        );
+    }
+
+    #[test]
+    fn dashboard_columns_follow_configured_order() {
+        let config: Config = serde_yaml::from_str("dashboard:\n  columns: [status, title, time]\n")
+            .expect("config parses");
+        assert_eq!(
+            config.dashboard.columns(),
+            vec![
+                DashboardColumn::Status,
+                DashboardColumn::Title,
+                DashboardColumn::Time
+            ]
+        );
+    }
+
+    #[test]
+    fn dashboard_columns_drop_duplicates_and_allow_omitting() {
+        let config: Config =
+            serde_yaml::from_str("dashboard:\n  columns: [title, title, status]\n")
+                .expect("config parses");
+        assert_eq!(
+            config.dashboard.columns(),
+            vec![DashboardColumn::Title, DashboardColumn::Status]
+        );
+    }
+
+    #[test]
+    fn dashboard_columns_empty_list_falls_back_to_default() {
+        let config: Config =
+            serde_yaml::from_str("dashboard:\n  columns: []\n").expect("config parses");
+        assert_eq!(config.dashboard.columns().len(), 3);
+    }
 
     fn cfg(edit: impl FnOnce(&mut Config)) -> Config {
         let mut config = Config::default();

--- a/src/multiplexer/tmux.rs
+++ b/src/multiplexer/tmux.rs
@@ -27,7 +27,7 @@ const LIVE_PANE_RECORD_SEPARATOR: char = '\x1e';
 const LIVE_PANE_FIELD_SEPARATOR: char = '\x1f';
 const LIVE_PANE_ESCAPED_RECORD_SEPARATOR: &str = "\\036";
 const LIVE_PANE_ESCAPED_FIELD_SEPARATOR: &str = "\\037";
-const LIVE_PANE_FORMAT: &str = "\x1e#{pane_id}\x1f#{pane_pid}\x1f#{pane_current_command}\x1f#{pane_current_path}\x1f#{pane_title}\x1f#{session_name}\x1f#{window_name}\x1f#{session_id}\x1f#{window_id}";
+const LIVE_PANE_FORMAT: &str = "\x1e#{pane_id}\x1f#{pane_pid}\x1f#{pane_current_command}\x1f#{pane_current_path}\x1f#{pane_title}\x1f#{session_name}\x1f#{window_name}\x1f#{session_id}\x1f#{window_id}\x1f#{window_index}";
 
 fn live_pane_fields(line: &str) -> Vec<&str> {
     if line.contains(LIVE_PANE_FIELD_SEPARATOR) {
@@ -38,6 +38,9 @@ fn live_pane_fields(line: &str) -> Vec<&str> {
         line.split('\t').collect()
     }
 }
+
+/// Fields LIVE_PANE_FORMAT has always produced; later ones are optional.
+const LIVE_PANE_REQUIRED_FIELDS: usize = 9;
 
 fn parse_live_pane_line(line: &str) -> Option<(String, LivePaneInfo)> {
     let line = line
@@ -70,6 +73,7 @@ fn parse_live_pane_line(line: &str) -> Option<(String, LivePaneInfo)> {
                 .get(8)
                 .map(|value| value.to_string())
                 .filter(|value| !value.is_empty()),
+            window_index: parts.get(9).and_then(|value| value.parse().ok()),
         },
     ))
 }
@@ -101,7 +105,10 @@ fn parse_live_pane_snapshot_lossy(output: &str) -> HashMap<String, LivePaneInfo>
 
 fn parse_live_pane_line_strict(line: &str) -> Result<(String, LivePaneInfo)> {
     let parts = live_pane_fields(line);
-    if parts.len() != 9 || parts[0].is_empty() {
+    // LIVE_PANE_FORMAT has grown over time and the trailing fields are read with
+    // get(), so accept anything from the required prefix upwards rather than an
+    // exact count that has to be bumped with every new field
+    if parts.len() < LIVE_PANE_REQUIRED_FIELDS || parts[0].is_empty() {
         return Err(anyhow!(
             "tmux returned malformed pane information: {line:?}"
         ));
@@ -1240,6 +1247,31 @@ mod tests {
 
         assert_eq!(panes["%7"].working_dir, PathBuf::from("/repo/a"));
         assert_eq!(panes["%8"].window_id.as_deref(), Some("@3"));
+    }
+
+    #[test]
+    fn parse_live_pane_line_strict_accepts_fields_beyond_the_required_prefix() {
+        // guards against the exact-count check that rejected live output as soon
+        // as LIVE_PANE_FORMAT gained a field
+        let line = "%7\x1f12345\x1fnode\x1f/repo\x1fWorking\x1fmain\x1fwork\x1f$1\x1f@2\x1f4";
+        let (pane_id, info) = parse_live_pane_line_strict(line).expect("line parses");
+        assert_eq!(pane_id, "%7");
+        assert_eq!(info.window_index, Some(4));
+    }
+
+    #[test]
+    fn parse_live_pane_line_reads_window_index() {
+        let line = "\x1e%7\x1f12345\x1fnode\x1f/repo/a\x1fWorking\x1fmain\x1fwork\x1f$1\x1f@2\x1f3";
+        let (pane_id, info) = parse_live_pane_line(line).expect("line parses");
+        assert_eq!(pane_id, "%7");
+        assert_eq!(info.window_index, Some(3));
+    }
+
+    #[test]
+    fn parse_live_pane_line_without_window_index_is_none() {
+        let line = "\x1e%7\x1f12345\x1fnode\x1f/repo/a\x1fWorking\x1fmain\x1fwork\x1f$1\x1f@2";
+        let (_, info) = parse_live_pane_line(line).expect("line parses");
+        assert_eq!(info.window_index, None);
     }
 
     #[test]

--- a/src/multiplexer/types.rs
+++ b/src/multiplexer/types.rs
@@ -243,4 +243,8 @@ pub struct LivePaneInfo {
 
     /// Stable window ID for backends that expose one.
     pub window_id: Option<String>,
+
+    /// Window index as shown in the tmux status bar. None for backends that
+    /// do not number their windows.
+    pub window_index: Option<u32>,
 }

--- a/src/multiplexer/util.rs
+++ b/src/multiplexer/util.rs
@@ -64,6 +64,7 @@ pub fn build_live_pane_info(
         window: Some(window),
         session_id: None,
         window_id: None,
+        window_index: None,
     }
 }
 

--- a/src/multiplexer/zellij.rs
+++ b/src/multiplexer/zellij.rs
@@ -438,6 +438,7 @@ impl ZellijBackend {
             window: Some(canonical_tab_name(&pane.tab_name).to_string()).filter(|t| !t.is_empty()),
             session_id: None,
             window_id: None,
+            window_index: None,
         }
     }
 

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -622,6 +622,12 @@ impl StateStore {
                     if live.title.is_some() {
                         agent_pane.pane_title = live.title.clone();
                     }
+                    // Window index is a live property: a stored one goes stale as
+                    // soon as windows are moved or renumbered
+                    agent_pane.window_index = live.window_index;
+                    if let Some(window_id) = live.window_id.clone() {
+                        agent_pane.window_id = window_id;
+                    }
                     // Only the tmux backend can reliably distinguish auto-renamed
                     // window names from sticky user-set ones via pane_current_command.
                     if backend == "tmux" {
@@ -1083,6 +1089,7 @@ mod tests {
                 window: Some("node".to_string()),
                 session_id: None,
                 window_id: None,
+                window_index: None,
             },
         );
         live_panes.insert(
@@ -1096,6 +1103,7 @@ mod tests {
                 window: Some("node".to_string()),
                 session_id: None,
                 window_id: None,
+                window_index: None,
             },
         );
         live_panes.insert(
@@ -1109,6 +1117,7 @@ mod tests {
                 window: Some("user-name".to_string()),
                 session_id: None,
                 window_id: None,
+                window_index: None,
             },
         );
 


### PR DESCRIPTION
> [!NOTE]
> Builds on #225 (`dashboard.columns`), which the new column is selected through. The first commit here is that PR; review it first, and this branch rebases cleanly once it lands.

## Why

The sidebar can show the tmux window index since the `{window_index}` token, but the dashboard cannot — and the dashboard is the view that lists every agent across sessions, so it is where lining the table up with the tmux status bar is most useful. Knowing that an agent is in window 3 means `prefix + 3` gets you there.

The number was simply not available: `LivePaneInfo` carried `window_id` but no index, and the sidebar gets its own from a separate query in the sidebar daemon.

## What

- `LIVE_PANE_FORMAT` asks tmux for `#{window_index}` and `LivePaneInfo` carries it.
- Reconciliation stamps it onto each agent, and treats it as a **live** property: a stored index goes stale as soon as windows are moved or renumbered. `window_id` is refreshed from the live pane in the same place, for the same reason.
- The column is opt-in through `dashboard.columns`, so nothing changes unless it is asked for:

```yaml
dashboard:
  columns: [window, status, time, title]
```

- Backends that do not number their windows (wezterm, zellij, kitty) leave the cell blank rather than printing a placeholder.

## A latent bug this surfaced

`parse_live_pane_line_strict` required **exactly** 9 fields, while the lossy parser reads trailing fields with `get()`. Adding one field to the format made the strict path reject real tmux output outright — `workmux status` failed with `tmux returned malformed pane information` on live panes. It now accepts the required prefix and treats later fields as optional, so the format can grow again without breaking. This is the same shape of problem as #213: strict parsing turning a benign difference into a hard failure.

## Testing

- Three parser tests: the index is read, its absence yields `None`, and the strict parser accepts fields beyond the required prefix.
- Full suite green (1424 passed), `cargo fmt --check` clean.
- Verified against a real tmux server: the format string and strict parser handle live output (that is how the bug above was found), and the rendered header shows `Win` in the configured position.