### PR TITLE
feat: configurable default dashboard sort mode

### DIFF
--- a/docs/src/content/docs/guide/dashboard/index.mdx
+++ b/docs/src/content/docs/guide/dashboard/index.mdx
@@ -142,7 +142,12 @@ Press `s` to cycle through sort modes:
 - **Recency**: Most recently updated first
 - **Natural**: Original tmux order (by pane creation)
 
-Your sort preference persists in the tmux session.
+Your sort preference persists across dashboard sessions. To change the default used when no preference has been persisted yet, set `dashboard.sort_mode` in your config:
+
+```yaml
+dashboard:
+  sort_mode: recency # priority (default), project, recency, natural
+```
 
 ## Session filter
 

--- a/src/command/dashboard/app/mod.rs
+++ b/src/command/dashboard/app/mod.rs
@@ -198,7 +198,15 @@ impl App {
         let scheme = config.theme.scheme;
         let palette = ThemePalette::from_config(&config.theme, theme_mode);
         let config_path = crate::config::global_config_path();
-        let sort_mode = SortMode::load();
+        // Sort mode: persisted preference > config.yaml default > priority
+        let sort_mode = SortMode::load_with_default(
+            config
+                .dashboard
+                .sort_mode
+                .as_deref()
+                .map(SortMode::parse)
+                .unwrap_or_default(),
+        );
         let scope_mode = if cli_session_filter {
             ScopeMode::Session
         } else {

--- a/src/command/dashboard/sort.rs
+++ b/src/command/dashboard/sort.rs
@@ -48,7 +48,7 @@ impl SortMode {
     }
 
     /// Parse from storage string.
-    fn from_str(s: &str) -> Self {
+    pub fn parse(s: &str) -> Self {
         match s.trim().to_lowercase().as_str() {
             "project" => SortMode::Project,
             "recency" => SortMode::Recency,
@@ -57,13 +57,13 @@ impl SortMode {
         }
     }
 
-    /// Load sort mode from StateStore.
-    pub fn load() -> Self {
+    /// Load sort mode from StateStore, falling back to `default` when unset.
+    pub fn load_with_default(default: Self) -> Self {
         StateStore::new()
             .ok()
             .and_then(|store| store.load_settings().ok())
-            .map(|s| Self::from_str(&s.sort_mode))
-            .unwrap_or_default()
+            .map(|s| Self::parse(&s.sort_mode))
+            .unwrap_or(default)
     }
 
     /// Save sort mode to StateStore.
@@ -129,5 +129,29 @@ impl WorktreeSortMode {
             settings.worktree_sort_mode = Some(self.as_str().to_string());
             let _ = store.save_settings(&settings);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SortMode;
+
+    #[test]
+    fn parse_known_modes() {
+        assert_eq!(SortMode::parse("priority"), SortMode::Priority);
+        assert_eq!(SortMode::parse("project"), SortMode::Project);
+        assert_eq!(SortMode::parse("recency"), SortMode::Recency);
+        assert_eq!(SortMode::parse("natural"), SortMode::Natural);
+    }
+
+    #[test]
+    fn parse_is_case_insensitive_and_trims() {
+        assert_eq!(SortMode::parse("  Recency "), SortMode::Recency);
+    }
+
+    #[test]
+    fn parse_unknown_falls_back_to_priority() {
+        assert_eq!(SortMode::parse(""), SortMode::Priority);
+        assert_eq!(SortMode::parse("bogus"), SortMode::Priority);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,6 +97,12 @@ pub struct DashboardConfig {
     /// list are not rendered.
     /// Default: number, project, worktree, git, pr, status, time, title.
     pub agent_columns: Option<Vec<AgentColumn>>,
+
+    /// Default sort mode for the agent list: "priority", "project", "recency", "natural".
+    /// Used when the dashboard has no persisted sort preference.
+    /// Default: "priority"
+    #[serde(default)]
+    pub sort_mode: Option<String>,
 }
 
 /// A configurable column of the dashboard agents table.
@@ -558,8 +564,8 @@ pub struct Config {
     pub theme: ThemeConfig,
 
     /// Mode for tmux operations: window (default) or session
-    /// None means "use default" (Window), Some means explicitly set
     #[serde(default)]
+    /// None means "use default" (Window), Some means explicitly set
     pub mode: Option<MuxMode>,
 
     /// Placement for new tmux windows in window mode.
@@ -2651,6 +2657,7 @@ impl Config {
                 .agent_columns
                 .clone()
                 .or_else(|| self.dashboard.agent_columns.clone()),
+            sort_mode: project.dashboard.sort_mode.or(self.dashboard.sort_mode),
         };
 
         // Sidebar config: per-field override
@@ -3128,11 +3135,14 @@ pub const EXAMPLE_PROJECT_CONFIG: &str = r#"# workmux project configuration
 # Preview size (10-90): larger = more preview, less table. Use +/- keys to adjust.
 # Columns of the agents table, in display order. Omit a column to hide it:
 # number, project, worktree, git, pr, status, time, title.
+# Default sort mode for the agent list: priority (default), project, recency, natural.
+# Used only when no sort preference has been persisted in the dashboard.
 # dashboard:
 #   commit: "Commit staged changes with a descriptive message"
 #   merge: "!workmux merge"
 #   preview_size: 60
 #   agent_columns: [number, project, worktree, git, pr, status, time, title]
+#   sort_mode: priority
 
 #-------------------------------------------------------------------------------
 # Sidebar
@@ -4482,6 +4492,33 @@ agents:
             merged.sandbox.container.excluded_files,
             Some(vec![".env".into()])
         );
+    }
+
+    #[test]
+    fn test_dashboard_sort_mode_project_overrides_global() {
+        let global = cfg(|config| {
+            config.dashboard.sort_mode = Some("priority".into());
+        });
+        let project = cfg(|config| {
+            config.dashboard.sort_mode = Some("recency".into());
+        });
+        let merged = global.merge(project);
+        assert_eq!(merged.dashboard.sort_mode.as_deref(), Some("recency"));
+    }
+
+    #[test]
+    fn test_dashboard_sort_mode_project_only_inherited() {
+        let global = Config::default();
+        let project = cfg(|config| {
+            config.dashboard.sort_mode = Some("recency".into());
+        });
+        let merged = global.merge(project);
+        assert_eq!(merged.dashboard.sort_mode.as_deref(), Some("recency"));
+    }
+
+    #[test]
+    fn test_dashboard_sort_mode_defaults_none() {
+        assert_eq!(Config::default().dashboard.sort_mode, None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #249

Adds `dashboard.sort_mode` config option (`priority` default, `project`, `recency`, `natural`) used when no sort preference has been persisted in the dashboard. Persisted preference from pressing `s` still wins.

## Changes

- `src/config.rs`: `DashboardConfig.sort_mode: Option<String>`, merged global-over-project, documented in example config, tests
- `src/command/dashboard/sort.rs`: `SortMode::parse()` (public) + `SortMode::load_with_default()`, tests
- `src/command/dashboard/app/mod.rs`: resolve via `load_with_default` with config fallback
- `docs/src/content/docs/guide/dashboard/index.mdx`: document the option

## Test plan

`cargo test sort_mode dashboard_sort_mode` — 6 tests pass. Config parse verified via `Config::load_with_override`.