### PR TITLE
Add herdr as an alternative multiplexer backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ parallel without conflict.
 windowing, git for worktrees, your agent for coding - workmux ties them together.
 
 <sup><sub>\* Also supports
+<a href="https://workmux.raine.dev/guide/herdr">herdr</a>,
 <a href="https://workmux.raine.dev/guide/kitty">kitty</a>,
 <a href="https://workmux.raine.dev/guide/wezterm">WezTerm</a>, and
 <a href="https://workmux.raine.dev/guide/zellij">Zellij</a> as alternative
@@ -163,6 +164,7 @@ For manual installation, see
 > [!NOTE]
 > workmux requires a terminal multiplexer. Make sure you have
 > [tmux](https://github.com/tmux/tmux) (or
+> [herdr](https://raine.github.io/workmux/guide/herdr) /
 > [WezTerm](https://raine.github.io/workmux/guide/wezterm) /
 > [Kitty](https://raine.github.io/workmux/guide/kitty) /
 > [Zellij](https://raine.github.io/workmux/guide/zellij)) installed and running
@@ -2735,6 +2737,10 @@ workmux completions fish | source
 While tmux is the primary and recommended backend, workmux also supports
 alternative terminal multiplexers:
 
+- **[herdr](https://workmux.raine.dev/guide/herdr)** (experimental) - For users
+  who prefer herdr. Detected automatically via `$HERDR_PANE_ID`. herdr manages
+  git worktrees itself, so `add` and `remove` delegate to it instead of running
+  git directly.
 - **[WezTerm](https://workmux.raine.dev/guide/wezterm)** (experimental) - For
   users who prefer WezTerm's features. Thanks to
   [@JeremyBYU](https://github.com/JeremyBYU) for contributing this backend.
@@ -2745,9 +2751,10 @@ alternative terminal multiplexers:
   users who prefer Zellij. Detected automatically via `$ZELLIJ`.
 
 workmux auto-detects the backend from environment variables (`$TMUX`,
-`$WEZTERM_PANE`, `$KITTY_WINDOW_ID`, or `$ZELLIJ`). Session-specific variables
-are checked first, so running tmux inside kitty correctly selects the tmux
-backend. Set `$WORKMUX_BACKEND` to override detection.
+`$WEZTERM_PANE`, `$KITTY_WINDOW_ID`, `$ZELLIJ`, or `$HERDR_PANE_ID`).
+Session-specific variables are checked first, so running tmux inside kitty or
+inside herdr correctly selects the tmux backend. Set `$WORKMUX_BACKEND` to
+override detection.
 
 ## Inspiration and related tools
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -135,6 +135,7 @@ export default defineConfig({
         {
           label: "Alternative backends",
           items: [
+            { label: "herdr", slug: "guide/herdr" },
             { label: "kitty", slug: "guide/kitty" },
             { label: "WezTerm", slug: "guide/wezterm" },
             { label: "Zellij", slug: "guide/zellij" },

--- a/docs/src/content/docs/guide/herdr.mdx
+++ b/docs/src/content/docs/guide/herdr.mdx
@@ -1,0 +1,89 @@
+---
+title: "herdr"
+description: Use herdr as an alternative multiplexer backend
+---
+
+:::caution[Experimental]
+The herdr backend is new. Expect rough edges.
+:::
+
+[herdr](https://herdr.dev) is an agent multiplexer that lives in your terminal.
+Detected automatically via `$HERDR_PANE_ID`.
+
+herdr calls its top-level containers workspaces. workmux maps one worktree onto
+one workspace, the same way it maps one worktree onto one tmux window.
+
+## Requirements
+
+- herdr 0.7.1 or later
+- `herdr` on `PATH`, or `$HERDR_BIN_PATH` pointing at the binary
+
+## Differences from tmux
+
+| Feature           | tmux               | herdr                   |
+| ----------------- | ------------------ | ----------------------- |
+| Agent status      | Yes (window names) | Yes (pane names)        |
+| Scope             | tmux session       | herdr session           |
+| Session mode      | Yes                | No (window only)        |
+| Pane size control | Percentage-based   | Percentage-based        |
+| Stacked panes     | No                 | No                      |
+| Dashboard preview | Yes                | Yes                     |
+| Worktree creation | `git worktree add` | `herdr worktree create` |
+| Renaming a target | Yes                | No                      |
+
+## Worktree integration
+
+herdr manages git worktrees itself, so workmux delegates to it rather than
+running git directly. `workmux add` becomes a single `herdr worktree create`
+that makes the worktree and the workspace together, and `workmux remove` becomes
+a single `herdr worktree remove`.
+
+This matters when removal is deferred. Running `workmux remove` from inside the
+workspace being removed cannot tear down its own terminal, so workmux hands
+herdr a command to run after the workspace closes. On other backends that step
+renames the worktree to a trash directory and prunes it; on herdr the one
+command covers both, and no trash directory is created.
+
+workmux falls back to separate `git worktree add` and workspace creation when
+the combined call cannot express the request, namely when checking out an
+existing branch or tracking an upstream branch. Both paths produce the same
+result.
+
+## Configuration
+
+No herdr configuration is required. workmux drives herdr through its JSON CLI,
+which works out of the box.
+
+To override the auto-detected backend:
+
+```bash
+export WORKMUX_BACKEND=herdr
+```
+
+Two environment variables affect the backend.
+
+`$HERDR_BIN_PATH` is the path to the `herdr` binary, defaulting to `herdr` on
+`PATH`. Set it when herdr is installed elsewhere. Deferred cleanup commands
+embed this path, so they keep working in a detached shell.
+
+`$HERDR_SOCKET_PATH` is the socket of the herdr instance. herdr sets it, one
+value per named session, and workmux keys its stored state on it. Sessions
+started with `herdr --session <name>` therefore stay isolated from each other.
+
+## Detection order
+
+workmux checks `$TMUX` before `$HERDR_PANE_ID`. herdr exports `HERDR_PANE_ID`
+into every descendant process, so a tmux server started inside a herdr pane sets
+both; checking tmux first selects the inner multiplexer, which is the one the
+user is looking at. Set `$WORKMUX_BACKEND` to override.
+
+## Known limitations
+
+- Session mode is not supported, only window mode
+- `workmux rename` renames the worktree and branch, but leaves the workspace
+  label unchanged
+- Pane display names (`name` in a pane config) are not applied
+- Stacked panes are not supported
+- Agent status icons do not clear when a pane receives focus
+- herdr does not report pane PIDs or foreground commands, so workmux treats a
+  live pane as a live agent rather than checking the process

--- a/src/multiplexer/herdr.rs
+++ b/src/multiplexer/herdr.rs
@@ -1,0 +1,776 @@
+//! Herdr backend implementation for the Multiplexer trait.
+//!
+//! This module provides HerdrBackend, which drives herdr through its JSON CLI.
+//! It holds no session state of its own: everything is read from the environment
+//! or queried live. Like the WezTerm backend, it is CLI-driven and needs no
+//! daemon socket.
+
+use anyhow::{Context, Result, anyhow};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::cmd::Cmd;
+use crate::config::SplitDirection;
+use crate::shell::shell_quote;
+
+use super::Multiplexer;
+use super::types::*;
+use super::util;
+
+/// herdr's error code for a pane that no longer exists.
+const PANE_NOT_FOUND: &str = "pane_not_found";
+
+/// A decoded herdr JSON envelope.
+///
+/// herdr reports failures in-band: the process still exits 0 and the envelope
+/// carries an `error` object instead of `result`. Treating a missing `result`
+/// as an empty payload would turn every backend failure into "nothing there",
+/// so the two cases are kept distinct.
+#[derive(Debug, PartialEq)]
+enum Envelope {
+    Result(Value),
+    Error { code: String, message: String },
+}
+
+fn parse_envelope(raw: &str) -> Result<Envelope> {
+    let envelope: Value = serde_json::from_str(raw)?;
+
+    if let Some(error) = envelope.get("error").filter(|e| !e.is_null()) {
+        let code = error["code"].as_str().unwrap_or_default().to_string();
+        let message = error["message"].as_str().unwrap_or_default().to_string();
+        return Ok(Envelope::Error { code, message });
+    }
+
+    match envelope.get("result") {
+        Some(result) if !result.is_null() => Ok(Envelope::Result(result.clone())),
+        _ => Err(anyhow!("envelope has neither result nor error")),
+    }
+}
+
+/// Build a `cd <cwd>` script, optionally chaining a command onto it.
+///
+/// The path is quoted because worktree paths routinely contain spaces.
+fn cd_script(cwd: &Path, cmd: Option<&str>) -> String {
+    let quoted = shell_quote(&cwd.to_string_lossy());
+    match cmd {
+        Some(command) => format!("cd {quoted} && {command}"),
+        None => format!("cd {quoted}"),
+    }
+}
+
+/// `create.rs` rejects session mode for non-tmux backends, so no caller reaches
+/// these; herdr has workspaces, not sessions.
+fn no_sessions<T>() -> Result<T> {
+    Err(anyhow!("sessions not supported by the herdr backend"))
+}
+
+#[derive(Debug, Deserialize)]
+struct HerdrWorkspace {
+    workspace_id: String,
+    label: String,
+    #[serde(default)]
+    focused: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct HerdrPane {
+    pane_id: String,
+    workspace_id: String,
+    cwd: String,
+    foreground_cwd: Option<String>,
+}
+
+impl HerdrPane {
+    fn working_dir(&self) -> PathBuf {
+        let path = self.foreground_cwd.as_deref().unwrap_or(&self.cwd);
+        PathBuf::from(path)
+    }
+}
+
+/// Herdr backend. Invokes `herdr` (or `$HERDR_BIN_PATH`) for all operations.
+#[derive(Debug)]
+pub struct HerdrBackend {
+    bin: String,
+}
+
+impl Default for HerdrBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HerdrBackend {
+    pub fn new() -> Self {
+        // Deferred cleanup scripts embed this path, so it must resolve whether
+        // or not herdr is on `PATH`.
+        Self {
+            bin: std::env::var("HERDR_BIN_PATH").unwrap_or_else(|_| "herdr".into()),
+        }
+    }
+
+    fn cmd(&self) -> Cmd<'_> {
+        Cmd::new(&self.bin)
+    }
+
+    fn run(&self, args: &[&str]) -> Result<String> {
+        self.cmd()
+            .args(args)
+            .run_and_capture_stdout()
+            .with_context(|| format!("herdr {}", args.join(" ")))
+    }
+
+    /// Run a herdr command and decode its JSON envelope.
+    fn run_envelope(&self, args: &[&str]) -> Result<Envelope> {
+        let raw = self.run(args)?;
+        parse_envelope(&raw).with_context(|| format!("parse JSON from: herdr {}", args.join(" ")))
+    }
+
+    /// Run a herdr command and return its `result` payload, failing on an error
+    /// envelope. Callers that need to act on a specific error code use
+    /// `run_envelope` instead.
+    fn run_json(&self, args: &[&str]) -> Result<Value> {
+        match self.run_envelope(args)? {
+            Envelope::Result(result) => Ok(result),
+            Envelope::Error { code, message } => {
+                Err(anyhow!("herdr {}: {message} ({code})", args.join(" ")))
+            }
+        }
+    }
+
+    fn list_workspaces(&self) -> Result<Vec<HerdrWorkspace>> {
+        let result = self.run_json(&["workspace", "list"])?;
+        let workspaces: Vec<HerdrWorkspace> =
+            serde_json::from_value(result["workspaces"].clone()).context("parse workspace list")?;
+        Ok(workspaces)
+    }
+
+    fn list_panes(&self) -> Result<Vec<HerdrPane>> {
+        let result = self.run_json(&["pane", "list"])?;
+        let panes: Vec<HerdrPane> =
+            serde_json::from_value(result["panes"].clone()).context("parse pane list")?;
+        Ok(panes)
+    }
+
+    fn workspace_id_for_label(&self, label: &str) -> Result<String> {
+        self.list_workspaces()?
+            .into_iter()
+            .find(|w| w.label == label)
+            .map(|w| w.workspace_id)
+            .ok_or_else(|| anyhow!("no workspace with label '{label}'"))
+    }
+
+    fn workspace_label_for_id(&self, workspace_id: &str) -> Result<String> {
+        self.list_workspaces()?
+            .into_iter()
+            .find(|w| w.workspace_id == workspace_id)
+            .map(|w| w.label)
+            .ok_or_else(|| anyhow!("no workspace with id '{workspace_id}'"))
+    }
+
+    fn workspace_id_for_pane(&self, pane_id: &str) -> Option<String> {
+        // pane_id format is "wN:pM", so the workspace_id is the part before the
+        // separator. Without a separator the id is not one we can attribute, and
+        // guessing would target an unrelated workspace.
+        pane_id
+            .split_once(':')
+            .map(|(workspace_id, _)| workspace_id.to_string())
+    }
+
+    // `worktree create`/`worktree open` resolve their source workspace from
+    // herdr's ambient/focused-client state when `--workspace` is omitted.
+    // That state drifts as workspaces open/close during a session and can
+    // point at a linked worktree, which herdr refuses as a source
+    // ("New and open worktree actions start from the repo parent
+    // workspace"). HERDR_PANE_ID always names the actual calling pane, so
+    // deriving `--workspace` from it sidesteps ambient drift entirely.
+    fn own_workspace_id(&self) -> Option<String> {
+        std::env::var("HERDR_PANE_ID")
+            .ok()
+            .and_then(|pane_id| self.workspace_id_for_pane(&pane_id))
+    }
+
+    /// Shared by `worktree create` and `worktree open`: both answer in the same
+    /// envelope shape.
+    ///
+    /// Appends `--workspace` so herdr resolves the source from the calling pane
+    /// rather than from ambient focus.
+    fn worktree_workspace(&self, args: &[&str]) -> Result<Option<(String, String)>> {
+        let mut args = args.to_vec();
+        let source_workspace = self.own_workspace_id();
+        if let Some(ref workspace_id) = source_workspace {
+            args.extend_from_slice(&["--workspace", workspace_id]);
+        }
+
+        let result = self.run_json(&args)?;
+        let field = |path: &str| {
+            result
+                .pointer(path)
+                .and_then(Value::as_str)
+                .map(String::from)
+                .ok_or_else(|| anyhow!("herdr {}: missing result{path}", args.join(" ")))
+        };
+        Ok(Some((
+            field("/workspace/workspace_id")?,
+            field("/root_pane/pane_id")?,
+        )))
+    }
+
+    /// Attach a workspace to a worktree already on disk.
+    ///
+    /// Separate from `worktree create`, which always runs `git worktree add` and
+    /// so fails with "already exists" on a path that is already checked out.
+    fn open_worktree_workspace(
+        &self,
+        path: &Path,
+        label: &str,
+    ) -> Result<Option<(String, String)>> {
+        let path_str = path.to_string_lossy();
+        self.worktree_workspace(&[
+            "worktree",
+            "open",
+            "--path",
+            path_str.as_ref(),
+            "--label",
+            label,
+            "--no-focus",
+        ])
+    }
+
+    /// herdr has no send-and-submit primitive.
+    fn send_line(&self, pane_id: &str, text: &str) -> Result<()> {
+        self.run(&["pane", "send-text", pane_id, text])?;
+        self.run(&["pane", "send-keys", pane_id, "Enter"])?;
+        Ok(())
+    }
+}
+
+impl Multiplexer for HerdrBackend {
+    fn name(&self) -> &'static str {
+        "herdr"
+    }
+
+    fn supports_atomic_worktree_workspace(&self) -> bool {
+        true
+    }
+
+    // === Server ===
+
+    fn is_running(&self) -> Result<bool> {
+        if std::env::var("HERDR_PANE_ID").is_ok() {
+            return Ok(true);
+        }
+        Ok(self.run_json(&["workspace", "list"]).is_ok())
+    }
+
+    // === Pane ID from environment ===
+
+    fn current_pane_id(&self) -> Option<String> {
+        std::env::var("HERDR_PANE_ID").ok()
+    }
+
+    fn active_pane_id(&self) -> Option<String> {
+        let result = self.run_json(&["pane", "current"]).ok()?;
+        result["pane"]["pane_id"].as_str().map(String::from)
+    }
+
+    // === Active pane path ===
+
+    fn get_client_active_pane_path(&self) -> Result<PathBuf> {
+        let result = self.run_json(&["pane", "current"])?;
+        let cwd = result["pane"]["foreground_cwd"]
+            .as_str()
+            .or_else(|| result["pane"]["cwd"].as_str())
+            .ok_or_else(|| anyhow!("pane current: missing cwd"))?;
+        Ok(PathBuf::from(cwd))
+    }
+
+    // === Window / workspace management ===
+
+    fn create_worktree_and_workspace(
+        &self,
+        branch: &str,
+        base: Option<&str>,
+        path: &Path,
+        label: &str,
+    ) -> Result<Option<(String, String)>> {
+        let path_str = path.to_string_lossy();
+        let mut args = vec![
+            "worktree",
+            "create",
+            "--branch",
+            branch,
+            "--path",
+            path_str.as_ref(),
+            "--label",
+            label,
+            "--no-focus",
+        ];
+        if let Some(base_ref) = base {
+            args.extend_from_slice(&["--base", base_ref]);
+        }
+        self.worktree_workspace(&args)
+    }
+
+    fn remove_worktree_and_workspace(&self, workspace_id: &str) -> Result<bool> {
+        self.run(&["worktree", "remove", "--workspace", workspace_id])?;
+        Ok(true)
+    }
+
+    fn shell_remove_worktree_and_workspace_cmd(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Option<String>> {
+        Ok(Some(format!(
+            "{} worktree remove --workspace {}",
+            shell_quote(&self.bin),
+            shell_quote(workspace_id)
+        )))
+    }
+
+    fn ensure_worktree_workspace(
+        &self,
+        path: &Path,
+        label: &str,
+        branch: &str,
+    ) -> Result<Option<(String, String)>> {
+        if self.workspace_id_for_label(label).is_ok() {
+            return Ok(None);
+        }
+        if path.exists() {
+            self.open_worktree_workspace(path, label)
+        } else {
+            // The worktree was removed outside workmux, so the directory has to
+            // be recreated alongside the workspace.
+            self.create_worktree_and_workspace(branch, None, path, label)
+        }
+    }
+
+    fn create_window(&self, params: CreateWindowParams) -> Result<String> {
+        let label = util::prefixed(params.prefix, params.name);
+        let cwd = params.cwd.to_string_lossy();
+        let result = self.run_json(&[
+            "workspace",
+            "create",
+            "--cwd",
+            &cwd,
+            "--label",
+            &label,
+            "--no-focus",
+        ])?;
+        let pane_id = result["root_pane"]["pane_id"]
+            .as_str()
+            .ok_or_else(|| anyhow!("workspace create: missing root_pane.pane_id"))?;
+        Ok(pane_id.to_string())
+    }
+
+    fn create_session(&self, _params: CreateSessionParams) -> Result<String> {
+        no_sessions()
+    }
+
+    fn switch_to_session(&self, _prefix: &str, _name: &str) -> Result<()> {
+        no_sessions()
+    }
+
+    fn kill_window(&self, full_name: &str) -> Result<()> {
+        let workspace_id = self.workspace_id_for_label(full_name)?;
+        self.run(&["workspace", "close", &workspace_id])?;
+        Ok(())
+    }
+
+    fn schedule_window_close(&self, full_name: &str, delay: Duration) -> Result<()> {
+        let workspace_id = self.workspace_id_for_label(full_name)?;
+        let secs = delay.as_secs();
+        let script = format!("sleep {secs}; {} workspace close {workspace_id}", self.bin);
+        util::run_detached_sh_c(&script)
+    }
+
+    fn schedule_session_close(&self, _full_name: &str, _delay: Duration) -> Result<()> {
+        no_sessions()
+    }
+
+    fn run_deferred_script(&self, script: &str) -> Result<()> {
+        util::run_detached_sh_c(script)
+    }
+
+    fn shell_select_window_cmd(&self, full_name: &str) -> Result<String> {
+        let workspace_id = self.workspace_id_for_label(full_name)?;
+        Ok(format!("{} workspace focus {workspace_id}", self.bin))
+    }
+
+    fn shell_kill_window_cmd(&self, full_name: &str) -> Result<String> {
+        let workspace_id = self.workspace_id_for_label(full_name)?;
+        Ok(format!("{} workspace close {workspace_id}", self.bin))
+    }
+
+    fn shell_switch_session_cmd(&self, _full_name: &str) -> Result<String> {
+        no_sessions()
+    }
+
+    fn shell_kill_session_cmd(&self, _full_name: &str) -> Result<String> {
+        no_sessions()
+    }
+
+    fn select_window(&self, prefix: &str, name: &str) -> Result<()> {
+        let label = util::prefixed(prefix, name);
+        let workspace_id = self.workspace_id_for_label(&label)?;
+        self.run(&["workspace", "focus", &workspace_id])?;
+        Ok(())
+    }
+
+    fn current_window_name(&self) -> Result<Option<String>> {
+        let workspaces = self.list_workspaces()?;
+        Ok(workspaces.into_iter().find(|w| w.focused).map(|w| w.label))
+    }
+
+    fn get_all_window_names(&self) -> Result<HashSet<String>> {
+        Ok(self
+            .list_workspaces()?
+            .into_iter()
+            .map(|w| w.label)
+            .collect())
+    }
+
+    fn wait_until_session_closed(&self, _full_session_name: &str) -> Result<()> {
+        no_sessions()
+    }
+
+    // === Pane management ===
+
+    fn select_pane(&self, pane_id: &str) -> Result<()> {
+        self.run(&["pane", "zoom", pane_id, "--on"])?;
+        Ok(())
+    }
+
+    fn switch_to_pane(&self, pane_id: &str, _window_hint: Option<&str>) -> Result<()> {
+        if let Some(workspace_id) = self.workspace_id_for_pane(pane_id) {
+            let _ = self.run(&["workspace", "focus", &workspace_id]);
+        }
+        self.run(&["pane", "zoom", pane_id, "--on"])?;
+        Ok(())
+    }
+
+    fn kill_pane(&self, pane_id: &str) -> Result<()> {
+        self.run(&["pane", "close", pane_id])?;
+        Ok(())
+    }
+
+    fn respawn_pane(&self, pane_id: &str, cwd: &Path, cmd: Option<&str>) -> Result<String> {
+        // herdr exposes no respawn primitive, so like the Zellij backend this
+        // reuses the pane rather than replacing its process: cd into the target
+        // directory and run the command there. The sole caller, `setup_panes`,
+        // invokes this on a freshly created pane sitting at a shell prompt, so
+        // there is no existing process to displace.
+        self.send_line(pane_id, &cd_script(cwd, cmd))?;
+        Ok(pane_id.to_string())
+    }
+
+    fn capture_pane(&self, pane_id: &str, lines: u16) -> Option<String> {
+        let lines_str = lines.to_string();
+        self.run(&[
+            "pane",
+            "read",
+            pane_id,
+            "--source",
+            "recent-unwrapped",
+            "--lines",
+            &lines_str,
+        ])
+        .ok()
+    }
+
+    // === Text I/O ===
+
+    fn send_text_fragment(&self, pane_id: &str, text: &str) -> Result<()> {
+        self.run(&["pane", "send-text", pane_id, text])?;
+        Ok(())
+    }
+
+    fn send_enter(&self, pane_id: &str) -> Result<()> {
+        self.run(&["pane", "send-keys", pane_id, "Enter"])?;
+        Ok(())
+    }
+
+    fn send_key(&self, pane_id: &str, key: &str) -> Result<()> {
+        self.run(&["pane", "send-keys", pane_id, key])?;
+        Ok(())
+    }
+
+    fn paste_text(&self, pane_id: &str, content: &str) -> Result<()> {
+        // herdr send-text handles newlines correctly; no paste-mode distinction needed
+        self.run(&["pane", "send-text", pane_id, content])?;
+        Ok(())
+    }
+
+    // === Status ===
+
+    fn set_status(&self, pane_id: &str, icon: &str, _auto_clear_on_focus: bool) -> Result<()> {
+        self.run(&["pane", "rename", pane_id, icon])?;
+        Ok(())
+    }
+
+    fn clear_status(&self, pane_id: &str) -> Result<()> {
+        self.run(&["pane", "rename", pane_id, "--clear"])?;
+        Ok(())
+    }
+
+    fn ensure_status_format(&self, _pane_id: &str) -> Result<()> {
+        // herdr renders pane status itself; no format string to configure.
+        Ok(())
+    }
+
+    // === Pane splitting ===
+
+    fn split_pane(
+        &self,
+        target_pane_id: &str,
+        direction: &SplitDirection,
+        cwd: &Path,
+        _size: Option<u16>,
+        percentage: Option<u8>,
+        command: Option<&str>,
+    ) -> Result<String> {
+        let direction_arg = match direction {
+            SplitDirection::Horizontal => "right",
+            SplitDirection::Vertical => "down",
+            SplitDirection::Stacked => {
+                return Err(anyhow!(
+                    "split: stacked is only supported by the Zellij backend"
+                ));
+            }
+        };
+        let cwd_str = cwd.to_string_lossy();
+
+        let mut args = vec![
+            "pane",
+            "split",
+            target_pane_id,
+            "--direction",
+            direction_arg,
+            "--cwd",
+            cwd_str.as_ref(),
+        ];
+
+        let ratio_str;
+        if let Some(pct) = percentage {
+            ratio_str = format!("{:.2}", pct as f64 / 100.0);
+            args.push("--ratio");
+            args.push(&ratio_str);
+        }
+
+        let result = self.run_json(&args)?;
+        let new_pane_id = result["pane"]["pane_id"]
+            .as_str()
+            .ok_or_else(|| anyhow!("pane split: missing result.pane.pane_id"))?
+            .to_string();
+
+        if let Some(cmd) = command {
+            self.send_line(&new_pane_id, &cd_script(cwd, Some(cmd)))?;
+        }
+
+        Ok(new_pane_id)
+    }
+
+    // === Instance identity ===
+
+    fn instance_id(&self) -> String {
+        std::env::var("HERDR_SOCKET_PATH").unwrap_or_else(|_| "herdr-default".into())
+    }
+
+    fn resolve_instance_id(&self) -> Result<String> {
+        std::env::var("HERDR_SOCKET_PATH")
+            .ok()
+            .filter(|instance| !instance.trim().is_empty())
+            .ok_or_else(|| anyhow!("HERDR_SOCKET_PATH is required to resolve the herdr instance"))
+    }
+
+    // === State reconciliation ===
+
+    fn get_live_pane_info(&self, pane_id: &str) -> Result<Option<LivePaneInfo>> {
+        // Only a positively reported missing pane counts as gone. Any other
+        // failure has to propagate, otherwise a transient herdr error would read
+        // as "this agent vanished" and reconciliation would drop live agents.
+        let result = match self
+            .run_envelope(&["pane", "get", pane_id])
+            .with_context(|| format!("failed to query herdr pane {pane_id}"))?
+        {
+            Envelope::Result(result) => result,
+            Envelope::Error { code, .. } if code == PANE_NOT_FOUND => return Ok(None),
+            Envelope::Error { code, message } => {
+                return Err(anyhow!("herdr pane get {pane_id}: {message} ({code})"));
+            }
+        };
+
+        let pane = &result["pane"];
+        if pane.is_null() {
+            return Ok(None);
+        }
+
+        let cwd = pane["foreground_cwd"]
+            .as_str()
+            .or_else(|| pane["cwd"].as_str())
+            .unwrap_or("/");
+        let working_dir = PathBuf::from(cwd);
+
+        let workspace_id = pane["workspace_id"].as_str().unwrap_or("").to_string();
+        let label = self
+            .workspace_label_for_id(&workspace_id)
+            .unwrap_or_default();
+
+        Ok(Some(util::build_live_pane_info(
+            None, // herdr doesn't expose shell PID
+            None, // herdr doesn't expose foreground command name
+            working_dir,
+            "", // no pane title concept in herdr
+            workspace_id,
+            label,
+        )))
+    }
+
+    fn get_all_live_pane_info(&self) -> Result<HashMap<String, LivePaneInfo>> {
+        let panes = self.list_panes()?;
+        let workspaces: HashMap<String, String> = self
+            .list_workspaces()?
+            .into_iter()
+            .map(|w| (w.workspace_id, w.label))
+            .collect();
+
+        let snapshots = panes.into_iter().map(|p| {
+            let label = workspaces.get(&p.workspace_id).cloned().unwrap_or_default();
+            let working_dir = p.working_dir();
+            util::LivePaneSnapshot {
+                pane_id: p.pane_id,
+                pid: None,
+                current_command: None,
+                working_dir,
+                title: String::new(),
+                session: p.workspace_id,
+                window: label,
+            }
+        });
+
+        Ok(util::live_pane_map(snapshots))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Envelopes below are verbatim herdr 0.7.1 CLI output.
+
+    #[test]
+    fn parses_result_envelope() {
+        let raw =
+            r#"{"id":"cli:pane:get","result":{"pane":{"pane_id":"w2:p1"},"type":"pane_info"}}"#;
+        let envelope = parse_envelope(raw).unwrap();
+        match envelope {
+            Envelope::Result(result) => assert_eq!(result["pane"]["pane_id"], "w2:p1"),
+            other => panic!("expected result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_error_envelope() {
+        // herdr exits 0 for this, so the error is only visible in the payload.
+        let raw = r#"{"error":{"code":"pane_not_found","message":"pane w99:p99 not found"},"id":"cli:pane:get"}"#;
+        assert_eq!(
+            parse_envelope(raw).unwrap(),
+            Envelope::Error {
+                code: "pane_not_found".to_string(),
+                message: "pane w99:p99 not found".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn envelope_without_result_or_error_is_rejected() {
+        // Must not silently decode as an empty result.
+        let err = parse_envelope(r#"{"id":"cli:pane:get"}"#).unwrap_err();
+        assert!(err.to_string().contains("neither result nor error"));
+    }
+
+    #[test]
+    fn null_result_is_rejected() {
+        let err = parse_envelope(r#"{"id":"cli:pane:get","result":null}"#).unwrap_err();
+        assert!(err.to_string().contains("neither result nor error"));
+    }
+
+    #[test]
+    fn malformed_json_is_rejected() {
+        assert!(parse_envelope("not json").is_err());
+    }
+
+    #[test]
+    fn workspace_id_for_pane_splits_on_separator() {
+        let backend = HerdrBackend {
+            bin: "herdr".to_string(),
+        };
+        assert_eq!(
+            backend.workspace_id_for_pane("w2Z:p1"),
+            Some("w2Z".to_string())
+        );
+    }
+
+    #[test]
+    fn workspace_id_for_pane_rejects_id_without_separator() {
+        // Returning the whole string here would target an unrelated workspace.
+        let backend = HerdrBackend {
+            bin: "herdr".to_string(),
+        };
+        assert_eq!(backend.workspace_id_for_pane("nonsense"), None);
+    }
+
+    #[test]
+    fn cd_script_quotes_paths_with_spaces() {
+        let script = cd_script(Path::new("/tmp/my worktree"), Some("claude"));
+        assert_eq!(script, "cd '/tmp/my worktree' && claude");
+    }
+
+    #[test]
+    fn cd_script_leaves_plain_paths_unquoted() {
+        let script = cd_script(Path::new("/tmp/wt"), Some("claude"));
+        assert_eq!(script, "cd /tmp/wt && claude");
+    }
+
+    #[test]
+    fn cd_script_without_command_still_changes_directory() {
+        assert_eq!(cd_script(Path::new("/tmp/wt"), None), "cd /tmp/wt");
+    }
+
+    #[test]
+    fn shell_remove_cmd_uses_configured_binary() {
+        let backend = HerdrBackend {
+            bin: "/opt/herdr/bin/herdr".to_string(),
+        };
+
+        let cmd = backend
+            .shell_remove_worktree_and_workspace_cmd("ws-abc123")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            cmd,
+            "/opt/herdr/bin/herdr worktree remove --workspace ws-abc123"
+        );
+    }
+
+    #[test]
+    fn shell_remove_cmd_quotes_binary_with_spaces() {
+        let backend = HerdrBackend {
+            bin: "/Applications/My Tools/herdr".to_string(),
+        };
+
+        let cmd = backend
+            .shell_remove_worktree_and_workspace_cmd("ws-abc123")
+            .unwrap()
+            .unwrap();
+
+        assert!(
+            cmd.starts_with("'/Applications/My Tools/herdr' worktree remove"),
+            "binary path with spaces should be quoted: {cmd}"
+        );
+    }
+}

--- a/src/multiplexer/mod.rs
+++ b/src/multiplexer/mod.rs
@@ -7,6 +7,7 @@ pub mod agent;
 pub mod conversation;
 pub mod handle;
 pub mod handshake;
+pub mod herdr;
 pub mod kitty;
 pub mod tmux;
 pub mod types;
@@ -164,6 +165,69 @@ pub trait Multiplexer: Send + Sync {
     /// Kill a session by its full name (including prefix).
     fn kill_session(&self, _full_name: &str) -> Result<()> {
         Ok(())
+    }
+
+    /// Whether this backend owns git worktrees alongside its workspaces.
+    ///
+    /// Backends answering `true` must implement the atomic worktree hooks below.
+    fn supports_atomic_worktree_workspace(&self) -> bool {
+        false
+    }
+
+    /// Atomically create a git worktree and a multiplexer workspace/window.
+    ///
+    /// Returns `Some((workspace_id, initial_pane_id))` when the backend handled
+    /// both operations atomically (skipping the separate `git worktree add` +
+    /// `create_window` calls). Returns `Ok(None)` to fall back to the default
+    /// two-step path.
+    fn create_worktree_and_workspace(
+        &self,
+        _branch: &str,
+        _base: Option<&str>,
+        _path: &Path,
+        _label: &str,
+    ) -> Result<Option<(String, String)>> {
+        Ok(None)
+    }
+
+    /// Atomically remove a git worktree and its multiplexer workspace/window.
+    ///
+    /// Returns `true` when the backend handled both operations atomically
+    /// (skipping the separate `kill_window` + git cleanup calls). Returns
+    /// `false` to fall back to the default two-step path.
+    fn remove_worktree_and_workspace(&self, _workspace_id: &str) -> Result<bool> {
+        Ok(false)
+    }
+
+    /// Shell command that performs `remove_worktree_and_workspace` from a
+    /// detached script, for the deferred-cleanup path where the process is
+    /// tearing down the window it is running in.
+    ///
+    /// Returns `Ok(None)` when the backend has no such command, and the caller
+    /// falls back to the generic mv/prune/trash sequence.
+    fn shell_remove_worktree_and_workspace_cmd(
+        &self,
+        _workspace_id: &str,
+    ) -> Result<Option<String>> {
+        Ok(None)
+    }
+
+    /// Ensure a workspace/window labelled `label` is attached to the worktree
+    /// for `branch` at `path`, creating the worktree too if it is missing.
+    ///
+    /// The backend owns the "does it already exist" probe, so only backends
+    /// implementing this pay the mux round trip.
+    ///
+    /// Returns `Some((workspace_id, initial_pane_id))` when the backend
+    /// attached a workspace, `Ok(None)` when one was already present or the
+    /// backend does not handle this.
+    fn ensure_worktree_workspace(
+        &self,
+        _path: &Path,
+        _label: &str,
+        _branch: &str,
+    ) -> Result<Option<(String, String)>> {
+        Ok(None)
     }
 
     /// Kill a window by its full name (including prefix)
@@ -841,10 +905,11 @@ pub trait Multiplexer: Send + Sync {
 ///
 /// 1. `$WORKMUX_BACKEND` set → use that backend
 /// 2. `$TMUX` set → tmux
-/// 3. `$WEZTERM_PANE` set → WezTerm
-/// 4. `$ZELLIJ`, `$ZELLIJ_PANE_ID`, or `$ZELLIJ_SESSION_NAME` set → Zellij
-/// 5. `$KITTY_WINDOW_ID` set → Kitty
-/// 6. None → defaults to tmux (for backward compatibility)
+/// 3. `$HERDR_PANE_ID` set → herdr
+/// 4. `$WEZTERM_PANE` set → WezTerm
+/// 5. `$ZELLIJ`, `$ZELLIJ_PANE_ID`, or `$ZELLIJ_SESSION_NAME` set → Zellij
+/// 6. `$KITTY_WINDOW_ID` set → Kitty
+/// 7. None → defaults to tmux (for backward compatibility)
 ///
 /// This ordering ensures that running tmux inside kitty (or wezterm) correctly
 /// selects the innermost multiplexer.
@@ -854,7 +919,7 @@ pub fn detect_backend() -> BackendType {
             Ok(bt) => return bt,
             Err(_) => {
                 eprintln!(
-                    "workmux: invalid WORKMUX_BACKEND={val:?}, expected tmux|wezterm|kitty|zellij"
+                    "workmux: invalid WORKMUX_BACKEND={val:?}, expected tmux|wezterm|kitty|zellij|herdr"
                 );
             }
         }
@@ -869,7 +934,7 @@ pub fn detect_backend_strict() -> Result<BackendType> {
         && !value.trim().is_empty()
     {
         return value.parse().map_err(|_| {
-            anyhow!("invalid WORKMUX_BACKEND={value:?}, expected tmux|wezterm|kitty|zellij")
+            anyhow!("invalid WORKMUX_BACKEND={value:?}, expected tmux|wezterm|kitty|zellij|herdr")
         });
     }
 
@@ -878,6 +943,7 @@ pub fn detect_backend_strict() -> Result<BackendType> {
 
 fn detect_backend_from_environment() -> BackendType {
     resolve_backend(
+        std::env::var("HERDR_PANE_ID").is_ok(),
         std::env::var("TMUX").is_ok(),
         std::env::var("WEZTERM_PANE").is_ok(),
         std::env::var("ZELLIJ").is_ok()
@@ -888,9 +954,21 @@ fn detect_backend_from_environment() -> BackendType {
 }
 
 /// Pure auto-detection logic, separated for testability.
-fn resolve_backend(tmux: bool, wezterm: bool, zellij: bool, kitty: bool) -> BackendType {
+fn resolve_backend(
+    herdr: bool,
+    tmux: bool,
+    wezterm: bool,
+    zellij: bool,
+    kitty: bool,
+) -> BackendType {
+    // Checked after tmux: herdr exports HERDR_PANE_ID into every descendant, so
+    // tmux started inside a herdr pane sets both and the inner tmux should win.
     if tmux {
         return BackendType::Tmux;
+    }
+
+    if herdr {
+        return BackendType::Herdr;
     }
 
     if wezterm {
@@ -915,6 +993,7 @@ pub fn create_backend(backend_type: BackendType) -> Arc<dyn Multiplexer> {
         BackendType::WezTerm => Arc::new(wezterm::WezTermBackend::new()),
         BackendType::Kitty => Arc::new(kitty::KittyBackend::new()),
         BackendType::Zellij => Arc::new(zellij::ZellijBackend::new()),
+        BackendType::Herdr => Arc::new(herdr::HerdrBackend::new()),
     }
 }
 
@@ -949,15 +1028,23 @@ mod tests {
     #[test]
     fn no_env_defaults_to_tmux() {
         assert_eq!(
-            resolve_backend(false, false, false, false),
+            resolve_backend(false, false, false, false, false),
             BackendType::Tmux
+        );
+    }
+
+    #[test]
+    fn herdr_only() {
+        assert_eq!(
+            resolve_backend(true, false, false, false, false),
+            BackendType::Herdr
         );
     }
 
     #[test]
     fn tmux_only() {
         assert_eq!(
-            resolve_backend(true, false, false, false),
+            resolve_backend(false, true, false, false, false),
             BackendType::Tmux
         );
     }
@@ -965,7 +1052,7 @@ mod tests {
     #[test]
     fn wezterm_only() {
         assert_eq!(
-            resolve_backend(false, true, false, false),
+            resolve_backend(false, false, true, false, false),
             BackendType::WezTerm
         );
     }
@@ -973,7 +1060,7 @@ mod tests {
     #[test]
     fn zellij_only() {
         assert_eq!(
-            resolve_backend(false, false, true, false),
+            resolve_backend(false, false, false, true, false),
             BackendType::Zellij
         );
     }
@@ -981,30 +1068,47 @@ mod tests {
     #[test]
     fn kitty_only() {
         assert_eq!(
-            resolve_backend(false, false, false, true),
+            resolve_backend(false, false, false, false, true),
             BackendType::Kitty
         );
     }
 
     #[test]
+    fn tmux_inside_herdr() {
+        assert_eq!(
+            resolve_backend(true, true, false, false, false),
+            BackendType::Tmux
+        );
+    }
+
+    #[test]
     fn tmux_inside_kitty() {
-        assert_eq!(resolve_backend(true, false, false, true), BackendType::Tmux);
+        assert_eq!(
+            resolve_backend(false, true, false, false, true),
+            BackendType::Tmux
+        );
     }
 
     #[test]
     fn tmux_inside_wezterm() {
-        assert_eq!(resolve_backend(true, true, false, false), BackendType::Tmux);
+        assert_eq!(
+            resolve_backend(false, true, true, false, false),
+            BackendType::Tmux
+        );
     }
 
     #[test]
     fn tmux_inside_zellij() {
-        assert_eq!(resolve_backend(true, false, true, false), BackendType::Tmux);
+        assert_eq!(
+            resolve_backend(false, true, false, true, false),
+            BackendType::Tmux
+        );
     }
 
     #[test]
     fn wezterm_inside_kitty() {
         assert_eq!(
-            resolve_backend(false, true, false, true),
+            resolve_backend(false, false, true, false, true),
             BackendType::WezTerm
         );
     }
@@ -1012,13 +1116,16 @@ mod tests {
     #[test]
     fn zellij_inside_kitty() {
         assert_eq!(
-            resolve_backend(false, false, true, true),
+            resolve_backend(false, false, false, true, true),
             BackendType::Zellij
         );
     }
 
     #[test]
     fn all_env_vars_set() {
-        assert_eq!(resolve_backend(true, true, true, true), BackendType::Tmux);
+        assert_eq!(
+            resolve_backend(true, true, true, true, true),
+            BackendType::Tmux
+        );
     }
 }

--- a/src/multiplexer/types.rs
+++ b/src/multiplexer/types.rs
@@ -187,6 +187,8 @@ pub enum BackendType {
     Kitty,
     /// Zellij backend
     Zellij,
+    /// Herdr backend
+    Herdr,
 }
 
 impl std::fmt::Display for BackendType {
@@ -196,6 +198,7 @@ impl std::fmt::Display for BackendType {
             BackendType::WezTerm => write!(f, "wezterm"),
             BackendType::Kitty => write!(f, "kitty"),
             BackendType::Zellij => write!(f, "zellij"),
+            BackendType::Herdr => write!(f, "herdr"),
         }
     }
 }
@@ -209,6 +212,7 @@ impl std::str::FromStr for BackendType {
             "wezterm" => Ok(BackendType::WezTerm),
             "kitty" => Ok(BackendType::Kitty),
             "zellij" => Ok(BackendType::Zellij),
+            "herdr" => Ok(BackendType::Herdr),
             other => Err(format!("unknown backend: {}", other)),
         }
     }

--- a/src/workflow/cleanup.rs
+++ b/src/workflow/cleanup.rs
@@ -235,6 +235,89 @@ fn is_inside_matching_target(
     }
 }
 
+/// Kill the mux window(s)/session for `target_name`. Skipped entirely when a
+/// faster atomic removal path (e.g. herdr) already tore down the target.
+#[allow(clippy::too_many_arguments)]
+fn kill_target(
+    context: &WorkflowContext,
+    mux_running: bool,
+    is_session_mode: bool,
+    target_name: &str,
+    parent_session: Option<&str>,
+    window_token: Option<&str>,
+    handle: &str,
+    result: &mut CleanupResult,
+) -> Result<()> {
+    if mux_running {
+        if is_session_mode {
+            // For session mode, kill the session directly
+            let session_name = prefixed(&context.prefix, target_name);
+            if context.mux.session_exists(&session_name)? {
+                if let Err(e) = context.mux.kill_session(&session_name) {
+                    warn!(session = session_name, error = %e, "cleanup:failed to kill session");
+                } else {
+                    result.tmux_window_killed = true;
+                    info!(session = session_name, "cleanup:killed session");
+
+                    // Poll to confirm session is gone before proceeding
+                    const MAX_RETRIES: u32 = 20;
+                    const RETRY_DELAY: Duration = Duration::from_millis(50);
+                    for _ in 0..MAX_RETRIES {
+                        if !context.mux.session_exists(&session_name)? {
+                            break;
+                        }
+                        thread::sleep(RETRY_DELAY);
+                    }
+                }
+            }
+        } else {
+            // For window mode, find and kill all matching windows (including duplicates)
+            let matching_windows = find_matching_window_targets(
+                context.mux.as_ref(),
+                &context.prefix,
+                target_name,
+                parent_session,
+                window_token,
+            )?;
+            let mut killed_count = 0;
+            for target in &matching_windows {
+                if let Err(e) = context.mux.kill_window_target(target) {
+                    warn!(window = target.full_name, error = %e, "cleanup:failed to kill window");
+                } else {
+                    killed_count += 1;
+                    debug!(window = target.full_name, "cleanup:killed window");
+                }
+            }
+            if killed_count > 0 {
+                result.tmux_window_killed = true;
+                info!(
+                    count = killed_count,
+                    handle = handle,
+                    "cleanup:killed all matching windows"
+                );
+
+                // Poll to confirm windows are gone before proceeding
+                const MAX_RETRIES: u32 = 20;
+                const RETRY_DELAY: Duration = Duration::from_millis(50);
+                for _ in 0..MAX_RETRIES {
+                    let remaining = find_matching_window_targets(
+                        context.mux.as_ref(),
+                        &context.prefix,
+                        target_name,
+                        parent_session,
+                        window_token,
+                    )?;
+                    if remaining.is_empty() {
+                        break;
+                    }
+                    thread::sleep(RETRY_DELAY);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Centralized function to clean up tmux and git resources.
 /// `branch_name` is used for git operations (branch deletion).
 /// `handle` is used for tmux operations (window/session lookup/kill).
@@ -364,14 +447,22 @@ pub fn cleanup(
 
     // Helper closure to perform the actual filesystem and git cleanup.
     // This avoids code duplication while enforcing the correct operational order.
-    let perform_fs_git_cleanup = |result: &mut CleanupResult| -> Result<()> {
+    //
+    // `hooks_already_ran` is set when the atomic-removal path fired the hooks
+    // before its attempt failed; re-running them here would execute the user's
+    // whole pre_remove suite a second time.
+    let perform_fs_git_cleanup = |result: &mut CleanupResult,
+                                  hooks_already_ran: bool|
+     -> Result<()> {
         // Resolve the admin dir before the rename so we can unlock it later.
         let worktree_admin_dir = resolve_worktree_admin_dir(worktree_path, &context.git_common_dir);
 
         // Run pre-remove hooks before removing the worktree directory.
         // Skip if the worktree directory doesn't exist (e.g., user manually deleted it).
         // Skip if --no-hooks is set (e.g., RPC-triggered merge).
-        if worktree_path.exists() && !no_hooks {
+        if hooks_already_ran {
+            debug!("cleanup:pre-remove hooks already ran on the atomic removal attempt");
+        } else if worktree_path.exists() && !no_hooks {
             run_pre_remove_hooks(
                 context,
                 handle,
@@ -493,6 +584,16 @@ pub fn cleanup(
         Ok(())
     };
 
+    // Gated on the capability, not just on the id being present: the id is
+    // written at create time and outlives the herdr session, so a worktree
+    // created under herdr and removed under tmux would emit a herdr command
+    // into a tmux `run-shell` script and fail silently behind `>/dev/null 2>&1`.
+    let herdr_workspace_id = if context.mux.supports_atomic_worktree_workspace() {
+        git::get_worktree_meta(handle, "workspace-id")
+    } else {
+        None
+    };
+
     if running_inside_target {
         let (current_target, current_target_id) = current_matching_target.unwrap();
         info!(
@@ -593,6 +694,10 @@ pub fn cleanup(
                 force,
                 git_common_dir: context.git_common_dir.clone(),
                 worktree_admin_dir,
+                worktree_removal_cmd: match herdr_workspace_id {
+                    Some(ref wid) => context.mux.shell_remove_worktree_and_workspace_cmd(wid)?,
+                    None => None,
+                },
             });
             debug!(
                 worktree = %worktree_path.display(),
@@ -601,76 +706,63 @@ pub fn cleanup(
             );
         }
     } else {
-        // Not running inside any matching target, so kill it first
-        if mux_running {
-            if is_session_mode {
-                // For session mode, kill the session directly
-                let session_name = prefixed(&context.prefix, &target_name);
-                if context.mux.session_exists(&session_name)? {
-                    if let Err(e) = context.mux.kill_session(&session_name) {
-                        warn!(session = session_name, error = %e, "cleanup:failed to kill session");
-                    } else {
-                        result.tmux_window_killed = true;
-                        info!(session = session_name, "cleanup:killed session");
-
-                        // Poll to confirm session is gone before proceeding
-                        const MAX_RETRIES: u32 = 20;
-                        const RETRY_DELAY: Duration = Duration::from_millis(50);
-                        for _ in 0..MAX_RETRIES {
-                            if !context.mux.session_exists(&session_name)? {
-                                break;
-                            }
-                            thread::sleep(RETRY_DELAY);
-                        }
-                    }
-                }
-            } else {
-                // For window mode, find and kill all matching windows (including duplicates)
-                let matching_windows = find_matching_window_targets(
-                    context.mux.as_ref(),
-                    &context.prefix,
-                    &target_name,
-                    parent_session.as_deref(),
-                    window_token.as_deref(),
+        // Not running inside any matching target.
+        //
+        // For herdr: a stored workspace_id means we can close the workspace and
+        // remove the git worktree in a single atomic `herdr worktree remove` call.
+        let mut hooks_ran = false;
+        let herdr_removed = if let Some(ref wid) = herdr_workspace_id {
+            if worktree_path.exists() && !no_hooks {
+                run_pre_remove_hooks(
+                    context,
+                    handle,
+                    worktree_path,
+                    branch_name,
+                    show_hook_output,
                 )?;
-                let mut killed_count = 0;
-                for target in &matching_windows {
-                    if let Err(e) = context.mux.kill_window_target(target) {
-                        warn!(window = target.full_name, error = %e, "cleanup:failed to kill window");
-                    } else {
-                        killed_count += 1;
-                        debug!(window = target.full_name, "cleanup:killed window");
-                    }
-                }
-                if killed_count > 0 {
+                hooks_ran = true;
+            }
+            cleanup_prompt_files(branch_name);
+            match context.mux.remove_worktree_and_workspace(wid) {
+                Ok(true) => {
                     result.tmux_window_killed = true;
+                    result.worktree_removed = true;
                     info!(
-                        count = killed_count,
                         handle = handle,
-                        "cleanup:killed all matching windows"
+                        workspace_id = %wid,
+                        "cleanup:herdr worktree+workspace removed atomically"
                     );
-
-                    // Poll to confirm windows are gone before proceeding
-                    const MAX_RETRIES: u32 = 20;
-                    const RETRY_DELAY: Duration = Duration::from_millis(50);
-                    for _ in 0..MAX_RETRIES {
-                        let remaining = find_matching_window_targets(
-                            context.mux.as_ref(),
-                            &context.prefix,
-                            &target_name,
-                            parent_session.as_deref(),
-                            window_token.as_deref(),
-                        )?;
-                        if remaining.is_empty() {
-                            break;
-                        }
-                        thread::sleep(RETRY_DELAY);
+                    if !keep_branch {
+                        git::delete_branch_in(branch_name, force, &context.git_common_dir)
+                            .context("Failed to delete local branch")?;
+                        result.local_branch_deleted = true;
+                        info!(branch = branch_name, "cleanup:local branch deleted");
                     }
+                    true
+                }
+                Ok(false) => false, // backend declined; fall through
+                Err(e) => {
+                    warn!(handle = handle, error = %e, "cleanup:herdr atomic remove failed, falling back");
+                    false
                 }
             }
+        } else {
+            false
+        };
+
+        if !herdr_removed {
+            kill_target(
+                context,
+                mux_running,
+                is_session_mode,
+                &target_name,
+                parent_session.as_deref(),
+                window_token.as_deref(),
+                handle,
+                &mut result,
+            )?;
+            perform_fs_git_cleanup(&mut result, hooks_ran)?;
         }
-        // Now that windows/sessions are gone, clean up filesystem and git state.
-        perform_fs_git_cleanup(&mut result)?;
     }
 
     // Clean up worktree metadata from git config.
@@ -687,7 +779,7 @@ pub fn cleanup(
 
 /// Build the deferred cleanup script for rename, prune, branch delete, and trash removal.
 ///
-/// Generates a semicolon-separated sequence of shell commands that:
+/// Generates a semicolon-separated sequence of shell commands:
 /// 1. Renames the worktree directory to a trash path (frees the original path)
 /// 2. Removes any worktree lock (so prune can clean up the metadata)
 /// 3. Prunes git worktree metadata
@@ -695,25 +787,41 @@ pub fn cleanup(
 /// 5. Removes workmux worktree metadata from git config
 /// 6. Deletes the trash directory
 ///
+/// A backend that owns its worktrees supplies `worktree_removal_cmd`, a single
+/// command covering steps 1, 2, 3 and 6; only the branch and config cleanup
+/// remain generic.
+///
 /// The returned string starts with "; " so it can be appended to other commands.
 fn build_deferred_cleanup_script(dc: &DeferredCleanup) -> String {
-    let wt = shell_quote(&dc.worktree_path.to_string_lossy());
-    let trash = shell_quote(&dc.trash_path.to_string_lossy());
     let git_dir = shell_quote(&dc.git_common_dir.to_string_lossy());
 
     let mut cmds = Vec::new();
-    // 1. Rename worktree to trash
-    cmds.push(format!("mv {} {} >/dev/null 2>&1", wt, trash));
-    // 2. Remove worktree lock if present (git worktree prune skips locked entries)
-    if let Some(ref admin_dir) = dc.worktree_admin_dir
-        && admin_dir.is_absolute()
-    {
-        let locked = shell_quote(&admin_dir.join("locked").to_string_lossy());
-        cmds.push(format!("rm -f {} >/dev/null 2>&1", locked));
-    }
-    // 3. Prune git worktrees
-    cmds.push(format!("git -C {} worktree prune >/dev/null 2>&1", git_dir));
-    // 4. Delete branch (if not keeping)
+
+    // A backend that removes the worktree itself never creates a trash dir.
+    let trash_to_delete = match dc.worktree_removal_cmd {
+        Some(ref cmd) => {
+            cmds.push(format!("{} >/dev/null 2>&1", cmd));
+            None
+        }
+        None => {
+            let wt = shell_quote(&dc.worktree_path.to_string_lossy());
+            let trash = shell_quote(&dc.trash_path.to_string_lossy());
+            // 1. Rename worktree to trash
+            cmds.push(format!("mv {} {} >/dev/null 2>&1", wt, trash));
+            // 2. Remove worktree lock if present (git worktree prune skips locked entries)
+            if let Some(ref admin_dir) = dc.worktree_admin_dir
+                && admin_dir.is_absolute()
+            {
+                let locked = shell_quote(&admin_dir.join("locked").to_string_lossy());
+                cmds.push(format!("rm -f {} >/dev/null 2>&1", locked));
+            }
+            // 3. Prune git worktrees
+            cmds.push(format!("git -C {} worktree prune >/dev/null 2>&1", git_dir));
+            Some(trash)
+        }
+    };
+
+    // Branch delete and config cleanup always run after worktree removal.
     if !dc.keep_branch {
         let branch = shell_quote(&dc.branch_name);
         let force_flag = if dc.force { "-D" } else { "-d" };
@@ -722,14 +830,14 @@ fn build_deferred_cleanup_script(dc: &DeferredCleanup) -> String {
             git_dir, force_flag, branch
         ));
     }
-    // 5. Remove worktree metadata from git config
     let handle = shell_quote(&dc.handle);
     cmds.push(format!(
         "git -C {} config --local --remove-section workmux.worktree.{} >/dev/null 2>&1",
         git_dir, handle
     ));
-    // 6. Delete trash
-    cmds.push(format!("rm -rf {} >/dev/null 2>&1", trash));
+    if let Some(trash) = trash_to_delete {
+        cmds.push(format!("rm -rf {} >/dev/null 2>&1", trash));
+    }
 
     format!("; {}", cmds.join("; "))
 }
@@ -984,6 +1092,7 @@ mod tests {
             force,
             git_common_dir: PathBuf::from(git_dir),
             worktree_admin_dir: None,
+            worktree_removal_cmd: None,
         }
     }
 
@@ -1215,6 +1324,77 @@ mod tests {
         assert!(
             !script.contains("/locked"),
             "Should not have lock removal without admin dir: {script}"
+        );
+    }
+
+    #[test]
+    fn deferred_cleanup_script_backend_removal_replaces_mv_and_prune() {
+        let mut dc = make_deferred_cleanup(
+            "/repo/worktrees/feature",
+            "/repo/worktrees/.trash",
+            "feature",
+            "feature",
+            "/repo/.git",
+            false,
+            false,
+        );
+        dc.worktree_removal_cmd = Some("herdr worktree remove --workspace ws-abc123".to_string());
+
+        let script = build_deferred_cleanup_script(&dc);
+
+        assert!(
+            script.contains("herdr worktree remove --workspace ws-abc123"),
+            "backend removal command should be emitted: {script}"
+        );
+        assert!(
+            !script.contains("mv "),
+            "herdr path should not rename to trash: {script}"
+        );
+        assert!(
+            !script.contains("worktree prune"),
+            "herdr path should not call git worktree prune: {script}"
+        );
+        assert!(
+            !script.contains("rm -rf"),
+            "herdr path should not delete trash directory: {script}"
+        );
+        // Branch delete and config cleanup still run
+        assert!(
+            script.contains("branch -d feature"),
+            "herdr path should still delete the branch: {script}"
+        );
+        assert!(
+            script.contains("config --local --remove-section"),
+            "herdr path should still remove worktree metadata: {script}"
+        );
+    }
+
+    #[test]
+    fn deferred_cleanup_script_backend_removal_keep_branch_skips_branch_delete() {
+        let mut dc = make_deferred_cleanup(
+            "/repo/worktrees/feature",
+            "/repo/worktrees/.trash",
+            "feature",
+            "feature",
+            "/repo/.git",
+            true, // keep_branch
+            false,
+        );
+        dc.worktree_removal_cmd = Some("herdr worktree remove --workspace ws-xyz".to_string());
+
+        let script = build_deferred_cleanup_script(&dc);
+
+        assert!(
+            !script.contains("branch -d"),
+            "keep_branch should skip branch delete: {script}"
+        );
+        assert!(
+            !script.contains("branch -D"),
+            "keep_branch should skip branch delete: {script}"
+        );
+        assert!(
+            script.contains("herdr worktree remove"),
+            "should still emit the backend removal command: {script}"
         );
     }
 }

--- a/src/workflow/create.rs
+++ b/src/workflow/create.rs
@@ -30,6 +30,20 @@ fn is_registered_worktree(path: &Path, context: &WorkflowContext) -> Result<bool
     Ok(false)
 }
 
+/// Whether the backend's combined worktree-and-workspace call can be used.
+///
+/// Backends implementing it (herdr) create the git worktree and the mux workspace
+/// in one step. `herdr worktree create` always creates a new branch and has no
+/// flag for upstream tracking, and setup only consumes the pane it returns in
+/// window mode, so anything else has to take the two-step path instead.
+fn can_create_worktree_and_workspace(
+    mode: MuxMode,
+    create_new: bool,
+    track_upstream: bool,
+) -> bool {
+    mode == MuxMode::Window && create_new && !track_upstream
+}
+
 use super::cleanup;
 use super::context::WorkflowContext;
 use super::setup;
@@ -407,15 +421,57 @@ pub fn create(context: &WorkflowContext, args: CreateArgs) -> Result<CreateResul
         );
     }
 
-    git::create_worktree_in(
-        &worktree_path,
-        branch_name,
-        create_new,
-        base_branch_for_creation.as_deref(),
-        track_upstream,
-        Some(&context.execution_dir),
-    )
-    .context("Failed to create git worktree")?;
+    // For herdr, a single `herdr worktree create` call creates both the git
+    // worktree and the workspace atomically. Other backends return None and fall
+    // back to the separate `git worktree add` path below.
+    let atomic_workspace =
+        if can_create_worktree_and_workspace(options.mode, create_new, track_upstream) {
+            let label = options.primary_mux_label(&context.prefix, &current_handle);
+            context.mux.create_worktree_and_workspace(
+                branch_name,
+                base_branch_for_creation.as_deref(),
+                &worktree_path,
+                &label,
+            )?
+        } else {
+            None
+        };
+
+    let herdr_initial_pane = match atomic_workspace {
+        Some((workspace_id, pane_id)) => {
+            git::set_worktree_meta_in(
+                &current_handle,
+                "workspace-id",
+                &workspace_id,
+                Some(&context.execution_dir),
+            )
+            .with_context(|| {
+                format!(
+                    "Failed to store herdr workspace_id for worktree '{}'",
+                    current_handle
+                )
+            })?;
+            info!(
+                branch = branch_name,
+                workspace_id = %workspace_id,
+                pane_id = %pane_id,
+                "create:herdr worktree+workspace created atomically"
+            );
+            Some(pane_id)
+        }
+        None => {
+            git::create_worktree_in(
+                &worktree_path,
+                branch_name,
+                create_new,
+                base_branch_for_creation.as_deref(),
+                track_upstream,
+                Some(&context.execution_dir),
+            )
+            .context("Failed to create git worktree")?;
+            None
+        }
+    };
 
     // Store the tmux mode in git config for cleanup and reopen operations.
     // This allows remove/close/merge/open to know whether to kill a window or session.
@@ -566,6 +622,7 @@ pub fn create(context: &WorkflowContext, args: CreateArgs) -> Result<CreateResul
         &options_with_prompt,
         agent,
         placement_window_id,
+        herdr_initial_pane,
     )?;
     result.base_branch = base_branch_for_creation.clone();
     info!(
@@ -938,6 +995,74 @@ mod tests {
         fn get_all_live_pane_info(&self) -> Result<HashMap<String, LivePaneInfo>> {
             Ok(HashMap::new())
         }
+    }
+
+    #[test]
+    fn atomic_workspace_used_for_a_plain_new_window() {
+        assert!(can_create_worktree_and_workspace(
+            MuxMode::Window,
+            true,
+            false
+        ));
+    }
+
+    #[test]
+    fn atomic_workspace_skipped_in_session_mode() {
+        // Setup only consumes the returned pane in window mode, so taking this
+        // path in session mode orphans the workspace when create_session fails.
+        assert!(!can_create_worktree_and_workspace(
+            MuxMode::Session,
+            true,
+            false
+        ));
+    }
+
+    #[test]
+    fn atomic_workspace_skipped_for_an_existing_branch() {
+        // `herdr worktree create` always creates the branch.
+        assert!(!can_create_worktree_and_workspace(
+            MuxMode::Window,
+            false,
+            false
+        ));
+    }
+
+    #[test]
+    fn atomic_workspace_skipped_when_tracking_upstream() {
+        // `herdr worktree create` has no flag for upstream tracking.
+        assert!(!can_create_worktree_and_workspace(
+            MuxMode::Window,
+            true,
+            true
+        ));
+    }
+
+    #[test]
+    fn atomic_workspace_label_follows_the_explicit_window_name() {
+        // The workspace is created before setup runs, so it has to be labelled
+        // with the name setup will later look it up by. Deriving the label from
+        // the handle instead leaves kill_window and select_window unable to
+        // resolve it.
+        let mut options = SetupOptions::new(false, false, false);
+        options.mode = MuxMode::Window;
+        options.target_window_name = Some("custom-window".to_string());
+
+        assert_eq!(
+            options.primary_mux_label("wm/", "worktree-dir-handle"),
+            "wm/custom-window"
+        );
+    }
+
+    #[test]
+    fn atomic_workspace_label_falls_back_to_the_handle() {
+        let mut options = SetupOptions::new(false, false, false);
+        options.mode = MuxMode::Window;
+        options.target_window_name = None;
+
+        assert_eq!(
+            options.primary_mux_label("wm/", "worktree-dir-handle"),
+            "wm/worktree-dir-handle"
+        );
     }
 
     #[test]

--- a/src/workflow/open.rs
+++ b/src/workflow/open.rs
@@ -427,6 +427,36 @@ pub fn open(
         ..options
     };
 
+    // The workspace may have been lost while the worktree stayed on disk, e.g.
+    // after a herdr restart; ask the backend to re-attach one.
+    let herdr_initial_pane = if mode == MuxMode::Window {
+        let label = options_with_workdir.primary_mux_label(&context.prefix, &handle);
+        match context
+            .mux
+            .ensure_worktree_workspace(&worktree_path, &label, &branch_name)?
+        {
+            Some((workspace_id, pane_id)) => {
+                git::set_worktree_meta_in(
+                    &base_handle,
+                    "workspace-id",
+                    &workspace_id,
+                    Some(&context.execution_dir),
+                )
+                .context("Failed to store herdr workspace_id for re-opened worktree")?;
+                info!(
+                    branch = branch_name,
+                    workspace_id = %workspace_id,
+                    pane_id = %pane_id,
+                    "open:herdr workspace re-created for existing worktree"
+                );
+                Some(pane_id)
+            }
+            None => None,
+        }
+    } else {
+        None
+    };
+
     // Setup the environment
     let result = setup::setup_environment(
         context.mux.as_ref(),
@@ -437,6 +467,7 @@ pub fn open(
         &options_with_workdir,
         agent,
         None,
+        herdr_initial_pane,
     )?;
     info!(
         handle = handle,

--- a/src/workflow/setup.rs
+++ b/src/workflow/setup.rs
@@ -42,6 +42,7 @@ pub fn setup_environment(
     options: &super::types::SetupOptions,
     agent: Option<&str>,
     after_window: Option<String>,
+    initial_pane_id_override: Option<String>,
 ) -> Result<CreateResult> {
     debug!(
         branch = branch_name,
@@ -169,10 +170,7 @@ pub fn setup_environment(
 
     let target_window_name = options.target_window_name.as_deref().unwrap_or(handle);
     let target_session_name = options.target_session_name.as_deref().unwrap_or(handle);
-    let mux_target_full_name = match options.mode {
-        MuxMode::Window => crate::multiplexer::util::prefixed(prefix, target_window_name),
-        MuxMode::Session => crate::multiplexer::util::prefixed(prefix, target_session_name),
-    };
+    let mux_target_full_name = options.primary_mux_label(prefix, handle);
 
     // Track the focus and zoom pane across all windows
     let mut focus_pane_id: Option<String> = None;
@@ -184,9 +182,9 @@ pub fn setup_environment(
             let panes = window_plans[0].panes.as_deref().unwrap_or(&[]);
             let resolved_panes = resolve_pane_configuration(panes, config, agent);
 
-            let initial_pane_id = if let Some(parent_session) =
-                options.window_session_name.as_deref()
-            {
+            let initial_pane_id = if let Some(override_id) = initial_pane_id_override {
+                override_id
+            } else if let Some(parent_session) = options.window_session_name.as_deref() {
                 let parent_session_full_name = parent_session.to_string();
                 if mux.session_exists(&parent_session_full_name)? {
                     mux.create_window_in_session(CreateWindowInSessionParams {

--- a/src/workflow/types.rs
+++ b/src/workflow/types.rs
@@ -85,6 +85,10 @@ pub struct DeferredCleanup {
     /// Path to the git worktree admin directory (e.g., $GIT_COMMON_DIR/worktrees/<name>/).
     /// Used to remove lock files before pruning, since `git worktree prune` skips locked entries.
     pub worktree_admin_dir: Option<PathBuf>,
+    /// Backend-supplied command that removes the worktree and its workspace in
+    /// one step. When set, the deferred script runs it instead of the
+    /// mv+prune+trash sequence. Branch delete and config cleanup still run after.
+    pub worktree_removal_cmd: Option<String>,
 }
 
 /// Result of cleanup operations
@@ -212,6 +216,15 @@ impl SetupOptions {
             MuxMode::Window => self.target_window_name.as_deref().unwrap_or(handle),
             MuxMode::Session => self.target_session_name.as_deref().unwrap_or(handle),
         }
+    }
+
+    /// The full mux label for this worktree's primary window/session.
+    ///
+    /// Backends that create the workspace before setup runs must label it with
+    /// exactly this; every later `kill_window`/`select_window` lookup resolves
+    /// the workspace by label.
+    pub fn primary_mux_label(&self, prefix: &str, handle: &str) -> String {
+        crate::multiplexer::util::prefixed(prefix, self.primary_mux_target_name(handle))
     }
 
     pub fn has_explicit_primary_mux_target(&self) -> bool {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,6 +183,9 @@ class MuxEnvironment(ABC):
 
         # Base environment setup
         self.env = os.environ.copy()
+        # Ambient herdr hijacks backend detection and drives the user's real
+        # session, so scrub it here rather than per-backend below.
+        self.env.pop("HERDR_PANE_ID", None)
         self.env["PATH"] = f"{self.fake_bin_dir}:{self.env.get('PATH', '')}"
         self.env["TMPDIR"] = str(self.tmp_path)
         self.env["HOME"] = str(self.home_path)


### PR DESCRIPTION
## Summary

Adds [herdr](https://herdr.dev) as an alternative multiplexer backend alongside WezTerm, kitty and Zellij, closing #195. herdr is an agent multiplexer built for running AI coding agents, so the overlap with workmux is close to exact.

Unlike the other backends, herdr manages git worktrees itself. `workmux add` and `workmux remove` therefore delegate to `herdr worktree create` and `herdr worktree remove` rather than running git directly. That difference is expressed as a 
capability predicate on the `Multiplexer` trait, not as a check on the backend name, so the workflow layer stays backend neutral and the other backends are untouched.

I use this daily, which is how the label and deferred cleanup edge cases below were found.

## Changes

- `HerdrBackend` implements `Multiplexer` over herdr's JSON CLI. It holds no session state and needs no daemon socket, so it follows the WezTerm backend's shape.
- New trait hooks for backends that own their worktrees: `supports_atomic_worktree_workspace`, `create_worktree_and_workspace`,  `remove_worktree_and_workspace`, `ensure_worktree_workspace` and `shell_remove_worktree_and_workspace_cmd`. Every one has a default that opts out, so existing backends see no behavior change.
- Backend detection checks `$HERDR_PANE_ID` after `$TMUX`. herdr exports that variable into every descendant process, so a tmux server started inside a herdr pane sets both and the inner multiplexer has to win. `$WORKMUX_BACKEND=herdr` still overrides.
- herdr reports failures in band, exiting 0 with an `error` object instead of `result`. Envelope decoding keeps the two cases distinct, since treating a missing `result` as an empty payload would turn every backend failure into "nothing there" and silently drop live agents during reconciliation.
- Worktree removal is atomic where it can be. When `workmux remove` runs from inside the workspace being removed, the backend supplies the command for the deferred script instead of the generic rename-to-trash and prune sequence.
- Docs: new guide page, nav entry, README entries, and the previously undocumented `$HERDR_BIN_PATH` and `$HERDR_SOCKET_PATH`.
- `tests/conftest.py` scrubs `HERDR_PANE_ID` from the base `MuxEnvironment`.  Without it, running the suite inside a herdr session drives the developer's live session and creates real worktrees.

## Testing

- `cargo test --bin workmux`
- Integration suite: 450 passing. Eight failures reproduce identically on a clean `origin/main` checkout (seven `TestSetupNoPrompt` timeouts and one flaky dry run test), so they are environmental to my machine and unrelated to this change.
- `cargo fmt --check` and `cargo clippy --all-targets` clean, no new diagnostics.
- Exercised by hand against a live herdr session: add then remove; add with `--target-name` set, where the workspace label diverges from the work-tree directory name; remove run from inside the workspace being removed, which takes the deferred script path; and reopening a worktree whose workspace had been closed.

CI installs no herdr, so the unit tests are the real gate there. The integration job is unaffected.
