### PR TITLE
Add option to disable stale sidebar dimming

### DIFF
--- a/docs/src/content/docs/guide/sidebar/index.mdx
+++ b/docs/src/content/docs/guide/sidebar/index.mdx
@@ -77,6 +77,9 @@ sidebar:
   # Layout mode for the left sidebar: "compact" or "tiles" (default)
   layout: tiles
 
+  # Dim agents whose status has not changed for one hour (default: true)
+  dim_stale: true
+
   # Row ordering: "recency" (default, most recent status change first)
   # or "window" (tmux window order - stable rows that match the window
   # list, pairs well with the {window_index} template token)

--- a/docs/src/content/docs/reference/commands/sidebar.md
+++ b/docs/src/content/docs/reference/commands/sidebar.md
@@ -80,6 +80,7 @@ sidebar:
   width: 40 # left width in columns (default: "10%", clamped 25-50)
   # width: "15%"
   layout: tiles # left only: "compact" or "tiles" (default)
+  dim_stale: true # dim agents whose status has not changed for one hour
 ```
 
 For a horizontal top bar:

--- a/src/command/sidebar/app.rs
+++ b/src/command/sidebar/app.rs
@@ -223,6 +223,8 @@ pub struct SidebarApp {
     pub status_icons: StatusIcons,
     pub spinner_frame: u8,
     pub stale_threshold_secs: u64,
+    /// Whether stale agents use the dimmed visual treatment.
+    pub dim_stale: bool,
     pub position: SidebarPosition,
     pub layout_mode: SidebarLayoutMode,
     /// Area where the list was last rendered (for mouse hit testing)
@@ -308,6 +310,7 @@ impl SidebarApp {
             status_icons: StatusIcons::default(),
             spinner_frame: 0,
             stale_threshold_secs: 3600,
+            dim_stale: true,
             position: SidebarPosition::Left,
             layout_mode: SidebarLayoutMode::Compact,
             list_area: Rect::default(),
@@ -390,6 +393,7 @@ impl SidebarApp {
             status_icons,
             spinner_frame: 0,
             stale_threshold_secs: 60 * 60, // 60 minutes
+            dim_stale: config.sidebar.dim_stale(),
             position,
             layout_mode: SidebarLayoutMode::default(),
             list_area: Rect::default(),
@@ -561,6 +565,7 @@ impl SidebarApp {
         self.agent_icons = ResolvedAgentIcons::from_config(cfg.sidebar.agent_icons.as_ref());
         self.horizontal_item_width = cfg.sidebar.horizontal.item_width();
         self.current_width = cfg.sidebar.width.clone();
+        self.dim_stale = cfg.sidebar.dim_stale();
     }
 
     pub(super) fn host_identity(&self) -> Option<&HostIdentity> {

--- a/src/command/sidebar/template/context.rs
+++ b/src/command/sidebar/template/context.rs
@@ -70,13 +70,16 @@ impl<'a> RowContext<'a> {
 
         let is_sleeping = app.sleeping_pane_ids.contains(&agent.pane_id);
         let is_interrupted = app.interrupted_pane_ids.contains(&agent.pane_id);
-        let is_stale = is_agent_stale(
-            agent.status_ts,
-            agent.status,
-            now_secs,
-            app.stale_threshold_secs,
-            is_sleeping,
-            is_interrupted,
+        let is_stale = should_dim_agent(
+            app.dim_stale,
+            is_agent_stale(
+                agent.status_ts,
+                agent.status,
+                now_secs,
+                app.stale_threshold_secs,
+                is_sleeping,
+                is_interrupted,
+            ),
         );
         let is_active = app.host_agent_idx == Some(idx);
         let is_selected = selected_idx == Some(idx);
@@ -436,6 +439,10 @@ fn is_agent_stale(
         .unwrap_or(true)
 }
 
+fn should_dim_agent(dim_stale: bool, is_stale: bool) -> bool {
+    dim_stale && is_stale
+}
+
 fn display_width(s: &str) -> usize {
     s.chars()
         .map(|c| unicode_width::UnicodeWidthChar::width(c).unwrap_or(1))
@@ -483,6 +490,13 @@ mod tests {
             false,
             false
         ));
+    }
+
+    #[test]
+    fn stale_rendering_can_be_disabled() {
+        assert!(should_dim_agent(true, true));
+        assert!(!should_dim_agent(false, true));
+        assert!(!should_dim_agent(true, false));
     }
 
     #[test]
@@ -566,6 +580,7 @@ mod tests {
         );
     }
 
+    use crate::command::sidebar::app::TemplateError;
     use crate::config::{ThemeMode, ThemeScheme};
     use crate::github::{CheckState, PrSummary};
     use crate::multiplexer::AgentPane;
@@ -594,6 +609,24 @@ mod tests {
             agent_command: None,
             agent_kind: None,
         }
+    }
+
+    #[test]
+    fn row_context_keeps_stale_done_agent_colored_when_dimming_is_disabled() {
+        let mut app = SidebarApp::test_with_template_error(TemplateError {
+            location: String::new(),
+            message: String::new(),
+        });
+        app.dim_stale = false;
+
+        let mut agent = test_agent();
+        agent.status = Some(AgentStatus::Done);
+        agent.status_ts = Some(1);
+        let pane_suffixes = vec![String::new()];
+        let ctx = RowContext::build(&app, &agent, 0, &pane_suffixes, 7200, None);
+
+        assert!(!ctx.is_stale);
+        assert_eq!(ctx.status_color, app.palette.success);
     }
 
     fn make_context<'a>(

--- a/src/config.rs
+++ b/src/config.rs
@@ -224,6 +224,16 @@ pub struct SidebarConfig {
 
     /// Row ordering: "recency" (default) or "window".
     pub sort: Option<SidebarSort>,
+
+    /// Dim agents whose status has not changed for the stale threshold.
+    /// Default: true.
+    pub dim_stale: Option<bool>,
+}
+
+impl SidebarConfig {
+    pub fn dim_stale(&self) -> bool {
+        self.dim_stale.unwrap_or(true)
+    }
 }
 
 /// Sidebar row ordering.
@@ -2548,6 +2558,7 @@ impl Config {
                 (g, p) => p.or(g),
             },
             sort: project.sidebar.sort.or(self.sidebar.sort),
+            dim_stale: project.sidebar.dim_stale.or(self.sidebar.dim_stale),
         };
 
         // Sandbox config: per-field override with nested struct merging
@@ -3016,6 +3027,9 @@ pub const EXAMPLE_PROJECT_CONFIG: &str = r#"# workmux project configuration
 #   # Default: "tiles". Can be toggled at runtime with 'v' key.
 #   layout: tiles
 #
+#   # Dim agents whose status has not changed for one hour. Default: true.
+#   dim_stale: true
+#
 #   horizontal:
 #     item_width: 24  # horizontal chip width in columns, clamped 12-80
 #
@@ -3482,6 +3496,25 @@ sidebar:
         assert_eq!(merged.sidebar.width, Some(SidebarWidth::Absolute(40)));
         assert_eq!(merged.sidebar.height, Some(SidebarHeight::Absolute(4)));
         assert_eq!(merged.sidebar.horizontal.item_width, Some(36));
+    }
+
+    #[test]
+    fn sidebar_dim_stale_defaults_true_and_merges_per_field() {
+        let default_config = Config::default();
+        assert!(default_config.sidebar.dim_stale());
+
+        let global: Config = serde_yaml::from_str(
+            r#"
+sidebar:
+  dim_stale: false
+"#,
+        )
+        .unwrap();
+        let project: Config = serde_yaml::from_str("sidebar: {}\n").unwrap();
+        let merged = global.merge(project);
+
+        assert_eq!(merged.sidebar.dim_stale, Some(false));
+        assert!(!merged.sidebar.dim_stale());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `sidebar.dim_stale`, defaulting to `true`
- keep stale detection unchanged while allowing normal status colors and icons to render
- apply the setting during startup and live config reload
- document the option in the sidebar reference and guide

## Verification

- `cargo test --no-fail-fast` (1422 passed, 4 ignored)
- regression test confirms a stale completed agent keeps the success color when dimming is disabled