### PR TITLE
Fix OpenCode status aggregation across subagents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'

--- a/checkle.toml
+++ b/checkle.toml
@@ -21,6 +21,11 @@ mode = "cargo"
 command = ["cargo", "test", "--bin", "workmux", "--message-format=json"]
 
 [[check]]
+name = "opencode-plugin-tests"
+mode = "auto"
+command = ["bun", "test", "tests/opencode_status_plugin.test.ts"]
+
+[[check]]
 name = "ruff-check"
 mode = "auto"
 command = ["ruff", "check", "tests", "--quiet"]
@@ -37,4 +42,4 @@ command = ["node", "docs/scripts/check-content.mjs"]
 
 [[group]]
 name = "all"
-checks = ["format-rust-check", "format-python-check", "clippy", "unit-tests", "ruff-check", "pyright", "docs-check"]
+checks = ["format-rust-check", "format-python-check", "clippy", "unit-tests", "opencode-plugin-tests", "ruff-check", "pyright", "docs-check"]

--- a/resources/opencode/plugins/workmux-status.ts
+++ b/resources/opencode/plugins/workmux-status.ts
@@ -3,19 +3,40 @@ import type { Plugin } from '@opencode-ai/plugin';
 export const WorkmuxStatusPlugin: Plugin = async ({ $ }) => {
   // OpenCode can emit repeated `session.status busy` events for a single turn,
   // and can even emit a stale trailing `busy` after `idle` at the end. Track
-  // per-session status so workmux only sees real transitions.
-  const lastStatusBySession = new Map<string, string>();
+  // every parent and child session so one idle session cannot mark the whole
+  // pane done while another session is still working.
+  const statusBySession = new Map<string, string>();
   const acceptBusyBySession = new Map<string, boolean>();
+  const deletedSessions = new Set<string>();
+  let reportedStatus: string | undefined;
+
+  async function reportAggregateStatus() {
+    const statuses = [...statusBySession.values()];
+    let status = 'done';
+
+    if (statuses.includes('waiting')) {
+      status = 'waiting';
+    } else if (statuses.includes('working')) {
+      status = 'working';
+    }
+
+    if (reportedStatus === status) {
+      return;
+    }
+
+    reportedStatus = status;
+    await $`workmux set-window-status ${status}`.quiet();
+  }
 
   async function setStatus(
     sessionID: string | undefined,
     status: string,
   ) {
-    if (!sessionID) {
+    if (!sessionID || deletedSessions.has(sessionID)) {
       return;
     }
 
-    const previous = lastStatusBySession.get(sessionID);
+    const previous = statusBySession.get(sessionID);
     // Ignore the final stale `busy` OpenCode sometimes emits after a session is
     // already done. The next user message re-arms `working` for the new turn.
     if (status === 'working' && acceptBusyBySession.get(sessionID) === false) {
@@ -25,14 +46,14 @@ export const WorkmuxStatusPlugin: Plugin = async ({ $ }) => {
       return;
     }
 
-    lastStatusBySession.set(sessionID, status);
+    statusBySession.set(sessionID, status);
     if (status === 'done') {
       acceptBusyBySession.set(sessionID, false);
     } else {
       acceptBusyBySession.set(sessionID, true);
     }
 
-    await $`workmux set-window-status ${status}`.quiet();
+    await reportAggregateStatus();
   }
 
   return {
@@ -60,6 +81,12 @@ export const WorkmuxStatusPlugin: Plugin = async ({ $ }) => {
           break;
         case 'session.idle':
           await setStatus(event.properties.sessionID, 'done');
+          break;
+        case 'session.deleted':
+          deletedSessions.add(event.properties.info.id);
+          statusBySession.delete(event.properties.info.id);
+          acceptBusyBySession.delete(event.properties.info.id);
+          await reportAggregateStatus();
           break;
       }
     },

--- a/resources/opencode/plugins/workmux-status.ts
+++ b/resources/opencode/plugins/workmux-status.ts
@@ -37,6 +37,9 @@ export const WorkmuxStatusPlugin: Plugin = async ({ $ }) => {
     }
 
     const previous = statusBySession.get(sessionID);
+    if (status === 'done' && previous === undefined) {
+      return;
+    }
     // Ignore the final stale `busy` OpenCode sometimes emits after a session is
     // already done. The next user message re-arms `working` for the new turn.
     if (status === 'working' && acceptBusyBySession.get(sessionID) === false) {
@@ -82,12 +85,15 @@ export const WorkmuxStatusPlugin: Plugin = async ({ $ }) => {
         case 'session.idle':
           await setStatus(event.properties.sessionID, 'done');
           break;
-        case 'session.deleted':
-          deletedSessions.add(event.properties.info.id);
-          statusBySession.delete(event.properties.info.id);
-          acceptBusyBySession.delete(event.properties.info.id);
-          await reportAggregateStatus();
+        case 'session.deleted': {
+          const sessionID = event.properties.info.id;
+          deletedSessions.add(sessionID);
+          acceptBusyBySession.delete(sessionID);
+          if (statusBySession.delete(sessionID)) {
+            await reportAggregateStatus();
+          }
           break;
+        }
       }
     },
   };

--- a/tests/opencode_status_plugin.test.ts
+++ b/tests/opencode_status_plugin.test.ts
@@ -71,6 +71,25 @@ describe('WorkmuxStatusPlugin', () => {
     expect(harness.statuses).toEqual(['working', 'done']);
   });
 
+  test('ignores deletion of an untracked session', async () => {
+    const harness = await createHarness();
+
+    await harness.emit({
+      type: 'session.deleted',
+      properties: { info: { id: 'historical' } },
+    });
+
+    expect(harness.statuses).toEqual([]);
+  });
+
+  test('ignores idle status from an untracked session', async () => {
+    const harness = await createHarness();
+
+    await harness.emit(sessionStatus('parent', 'idle'));
+
+    expect(harness.statuses).toEqual([]);
+  });
+
   test('ignores stale busy events until a new user message', async () => {
     const harness = await createHarness();
 

--- a/tests/opencode_status_plugin.test.ts
+++ b/tests/opencode_status_plugin.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'bun:test';
+
+import { WorkmuxStatusPlugin } from '../resources/opencode/plugins/workmux-status';
+
+async function createHarness() {
+  const statuses: string[] = [];
+  const shell = (_strings: TemplateStringsArray, status: string) => ({
+    quiet: async () => {
+      statuses.push(status);
+    },
+  });
+  const hooks = await WorkmuxStatusPlugin({ $: shell } as never);
+
+  return {
+    statuses,
+    emit: async (event: unknown) => {
+      await hooks.event?.({ event } as never);
+    },
+  };
+}
+
+const sessionStatus = (sessionID: string, type: 'busy' | 'idle') => ({
+  type: 'session.status',
+  properties: { sessionID, status: { type } },
+});
+
+const userMessage = (sessionID: string) => ({
+  type: 'message.updated',
+  properties: { sessionID, info: { role: 'user', sessionID } },
+});
+
+describe('WorkmuxStatusPlugin', () => {
+  test('stays working when a child session finishes before its parent', async () => {
+    const harness = await createHarness();
+
+    await harness.emit(sessionStatus('parent', 'busy'));
+    await harness.emit(sessionStatus('child', 'busy'));
+    await harness.emit(sessionStatus('child', 'idle'));
+
+    expect(harness.statuses).toEqual(['working']);
+
+    await harness.emit(sessionStatus('parent', 'idle'));
+    expect(harness.statuses).toEqual(['working', 'done']);
+  });
+
+  test('stays working when a parent session idles before its child', async () => {
+    const harness = await createHarness();
+
+    await harness.emit(sessionStatus('parent', 'busy'));
+    await harness.emit(sessionStatus('child', 'busy'));
+    await harness.emit(sessionStatus('parent', 'idle'));
+
+    expect(harness.statuses).toEqual(['working']);
+
+    await harness.emit(sessionStatus('child', 'idle'));
+    expect(harness.statuses).toEqual(['working', 'done']);
+  });
+
+  test('forgets an active session when OpenCode deletes it', async () => {
+    const harness = await createHarness();
+
+    await harness.emit(sessionStatus('parent', 'busy'));
+    await harness.emit(sessionStatus('child', 'busy'));
+    await harness.emit(sessionStatus('parent', 'idle'));
+    await harness.emit({
+      type: 'session.deleted',
+      properties: { info: { id: 'child' } },
+    });
+    await harness.emit(sessionStatus('child', 'busy'));
+
+    expect(harness.statuses).toEqual(['working', 'done']);
+  });
+
+  test('ignores stale busy events until a new user message', async () => {
+    const harness = await createHarness();
+
+    await harness.emit(sessionStatus('parent', 'busy'));
+    await harness.emit(sessionStatus('parent', 'idle'));
+    await harness.emit(sessionStatus('parent', 'busy'));
+    expect(harness.statuses).toEqual(['working', 'done']);
+
+    await harness.emit(userMessage('parent'));
+    await harness.emit(sessionStatus('parent', 'busy'));
+    expect(harness.statuses).toEqual(['working', 'done', 'working']);
+  });
+
+  test('reports waiting while another session is working', async () => {
+    const harness = await createHarness();
+
+    await harness.emit(sessionStatus('parent', 'busy'));
+    await harness.emit({
+      type: 'question.asked',
+      properties: { sessionID: 'child' },
+    });
+    await harness.emit(sessionStatus('parent', 'idle'));
+    expect(harness.statuses).toEqual(['working', 'waiting']);
+
+    await harness.emit({
+      type: 'question.replied',
+      properties: { sessionID: 'child' },
+    });
+    expect(harness.statuses).toEqual(['working', 'waiting', 'working']);
+  });
+});


### PR DESCRIPTION
## Summary

- aggregate OpenCode status across parent and child sessions so one idle session cannot mark a still-working pane as done
- preserve waiting-state priority and stale busy-event suppression
- remove deleted sessions from the aggregate and ignore delayed events for them
- add Bun regression tests and run them in CI