### PR TITLE
fix clippy linter warnings

### DIFF
--- a/src/command/set_window_status.rs
+++ b/src/command/set_window_status.rs
@@ -140,7 +140,7 @@ fn apply_status_update(
     pane_id: &str,
 ) -> Result<()> {
     match cmd {
-        SetWindowStatusCommand::Clear => mux.clear_status(&pane_id)?,
+        SetWindowStatusCommand::Clear => mux.clear_status(pane_id)?,
         SetWindowStatusCommand::Working
         | SetWindowStatusCommand::Waiting
         | SetWindowStatusCommand::Done => {
@@ -159,14 +159,14 @@ fn apply_status_update(
 
             // Ensure the status format is applied so the icon actually shows up
             if config.status_format.unwrap_or(true) {
-                let _ = mux.ensure_status_format(&pane_id);
+                let _ = mux.ensure_status_format(pane_id);
             }
 
             // Update backend UI (status bar icon)
-            mux.set_status(&pane_id, icon, auto_clear)?;
+            mux.set_status(pane_id, icon, auto_clear)?;
 
             // Persist to state store so the dashboard sees this agent
-            crate::state::persist_agent_update(&*mux, &pane_id, Some(status), None);
+            crate::state::persist_agent_update(mux, pane_id, Some(status), None);
         }
     }
 

--- a/src/multiplexer/tmux.rs
+++ b/src/multiplexer/tmux.rs
@@ -798,7 +798,7 @@ impl Multiplexer for TmuxBackend {
                     let id = id.trim();
                     (!id.is_empty()).then(|| id.to_string())
                 })
-                .last()),
+                .next_back()),
             Err(_) => Ok(None),
         }
     }


### PR DESCRIPTION
I was reviewing your codes and the linter found these issues. 

- pane_id must have been a String before, but now is &str. We do not need to reference the &str.
- recommended to use next_back instead of last. next_back O(1) and last consume the entire iterator.